### PR TITLE
bugfix in time_to_solution() in qaoa_benchmark_data.py

### DIFF
--- a/src/qrisp/qaoa/qaoa_benchmark_data.py
+++ b/src/qrisp/qaoa/qaoa_benchmark_data.py
@@ -527,20 +527,15 @@ def max_five_metric(metric_dict):
     return fivesol
 
 
-def time_to_solution(run_data, optimal_solution, cost_function):
+def time_to_solution(counts, optimal_solution, cost_function):
     """
     Parameters
     ----------
-    obj_function : objective function of the problem
-                    (i.e. the "maxcut_obj" method for the MaxCut Problem).
-
     counts : the result dictionary from the QAOA method, contaning the 
                     bitstrings as keys and the counts divided by the number
                     of shots as values.
-
     optimal_solution: the optimal solution of the problem
-
-    G : the Graph related to the problem
+    cost_function : Cost Function used to evaluate the optimization
 
     Returns
     -------
@@ -553,7 +548,7 @@ def time_to_solution(run_data, optimal_solution, cost_function):
     obj_function = lambda x : cost_function({x : 1})
     optimal_solution_cost = obj_function(optimal_solution)
     
-    return 1/sum([v for k,v in run_data["counts"].items() if obj_function(k)==optimal_solution_cost])
+    return 1/sum([v for k,v in counts.items() if obj_function(k)==optimal_solution_cost])
 
 
 def approximation_ratio(counts, optimal_solution, cost_function):


### PR DESCRIPTION
run_data was replaced by counts, because run_data["counts"] is already given in the function call. time_to_solution() now works similar to approximation_ratio(). Doc string of the time_to_solution method was corrected as well to agree to parameters.