### PR TITLE
Update custom_control_environment.py

### DIFF
--- a/src/qrisp/environments/custom_control_environment.py
+++ b/src/qrisp/environments/custom_control_environment.py
@@ -167,7 +167,7 @@ def custom_control(func):
 
         # Check whether the function supports the ctrl_method kwarg and adjust
         # the kwargs accordingly
-        if "ctrl_method" in list(inspect.getargspec(func))[0] and isinstance(env, ControlEnvironment):
+        if "ctrl_method" in list(inspect.getfullargspec(func))[0] and isinstance(env, ControlEnvironment):
             kwargs.update({"ctrl_method" : env.ctrl_method})
         
         


### PR DESCRIPTION
ln 117
changed inspect.getargspec to inspect.getfullargspec 
prior is depreceated since python 3.11