### PR TITLE
correct qiskit-ibm-runtime package in requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,5 +7,5 @@ scipy>=1.10.0
 numba
 networkx
 tdqm
-qiskit_ibm_runtime
+qiskit-ibm-runtime
 dill


### PR DESCRIPTION
correct ibm-qiskit-runtime package from pypi, resolves #12