### PR TITLE
Enable authentification

### DIFF
--- a/src/qrisp/interface/__init__.py
+++ b/src/qrisp/interface/__init__.py
@@ -22,3 +22,4 @@ from qrisp.interface.backends import *
 from qrisp.interface.circuit_converter import *
 from qrisp.interface.thrift_interface import PortableQubit, PortableQuantumCircuit, PortableClbit, PortableOperation, PortableInstruction
 from qrisp.interface.docker_backends import *
+from qrisp.interface.request_manager import RequestManager

--- a/src/qrisp/interface/request_manager.py
+++ b/src/qrisp/interface/request_manager.py
@@ -3,30 +3,59 @@ from requests.auth import HTTPBasicAuth
 
 
 class RequestManager:
-    def __init__(self, base_url, username=None, password=None):
+    """
+        A class for managing HTTP requests with optional HTTP basic authentication.
+
+        Attributes:
+            base_url (str): The base URL for all requests.
+            session (requests.Session): A session object to manage HTTP connections.
+
+        Methods:
+            __init__(self, base_url, username=None, password=None):
+                Initializes the RequestManager with the base URL and optional credentials.
+
+            set_credentials(self, username, password):
+                Sets HTTP basic authentication credentials for the session.
+
+            get(self, endpoint, **kwargs):
+                Sends a GET request to the specified endpoint.
+
+            post(self, endpoint, data=None, json=None, **kwargs):
+                Sends a POST request to the specified endpoint.
+
+             post(self, endpoint, data=None, json=None, **kwargs):
+                Sends a DELETE request to the specified endpoint.
+
+            close(self):
+                Closes the session and cleans up associated resources.
+        """
+
+    def __init__(self, base_url: str, username: str = None, password: str = None):
         self.base_url = base_url
         self.session = requests.Session()
         if username is not None and password is not None:
             self.set_credentials(username, password)
 
-    def set_credentials(self, username, password):
+    def set_credentials(self, username: str, password: str):
         """Set HTTP basic authentication credentials."""
         self.session.auth = HTTPBasicAuth(username, password)
 
-    def get(self, endpoint, **kwargs):
+    def get(self, endpoint: str, **kwargs):
         """Execute GET request. """
         url = f"{self.base_url}{endpoint}"
         response = self.session.get(url, **kwargs)
         return response
 
-    def post(self, endpoint, data=None, json=None, **kwargs):
+    def post(self, endpoint: str, data=None, json=None, **kwargs):
+        """Execute POST request. """
         url = f"{self.base_url}{endpoint}"
         response = self.session.post(url, data=data, json=json, **kwargs)
         return response
 
-    def delete(self, endpoint, data=None, json=None, **kwargs):
+    def delete(self, endpoint: str, data=None, json=None, **kwargs):
+        """Execute POST request. """
         url = f"{self.base_url}{endpoint}"
-        response = self.session.post(url, data=data, json=json, **kwargs)
+        response = self.session.delete(url, data=data, json=json, **kwargs)
         return response
 
     def __enter__(self):

--- a/src/qrisp/interface/request_manager.py
+++ b/src/qrisp/interface/request_manager.py
@@ -1,0 +1,37 @@
+import requests
+from requests.auth import HTTPBasicAuth
+
+
+class RequestManager:
+    def __init__(self, base_url, username=None, password=None):
+        self.base_url = base_url
+        self.session = requests.Session()
+        if username is not None and password is not None:
+            self.set_credentials(username, password)
+
+    def set_credentials(self, username, password):
+        """Set HTTP basic authentication credentials."""
+        self.session.auth = HTTPBasicAuth(username, password)
+
+    def get(self, endpoint, **kwargs):
+        """Execute GET request. """
+        url = f"{self.base_url}{endpoint}"
+        response = self.session.get(url, **kwargs)
+        return response
+
+    def post(self, endpoint, data=None, json=None, **kwargs):
+        url = f"{self.base_url}{endpoint}"
+        response = self.session.post(url, data=data, json=json, **kwargs)
+        return response
+
+    def delete(self, endpoint, data=None, json=None, **kwargs):
+        url = f"{self.base_url}{endpoint}"
+        response = self.session.post(url, data=data, json=json, **kwargs)
+        return response
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        """Close the session."""
+        self.session.close()


### PR DESCRIPTION
- Add RequestManager class to managing HTTP requests with optional HTTP basic authentication.
- Minor changes: Fix the api path ("/" at the end of the path)
-  Remove init params `api_endpoint` and `port` of BackendClient due to refacotring (are handled by RequestManager now )
 
Question: Has the code  `if port is None: \n port = 9010` a purpose? This was deleted first since the purpose is unclear.
