### PR TITLE
Add documentation and dependencies to IQM Integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,11 @@ pip install qrisp
 ```
 Qrisp has been confirmed to work with Python version 3.8, 3.9 & 3.10.
 
+If you want to work with IQM quantum computers as a backend, you need to install additional dependencies using
+```bash
+pip install qrisp[iqm]
+```
+
 ## First Quantum Program with Qrisp
 The very first program you usually write, when learning a new programming language, is printing 'hello world'.
 We want to do the same, but in a quantum way.

--- a/documentation/source/reference/Backend Interface/IQMBackend.rst
+++ b/documentation/source/reference/Backend Interface/IQMBackend.rst
@@ -1,0 +1,9 @@
+.. _IQMBackend:
+
+IQMBackend
+==============
+
+.. currentmodule:: qrisp.interface
+
+.. autofunction:: IQMBackend
+

--- a/documentation/source/reference/Backend Interface/VirtualBackend.rst
+++ b/documentation/source/reference/Backend Interface/VirtualBackend.rst
@@ -16,6 +16,7 @@ From ``qrisp.interface`` is it possible to import the following kind of backends
 
    ":ref:`VirtualQiskitBackend`", "Allows to use a Qiskit Aer backend."
    ":ref:`QiskitRuntimeBackend`", "Allows to use a Qiskit Runtime backend, exploiting the Qiskit's Sampler primitive."
+   ":ref:`IQMBackend`", "Allows to use an IQM quantum computer as a backend via IQM Resonance."
 
 
 .. autoclass:: VirtualBackend

--- a/documentation/source/reference/Backend Interface/index.rst
+++ b/documentation/source/reference/Backend Interface/index.rst
@@ -11,6 +11,7 @@ Backend Interface
    VirtualQiskitBackend
    QiskitRuntimeBackend
    DockerSimulators
+   IQMBackend
    
 The backend interface contains a minimal set of features that apply to every gate-based quantum computer.
 The main motivation in designing the interface, is to provide a convenient setup for both clients and providers of physical quantum
@@ -83,3 +84,20 @@ This class is a wrapper for the VirtualBackend to quickly integrate Qiskit backe
    vrtl_qasm_sim = VirtualQiskitBackend(qiskit_backend)
 
 Naturally, this also works for non-simulator Qiskit backends.
+
+
+:ref:`IQMBackend`
+---------------------
+
+The IQMBackend class allows to run Qrisp programs on IQM quantum computers available via 
+`IQM Resonance <https://resonance.meetiqm.com/>`. 
+For an up-to-date list of device instance names check the IQM Resonance Dashboard. 
+Devices available via IQM Resonance currently support up to 20 000 shots. 
+
+.. code-block:: python
+
+   from qrisp.interface import IQMBackend
+   qrisp_garnet = IQMBackend(
+      api_token = "YOUR_IQM_RESONANCE_TOKEN", 
+      device_instance = "garnet" # check the website for an up-to-date list of devices
+   )

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,6 +19,9 @@ python_requires = >=3.8
 [options.packages.find]
 where = src
 
+[options.extras_require]
+iqm = qiskit-iqm
+
 [tool:pytest]
 testpaths = ./tests
 pythonpath = .

--- a/setup.py
+++ b/setup.py
@@ -49,6 +49,9 @@ setuptools.setup(
     package_dir={"": "src"},
     install_requires = REQUIREMENTS,
     setup_requires = REQUIREMENTS,
+    extras_require={
+        'iqm': ['qiskit-iqm']
+    },
     packages=setuptools.find_packages(where="src"),
     python_requires=">=3.8",
 )

--- a/src/qrisp/circuit/quantum_circuit.py
+++ b/src/qrisp/circuit/quantum_circuit.py
@@ -1526,7 +1526,7 @@ class QuantumCircuit:
 
         self.data.append(Instruction(operation, qubits, clbits))
 
-    def run(self, shots=100000, backend=None):
+    def run(self, shots=None, backend=None):
         """
         Runs a QuantumCircuit on a given backend.
 

--- a/src/qrisp/core/quantum_variable.py
+++ b/src/qrisp/core/quantum_variable.py
@@ -78,9 +78,9 @@ class QuantumVariable:
     >>> from qrisp import cx
     >>> cx(example_qv, example_qv_2)
     >>> print(example_qv.qs)
-    
+
     ::
-    
+
         QuantumCircuit:
         --------------
         example_qv.0: ──■────────────
@@ -116,9 +116,9 @@ class QuantumVariable:
             s += temp
 
     >>> print(s.qs)
-    
+
     ::
-    
+
         QuantumCircuit:
         --------------
                        ┌───────────┐┌───────────┐┌───────────┐┌───────────┐
@@ -318,54 +318,54 @@ class QuantumVariable:
         QuantumVariable.live_qvs.append(weakref.ref(self))
         self.creation_time = int(self.creation_counter[0])
         self.creation_counter += 1
-    
+
     def __or__(self, other):
         from qrisp import mcx, x, cx
-        
+
         if len(self) > len(other):
             or_res = self.duplicate()
         else:
             or_res = other.duplicate()
-        
+
         for i in range(min(len(self), len(other))):
-            mcx([self[i], other[i]], or_res[i], ctrl_state = 0)
+            mcx([self[i], other[i]], or_res[i], ctrl_state=0)
             x(or_res[i])
-        
+
         for i in range(min(len(self), len(other)), len(self)):
             cx(self[i], or_res[i])
-            
+
         for i in range(min(len(self), len(other)), len(other)):
             cx(other[i], or_res[i])
-        
+
         return or_res
-        
+
     def __and__(self, other):
         from qrisp import mcx
-        
+
         if len(self) > len(other):
             and_res = self.duplicate()
         else:
             and_res = other.duplicate()
-        
+
         for i in range(min(len(self), len(other))):
             mcx([self[i], other[i]], and_res[i])
-        
+
         return and_res
-    
+
     def __xor__(self, other):
         from qrisp import cx
-        
+
         if len(self) > len(other):
             and_res = self.duplicate()
         else:
             and_res = other.duplicate()
-        
+
         for i in range(min(len(self), len(other))):
             cx(self[i], and_res[i])
             cx(other[i], and_res[i])
-        
+
         return and_res
-        
+
     def delete(self, verify=False, recompute=False):
         r"""
         This method is for deleting a QuantumVariable and thus freeing up and resetting
@@ -498,17 +498,15 @@ class QuantumVariable:
         # Register duplicate variable in session manager
 
         if name is not None:
-            
+
             if name[-1] == "*":
                 self.user_given_name = False
                 name = name[:-1]
             else:
                 duplicate.user_given_name = True
-            
+
             duplicate.name = name
             new_qs.register_qv(duplicate)
-            
-            
 
         else:
             duplicate.user_given_name = False
@@ -627,7 +625,7 @@ class QuantumVariable:
 
         raise Exception("Value " + str(value) + " not supported by encoder.")
 
-    def encode(self, value, permit_dirtyness = False):
+    def encode(self, value, permit_dirtyness=False):
         """
         The encode method allows to quickly bring a QuantumVariable in a desired
         computational basis state.
@@ -667,10 +665,12 @@ class QuantumVariable:
         """
 
         from qrisp.misc import check_if_fresh, int_encoder
-        
+
         if not permit_dirtyness:
             if not check_if_fresh(self.reg, self.qs):
-                raise Exception("Tried to initialize qubits which are not fresh anymore.")
+                raise Exception(
+                    "Tried to initialize qubits which are not fresh anymore."
+                )
 
         int_encoder(self, self.encoder(value))
 
@@ -792,7 +792,13 @@ class QuantumVariable:
         insertion_qubits = self.qs.request_qubits(amount)
 
         for i in range(amount):
-            insertion_qubits[i].identifier =  self.name + "_ext_" + str(self.qs.qubit_index_counter[0]) + "." + str(self.size)
+            insertion_qubits[i].identifier = (
+                self.name
+                + "_ext_"
+                + str(self.qs.qubit_index_counter[0])
+                + "."
+                + str(self.size)
+            )
             self.reg.insert(position + i, insertion_qubits[i])
             self.size += 1
 
@@ -845,7 +851,9 @@ class QuantumVariable:
         for i in range(len(qubits)):
             for j in range(self.size):
                 if self.reg[j] == qubits[i]:
-                    self.reg[j].identifier = "reduced_" + str(self.qs.qubit_index_counter[0])
+                    self.reg[j].identifier = "reduced_" + str(
+                        self.qs.qubit_index_counter[0]
+                    )
                     self.qs.qubit_index_counter += 1
                     self.reg.pop(j)
                     break
@@ -858,13 +866,13 @@ class QuantumVariable:
         self,
         plot=False,
         backend=None,
-        shots=100000,
+        shots=None,
         compile=True,
         compilation_kwargs={},
         subs_dic={},
         circuit_preprocessor=None,
         filename=None,
-        precompiled_qc = None
+        precompiled_qc=None,
     ):
         r"""
         Method for quick access to the measurement results of the state of the variable.
@@ -880,7 +888,7 @@ class QuantumVariable:
             The backend on which to evaluate the quantum circuit. The default can be
             specified in the file default_backend.py.
         shots : integer, optional
-            The amount of shots to evaluate the circuit. The default is 10000.
+            The amount of shots to evaluate the circuit. The default is given by the backend it runs on.
         compile : bool, optional
             Boolean indicating if the .compile method of the underlying QuantumSession
             should be called before. The default is True.
@@ -942,7 +950,7 @@ class QuantumVariable:
         if self.size == 0:
             return {"": 1.0}
 
-        if precompiled_qc is None:        
+        if precompiled_qc is None:
             if compile:
                 qc = qompiler(
                     self.qs, intended_measurements=self.reg, **compilation_kwargs
@@ -956,6 +964,7 @@ class QuantumVariable:
         if subs_dic:
             qc = qc.bind_parameters(subs_dic)
             from qrisp.core.compilation import combine_single_qubit_gates
+
             qc = combine_single_qubit_gates(qc)
 
         # Copy circuit in over to prevent modification
@@ -1006,7 +1015,7 @@ class QuantumVariable:
             outcome_labels = []
             for i in range(2**self.size):
                 temp = self.decoder(i)
-                
+
                 try:
                     hash(temp)
                 except TypeError:
@@ -1051,12 +1060,12 @@ class QuantumVariable:
 
     def __str__(self):
         return str(self.get_measurement())
-    
+
     def __repr__(self):
         return "<" + str(type(self)).split(".")[-1][:-2] + " '" + self.name + "'>"
         return str(type(self)).split(".")[-1][:-2] + "(name = " + self.name + ")"
         return str(self)
-    
+
     def __del__(self):
         i = 0
         while i < len(self.live_qvs):
@@ -1064,7 +1073,6 @@ class QuantumVariable:
                 self.live_qvs.pop(i)
                 continue
             i += 1
-        
 
     def __len__(self):
         return self.size
@@ -1075,11 +1083,11 @@ class QuantumVariable:
         from qrisp.environments import q_eq
 
         return q_eq(self, other)
-    
+
     def __ne__(self, other):
         from qrisp.environments import q_eq
 
-        return q_eq(self, other, invert = True)
+        return q_eq(self, other, invert=True)
 
     def __hash__(self):
         return self.creation_time
@@ -1206,9 +1214,9 @@ class QuantumVariable:
         >>> cx(b[0], b[1])
         >>> p(0.5, b[1])
         >>> print(a.qs)
-        
+
         ::
-        
+
             QuantumCircuit:
             --------------
                       ┌───┐
@@ -1229,9 +1237,9 @@ class QuantumVariable:
 
         >>> b.uncompute()
         >>> print(b.qs)
-        
+
         ::
-        
+
             QuantumCircuit:
             --------------
                  ┌────────┐                              ┌────────┐┌───┐
@@ -1433,7 +1441,7 @@ def plot_histogram(outcome_labels, counts, filename=None):
         except KeyError:
             res_list.append(0)
 
-    plt.bar(outcome_labels, res_list, width = 0.8)
+    plt.bar(outcome_labels, res_list, width=0.8)
     plt.grid()
     plt.ylabel("Measurement probability")
     plt.xlabel("QuantumVariable value")

--- a/src/qrisp/default_backend.py
+++ b/src/qrisp/default_backend.py
@@ -18,25 +18,15 @@
 
 
 from qrisp.interface import VirtualBackend, VirtualQiskitBackend
-# from qrisp.interface.qunicorn import BackendClient
-# def_backend = VirtualQiskitBackend()
 from qrisp.simulator.simulator import run
 from qrisp import QuantumCircuit
-#
 
-def run_wrapper(qasm_str, shots, token = ""):
-    qc = QuantumCircuit.from_qasm_str(qasm_str)
-    return run(qc, shots)
-
-# def_backend = VirtualBackend(run_wrapper, port=8080)
 
 class DefaultBackend:
-    
-    def run(self, qc, shots, token = ""):
-        
+    def run(self, qc, shots=None, token=""):
+        if shots is None:
+            shots = 100000
         return run(qc, shots, token)
 
 
 def_backend = DefaultBackend()
-# def_backend = BackendClient()
-# raise

--- a/src/qrisp/examples/qiskit_backend_client.py
+++ b/src/qrisp/examples/qiskit_backend_client.py
@@ -44,7 +44,9 @@ print(qc)
 # %%
 # Create VirtualBackend
 
-def sample_run_func(qc, shots, token):
+def sample_run_func(qc, shots=None, token=""):
+    if shots is None:
+        shots = 1000
     print("Executing Circuit")
     return {"0": shots}
 

--- a/src/qrisp/interface/iqm_backend.py
+++ b/src/qrisp/interface/iqm_backend.py
@@ -16,9 +16,10 @@
 ********************************************************************************/
 """
 
+
 def IQMBackend(api_token, device_instance):
     """
-    This function instantiates an IQMBackend based on VirtualBackend 
+    This function instantiates an IQMBackend based on VirtualBackend
     using Qiskit and Qiskit-on-IQM.
 
 
@@ -27,7 +28,7 @@ def IQMBackend(api_token, device_instance):
     api_token : str
         An API token retrieved from the IQM Resonance website.
     device_instance : str
-        The device instance of the IQM backend such as "garnet". 
+        The device instance of the IQM backend such as "garnet".
         For an up-to-date list, see the IQM Resonance website.
 
     Examples
@@ -62,35 +63,44 @@ def IQMBackend(api_token, device_instance):
     """
 
     if not isinstance(api_token, str):
-        raise TypeError("api_token must be a string. You can create an API token on the IQM Resonance website.")
-    
+        raise TypeError(
+            "api_token must be a string. You can create an API token on the IQM Resonance website."
+        )
+
     if not isinstance(device_instance, str):
-        raise TypeError("Please provide a device_instance as a string. You can retrieve a list of available devices id on the IQM Resonance website.")
+        raise TypeError(
+            "Please provide a device_instance as a string. You can retrieve a list of available devices id on the IQM Resonance website."
+        )
 
     try:
         from iqm.qiskit_iqm import IQMProvider, transpile_to_IQM
     except ImportError:
-        raise ImportError("Please install qiskit-iqm to use the IQMBackend. You can do this by running `pip install qrisp[iqm]`.")
-    
+        raise ImportError(
+            "Please install qiskit-iqm to use the IQMBackend. You can do this by running `pip install qrisp[iqm]`."
+        )
+
     import qiskit
-    
-    def run_func_iqm(qasm_str, shots, token = ""):
-        
+
+    def run_func_iqm(qasm_str, shots=None, token=""):
+        if shots is None:
+            shots = 1000
         server_url = "https://cocos.resonance.meetiqm.com/" + device_instance
-        
-        backend = IQMProvider(server_url, token = api_token).get_backend()
+
+        backend = IQMProvider(server_url, token=api_token).get_backend()
         qc = qiskit.QuantumCircuit.from_qasm_str(qasm_str)
         qc_transpiled = transpile_to_IQM(qc, backend)
-        
+
         job = backend.run(qc_transpiled, shots=shots)
         import re
+
         counts = job.result().get_counts()
         new_counts = {}
         for key in counts.keys():
             counts_string = re.sub(r"\W", "", key)
             new_counts[counts_string] = counts[key]
-            
+
         return new_counts
-    
+
     from qrisp.interface import VirtualBackend
+
     return VirtualBackend(run_func_iqm)

--- a/src/qrisp/interface/iqm_backend.py
+++ b/src/qrisp/interface/iqm_backend.py
@@ -17,9 +17,63 @@
 """
 
 def IQMBackend(api_token, device_instance):
+    """
+    This function instantiates an IQMBackend based on VirtualBackend 
+    using Qiskit and Qiskit-on-IQM.
+
+
+    Parameters
+    ----------
+    api_token : str
+        An API token retrieved from the IQM Resonance website.
+    device_instance : str
+        The device instance of the IQM backend such as "garnet". 
+        For an up-to-date list, see the IQM Resonance website.
+
+    Examples
+    --------
+
+    We evaluate a QuantumFloat multiplication on the 20-qubit IQM Garnet.
+
+    >>> from qrisp.interface import IQMBackend
+    >>> qrisp_garnet = IQMBackend(api_token = "YOUR_IQM_RESONANCE_TOKEN", device_instance = "garnet")
+    >>> from qrisp import QuantumFloat
+    >>> a = QuantumFloat(2)
+    >>> a[:] = 2
+    >>> b = a*a
+    >>> b.get_measurement(backend = qrisp_garnet, shots=1000)
+    {4: 0.548,
+     5: 0.082,
+     0: 0.063,
+     6: 0.042,
+     8: 0.031,
+     2: 0.029,
+     12: 0.014,
+     10: 0.03,
+     1: 0.027,
+     7: 0.025,
+     15: 0.023,
+     9: 0.021,
+     14: 0.021,
+     13: 0.018,
+     11: 0.014,
+     3: 0.012}
+
+    """
+
+    if not isinstance(api_token, str):
+        raise TypeError("api_token must be a string. You can create an API token on the IQM Resonance website.")
     
-    from iqm.qiskit_iqm import IQMProvider, transpile_to_IQM
+    if not isinstance(device_instance, str):
+        raise TypeError("Please provide a device_instance as a string. You can retrieve a list of available devices id on the IQM Resonance website.")
+
+    try:
+        from iqm.qiskit_iqm import IQMProvider, transpile_to_IQM
+    except ImportError:
+        raise ImportError("Please install qiskit-iqm to use the IQMBackend. You can do this by running `pip install qrisp[iqm]`.")
+    
     import qiskit
+    
     def run_func_iqm(qasm_str, shots, token = ""):
         
         server_url = "https://cocos.resonance.meetiqm.com/" + device_instance

--- a/src/qrisp/misc/utility.py
+++ b/src/qrisp/misc/utility.py
@@ -74,7 +74,7 @@ def cnot_count(qc):
     cnot_count = 0
     for gate_name in ["cx", "cy", "cz"]:
         cnot_count += gate_count_dic.get(gate_name, 0)
-    
+
     return cnot_count
 
 
@@ -87,7 +87,7 @@ def is_inv(x, bit):
     return bool(int(x) % 2)
 
 
-def get_depth_dic(qc, transpile_qc=True, depth_indicator = lambda x : 1):
+def get_depth_dic(qc, transpile_qc=True, depth_indicator=lambda x: 1):
     if len(qc.qubits) == 0:
         return {}
 
@@ -126,9 +126,9 @@ def get_depth_dic(qc, transpile_qc=True, depth_indicator = lambda x : 1):
         levels = []
         reg_ints = []
         # If count then add one to stack heights
-        
+
         gate_depth = depth_indicator(instr.op)
-        
+
         for ind, reg in enumerate(qargs + cargs):
             # Add to the stacks of the qubits and
             # cbits used in the gate.
@@ -215,9 +215,9 @@ def gate_wrap(*args, permeability=None, is_qfree=None, name=None, verify=False):
         example_function(a, b)
 
     >>> print(a.qs)
-    
+
     ::
-    
+
         QuantumCircuit:
         --------------
              ┌───────────────────┐
@@ -237,11 +237,11 @@ def gate_wrap(*args, permeability=None, is_qfree=None, name=None, verify=False):
         ---------------------
         QuantumVariable a
         QuantumVariable b
-    
+
     >>> print(a.qs.transpile())
-    
+
     ::
-    
+
              ┌───┐                    ┌───┐
         b.0: ┤ X ├─────────────────■──┤ H ├──────────
              └─┬─┘┌───┐            │  └───┘┌───┐
@@ -278,9 +278,9 @@ def gate_wrap(*args, permeability=None, is_qfree=None, name=None, verify=False):
         res = example_function(qv_0, qv_1)
 
     >>> print(qv_0.qs)
-    
+
     ::
-    
+
         QuantumCircuit:
         --------------
                 ┌───────────────────┐
@@ -295,13 +295,13 @@ def gate_wrap(*args, permeability=None, is_qfree=None, name=None, verify=False):
         QuantumVariable qv_0
         QuantumVariable qv_1
         QuantumVariable res
-    
-    
+
+
     >>> qv_1.uncompute()
     >>> print(qv_0.qs)
-    
+
     ::
-    
+
         QuantumCircuit:
         --------------
                 ┌───────────────────┐
@@ -323,9 +323,9 @@ def gate_wrap(*args, permeability=None, is_qfree=None, name=None, verify=False):
     >>> qv_0.uncompute(do_it = False)
     >>> res.uncompute()
     >>> print(qv_0.qs)
-    
+
     ::
-    
+
         QuantumCircuit:
         --------------
                 ┌───────────────────┐┌──────────────────────┐
@@ -368,16 +368,13 @@ def gate_wrap_inner(
         from qrisp.environments import GateWrapEnvironment
         from qrisp import merge, QuantumVariable, QuantumArray
 
-
         try:
             qs = find_qs(args)
         except:
             qs_list = recursive_qs_search([args, kwargs])
             qs = qs_list[0]
-            
 
         initial_qubits = set(qs.qubits)
-
 
         if name is None:
             gwe = GateWrapEnvironment(name=function.__name__)
@@ -389,10 +386,10 @@ def gate_wrap_inner(
 
         if len(qs.env_stack):
             gwe.compile()
-            
+
         if gwe in qs.data:
             qs.data.remove(gwe)
-        
+
         if gwe.instruction is None:
             return result
 
@@ -417,22 +414,21 @@ def gate_wrap_inner(
             gwe.instruction.op.is_qfree = is_qfree
 
         if permeability is not None:
-            permeability_dict = {i : None for i in range(gwe.instruction.op.num_qubits)}
+            permeability_dict = {i: None for i in range(gwe.instruction.op.num_qubits)}
             permeable_qubits = []
             not_permeable_qubits = []
-            
 
             if isinstance(permeability, list):
-                
+
                 for i in range(len(args)):
-                    
+
                     if i in permeability:
                         extension_list = permeable_qubits
                     else:
                         extension_list = not_permeable_qubits
-                    
+
                     arg = args[i]
-                    
+
                     if isinstance(arg, QuantumVariable):
                         extension_list += arg.reg
                     elif isinstance(arg, (tuple, list)):
@@ -444,7 +440,6 @@ def gate_wrap_inner(
                     elif isinstance(arg, QuantumArray):
                         for qv in arg.flatten():
                             extension_list += qv.reg
-                        
 
                 if isinstance(result, QuantumVariable):
                     not_permeable_qubits += result.reg
@@ -457,11 +452,9 @@ def gate_wrap_inner(
                 elif isinstance(result, QuantumArray):
                     for qv in result.flatten():
                         not_permeable_qubits += qv.reg
-                    
-                    
-            
+
             elif isinstance(permeability, str):
-                
+
                 for arg in args:
                     if isinstance(arg, QuantumVariable):
                         permeable_qubits += arg.reg
@@ -481,7 +474,7 @@ def gate_wrap_inner(
                     extension_list = not_permeable_qubits
                 else:
                     raise Exception(f"Don't know permeability option {permeability}")
-                    
+
                 if isinstance(result, QuantumVariable):
                     extension_list += result.reg
                 elif isinstance(result, (tuple, list)):
@@ -495,14 +488,14 @@ def gate_wrap_inner(
                         extension_list += qv.reg
 
             for i in range(len(gwe.instruction.qubits)):
-                
+
                 qb = gwe.instruction.qubits[i]
                 if qb in permeable_qubits:
                     permeability_dict[i] = True
                 elif qb in not_permeable_qubits:
                     permeability_dict[i] = False
                 elif qb in ancillas:
-                    
+
                     # Even though ancilla qubits are permeable, we want to be able to
                     # use the gate_wrap decorator as an interface to perform
                     # recomputation. If we mark them as permeable, Unqomp won't  wrap
@@ -612,17 +605,18 @@ def gate_wrap_inner(
 
 
 def find_qs(args):
-    
+
     if hasattr(args, "qs"):
         return args.qs()
-    
+
     from qrisp import QuantumVariable, QuantumArray, Qubit
+
     for arg in args:
         if isinstance(arg, (QuantumVariable, QuantumArray)):
             return arg.qs
         if isinstance(arg, Qubit):
             return arg.qs()
-        
+
     else:
         for arg in args:
             if isinstance(arg, (list, tuple)):
@@ -635,12 +629,12 @@ def find_qs(args):
                     return find_qs(arg.items())
                 except:
                     pass
-    
+
     raise Exception("Couldn't find QuantumSession")
 
 
 # Function to measure multiple quantum variables at once to assess their entanglement
-def multi_measurement(qv_list, shots=100000, backend=None):
+def multi_measurement(qv_list, shots=None, backend=None):
     """
     This functions facilitates the measurement of multiple QuantumVariables at the same
     time. This can be used if the entanglement structure between several
@@ -651,7 +645,7 @@ def multi_measurement(qv_list, shots=100000, backend=None):
     qv_list : list[QuantumVariable]
         A list of QuantumVariables.
     shots : int, optional
-        The amount of shots to perform. The default is 10000.
+        The amount of shots to perform. The default is given by the backend used.
     backend : BackendClient, optional
         The backend to evaluate the compiled QuantumCircuit on. By default, the backend
         from default_backend.py will be used.
@@ -712,7 +706,6 @@ def multi_measurement(qv_list, shots=100000, backend=None):
     # compiled_qc = qv_list[0].qs.copy()
     # Add classical registers for the measurement results to be stored in
     cl_reg_list = []
-    
 
     for var in qv_list[::-1]:
         cl_reg = []
@@ -1207,8 +1200,7 @@ def get_statevector_function(qs, decimals=None):
                 raise Exception(
                     "Tried to invoke statevector debugger without specifying an "
                     "outcome label for each QuantumVariable registered in "
-                    "QuantumSession. Missing variables are: "
-                    + str(missing_variables)
+                    "QuantumSession. Missing variables are: " + str(missing_variables)
                 )
 
             bitstring = len(compiled_qc.qubits) * ["0"]
@@ -1232,21 +1224,21 @@ def get_statevector_function(qs, decimals=None):
         return statevector
 
 
-def check_if_fresh(qubits, qs, ignore_q_envs = True):
-    
+def check_if_fresh(qubits, qs, ignore_q_envs=True):
+
     from qrisp import QuantumEnvironment
-    
+
     if not ignore_q_envs:
         temp_data = list(qs.data)
         qs.data = []
-        
+
         for i in range(len(temp_data)):
             if isinstance(temp_data[i], QuantumEnvironment):
                 env = temp_data[i]
                 env.compile()
             else:
                 qs.append(temp_data[i])
-    
+
     for qb in qubits:
         reversed_data = qb.qs().data[::-1]
         for instr in reversed_data:
@@ -1263,7 +1255,7 @@ def check_if_fresh(qubits, qs, ignore_q_envs = True):
     return True
 
 
-def get_measurement_from_qc(qc, qubits, backend, shots=100000):
+def get_measurement_from_qc(qc, qubits, backend, shots=None):
     # Add classical registers for the measurement results to be stored in
     cl = []
     for i in range(len(qubits)):
@@ -1275,14 +1267,15 @@ def get_measurement_from_qc(qc, qubits, backend, shots=100000):
 
     # Execute circuit
     counts = backend.run(qc, shots)
-    
+
     # Remove other measurements outcomes from counts dic
     new_counts_dic = {}
+    no_of_shots_executed = 0
     for key in counts.keys():
         # Remove possible whitespaces
         new_key = key.replace(" ", "")
         # Remove other measurements
-        new_key = new_key[:len(cl)]
+        new_key = new_key[: len(cl)]
 
         new_key = int(new_key, base=2)
         try:
@@ -1290,13 +1283,15 @@ def get_measurement_from_qc(qc, qubits, backend, shots=100000):
         except KeyError:
             new_counts_dic[new_key] = counts[key]
 
+        no_of_shots_executed += counts[key]
+
     counts = new_counts_dic
-    
+
     # Plot result (if needed)
 
     # Normalize counts
     for key in counts.keys():
-        counts[key] = counts[key] / abs(shots)
+        counts[key] = counts[key] / abs(no_of_shots_executed)
 
     return counts
 
@@ -1308,10 +1303,9 @@ def find_calling_line(level=0):
     )  # prints "a = fct1()"
 
 
-
 def retarget_instructions(data, source_qubits, target_qubits):
     from qrisp import QuantumEnvironment, recursive_qs_search, multi_session_merge
-    
+
     for i in range(len(data)):
         instr = data[i]
 
@@ -1323,6 +1317,7 @@ def retarget_instructions(data, source_qubits, target_qubits):
         for j in range(len(instr.qubits)):
             if instr.qubits[j] in source_qubits:
                 instr.qubits[j] = target_qubits[source_qubits.index(instr.qubits[j])]
+
 
 def redirect_qfunction(function_to_redirect):
     """
@@ -1380,9 +1375,9 @@ def redirect_qfunction(function_to_redirect):
 
 
     >>> print(a.qs)
-    
+
     ::
-    
+
         QuantumCircuit:
         --------------
         b.0: ──■──
@@ -1402,13 +1397,20 @@ def redirect_qfunction(function_to_redirect):
     """
     from qrisp import QuantumEnvironment, QuantumVariable, merge, QuantumArray
     import weakref
+
     def redirected_qfunction(*args, target=None, **kwargs):
-        
-        merge([arg for arg in list(args) + [target] if isinstance(arg, (QuantumVariable, QuantumArray))])
+
+        merge(
+            [
+                arg
+                for arg in list(args) + [target]
+                if isinstance(arg, (QuantumVariable, QuantumArray))
+            ]
+        )
         env = QuantumEnvironment()
         env.manual_allocation_management = True
         qs = target.qs
-        
+
         with env:
             res = function_to_redirect(*args, **kwargs)
 
@@ -1426,9 +1428,9 @@ def redirect_qfunction(function_to_redirect):
             i = 0
             res_is_new = False
             while i < len(env.env_qs.data):
-                
+
                 instr = env.env_qs.data[i]
-                
+
                 if isinstance(instr, QuantumEnvironment):
                     pass
                 elif instr.op.name == "qb_alloc" and instr.qubits[0] in list(res):
@@ -1484,7 +1486,7 @@ def get_sympy_state(qs, decimals):
     from qrisp.simulator import statevector_sim
 
     qv_list = list(qs.qv_list)
-    
+
     labels = []
     for qv in qv_list:
         labels.append([qv.decoder(i) for i in range(2**qv.size)])
@@ -1530,26 +1532,26 @@ def get_sympy_state(qs, decimals):
         amplitude = sv_array[ind]
 
         if not sv_array.dtype == np.dtype("O"):
-            
+
             if decimals is None:
-                
+
                 try:
                     abs_amp = trigify_amp(amplitude, nnz)
                 except TypeError:
                     abs_amp = amplitude
-                
+
                 # For some reason there is a sympy error, when the angle is equal to 1
                 if angles[ind] == 1:
                     phase = 1
                 else:
-                    phase = nsimplify(float(angles[ind]), tolerance=10 ** -5)
-    
+                    phase = nsimplify(float(angles[ind]), tolerance=10**-5)
+
                 if count_ops(phase) > 5:
                     phase = angles[ind]
-    
+
                 ket_expr = exp(I * phase * pi) * abs_amp * nnz**0.5
             else:
-                
+
                 ket_expr = sympy.N(amplitude, decimals)
 
         else:
@@ -1579,16 +1581,16 @@ def get_sympy_state(qs, decimals):
                     if np.angle(complex(a.evalf())) / np.pi == 1:
                         phase = -1
                     else:
-                        
+
                         phase = sp.exp(
                             sp.I
                             * nsimplify(
                                 np.angle(complex(a.evalf())) / np.pi,
-                                tolerance=10 ** -5,
+                                tolerance=10**-5,
                             )
                             * Symbol("pi")
                         )
-                        
+
                     expr = abs_amp * phase
 
                     amplitude = amplitude.subs(a, expr)
@@ -1609,7 +1611,7 @@ def get_sympy_state(qs, decimals):
             ket_expr *= OrthogonalKet((label))
 
         res += ket_expr
-    
+
     if decimals is None or sv_array.dtype == np.dtype("O"):
         res = cancel(nsimplify(1 / nnz**0.5) * res)
 
@@ -1642,10 +1644,10 @@ def trigify_amp(amplitude, nnz):
     )
 
     cos_expr = nsimplify(
-        float(np.arccos(np.abs(amplitude)) / np.pi), tolerance=10 ** -5
+        float(np.arccos(np.abs(amplitude)) / np.pi), tolerance=10**-5
     )
     sin_expr = nsimplify(
-        float(np.arcsin(np.abs(amplitude)) / np.pi), tolerance=10 ** -5
+        float(np.arcsin(np.abs(amplitude)) / np.pi), tolerance=10**-5
     )
 
     # if count_ops(sin_expr) > count_ops(cos_expr):
@@ -1665,14 +1667,13 @@ def trigify_amp(amplitude, nnz):
             temp = sin_expr
     else:
         temp = (
-            nsimplify(np.abs(amplitude) * nnz**0.5, tolerance=10 ** -5)
-            / nnz**0.5
+            nsimplify(np.abs(amplitude) * nnz**0.5, tolerance=10**-5) / nnz**0.5
         )
 
     # if count_ops(temp) > 4:
     if len(latex(temp)) > 20:
         temp = (
-            nsimplify(float(np.abs(amplitude) * nnz**0.5), tolerance=10 ** -5)
+            nsimplify(float(np.abs(amplitude) * nnz**0.5), tolerance=10**-5)
             / nnz**0.5
         )
         if len(latex(temp)) > 20:
@@ -1779,9 +1780,9 @@ def lifted(*args, verify=False):
         res = margolus(control)
 
     >>> print(res.qs)
-    
+
     ::
-    
+
         QuantumCircuit:
         --------------
                    ┌───────────┐
@@ -1798,9 +1799,9 @@ def lifted(*args, verify=False):
 
     >>> res.uncompute()
     >>> print(res.qs)
-    
+
     ::
-    
+
         QuantumCircuit:
         --------------
                    ┌───────────┐┌──────────────┐
@@ -1836,11 +1837,11 @@ def lifted(*args, verify=False):
 def t_depth_indicator(op, epsilon):
     r"""
     This function returns the T-depth of an :ref:`Operation` object.
-    
+
     According to `this paper <https://arxiv.org/abs/1403.2975>`_, the synthesis of an $RZ(\phi)$
-    up to precision $\epsilon$ requires $3\text{log}_2(\frac{1}{\epsilon})$ 
+    up to precision $\epsilon$ requires $3\text{log}_2(\frac{1}{\epsilon})$
     T-gates.
-    
+
     Parameters
     ----------
     op : :ref:`Operation`
@@ -1855,47 +1856,64 @@ def t_depth_indicator(op, epsilon):
         The estimated T-depth of the Operation.
 
     """
-    
+
     from qrisp import ClControlledOperation
-    
+
     if isinstance(op, ClControlledOperation):
         return t_depth_indicator(op.base_op, epsilon)
     elif op.definition is not None:
         return op.definition.t_depth(epsilon)
-    elif op.name in ["cx", "cx", "cz", "x", "y", "z", "s", "h", "s_dg", "measure", "reset", "qb_alloc", "qb_dealloc", "barrier", "gphase"]:
+    elif op.name in [
+        "cx",
+        "cx",
+        "cz",
+        "x",
+        "y",
+        "z",
+        "s",
+        "h",
+        "s_dg",
+        "measure",
+        "reset",
+        "qb_alloc",
+        "qb_dealloc",
+        "barrier",
+        "gphase",
+    ]:
         return 0
     elif op.name in ["rx", "ry", "rz", "p", "u1"]:
-        par = op.params[0]/(np.pi)%1
-        if par in [0, 1/2]:
+        par = op.params[0] / (np.pi) % 1
+        if par in [0, 1 / 2]:
             return 0
-        elif par in [1/4, 3/4]:
+        elif par in [1 / 4, 3 / 4]:
             return 1
         else:
-            return 3*np.log2(1/epsilon)
+            return 3 * np.log2(1 / epsilon)
     elif op.name in ["t", "t_dg"]:
         return 1
     elif op.name == "u3":
         res = 0
         for i in range(3):
-            par = op.params[0]/(np.pi)%1
-            if par in [0, 1/2]:
+            par = op.params[0] / (np.pi) % 1
+            if par in [0, 1 / 2]:
                 pass
-            elif par in [1/4, 3/4]:
+            elif par in [1 / 4, 3 / 4]:
                 res += 1
             else:
-                res += 3*np.log2(1/epsilon)
+                res += 3 * np.log2(1 / epsilon)
         return res
     else:
         raise Exception(f"Gate {op.name} not implemented")
 
+
 def cnot_depth_indicator(op):
     r"""
     This function returns the CNOT-depth of an :ref:`Operation` object.
-    
-    In NISQ-era devices, CNOT gates are the restricting bottleneck for quantum 
+
+    In NISQ-era devices, CNOT gates are the restricting bottleneck for quantum
     circuit execution. This function can be used as a gate-speed specifier for
     the :meth:`compile <qrisp.QuantumSession.compile>` method.
-    
+
     Parameters
     ----------
     op : :ref:`Operation`
@@ -1907,9 +1925,9 @@ def cnot_depth_indicator(op):
         The CNOT-depth of the Operation.
 
     """
-    
+
     from qrisp import ClControlledOperation
-    
+
     if isinstance(op, ClControlledOperation):
         return cnot_depth_indicator(op.base_op)
     elif op.definition is not None:
@@ -1920,11 +1938,12 @@ def cnot_depth_indicator(op):
         return 1
     else:
         raise Exception(f"Gate {op.name} not implemented")
-        
+
+
 def inpl_adder_test(inpl_adder):
     """
     This function runs tests on a desired inplace addition function.
-    An inplace addition function is a function mapping (a, b) to (a, a+b), 
+    An inplace addition function is a function mapping (a, b) to (a, a+b),
     where a is a :ref:`QuantumVariable`, list[:ref:`Qubit`] or an integer
     and b is either a :ref:`QuantumVariable` or a list[:ref:`Qubit`].
 
@@ -1936,152 +1955,166 @@ def inpl_adder_test(inpl_adder):
 
     Returns
     -------
-    Bool:  
+    Bool:
         True if all tests are passed, else False/ Exceptions.
-        
+
     Examples
     --------
-    
+
     We test the built-in Cuccaro adder:
-        
+
     ::
-        
+
         from qrisp import cuccaro_adder, inpl_adder_test
-        
+
         inpl_adder_test(cuccaro_adder)
         print("The cuccaro adder passed the tests without errors.")
-    
+
     And now a new user-defined qcla adder:
     ::
-        
+
         from qrisp import inpl_adder_test, qcla
-        
+
         qcla_2_0 = lambda x, y : qcla(x, y, radix_base = 2, radix_exponent = 0)
         inpl_adder_test(qcla_2_0)
         print("The qcla_2_0 adder passed the tests without errors.")
 
     """
     from qrisp import QuantumFloat, multi_measurement, h, control, QuantumBool
-    
+
     for i in range(1, 7):
-        
-        for j in range(1, i+1):
+
+        for j in range(1, i + 1):
             a = QuantumFloat(j)
             b = QuantumFloat(i)
             c = QuantumFloat(i)
-            
+
             h(a)
             h(b)
-            
+
             c[:] = b
-            
+
             inpl_adder(a, c)
-            
+
             statevector_arr = a.qs.compile().statevector_array()
             angles = np.angle(
                 statevector_arr[
                     np.abs(statevector_arr) > 1 / 2 ** ((a.size + b.size) / 2 + 1)
                 ]
             )
-    
+
             # Test correct phase behavior
-            assert np.sum(np.abs(angles)) < 0.1, f"Quantum-quantum adder produced a faulty phase shift on input sizes, {i},{j}."
-            
-            
-            
-            mes_res = multi_measurement([a,b,c])
-            
+            assert (
+                np.sum(np.abs(angles)) < 0.1
+            ), f"Quantum-quantum adder produced a faulty phase shift on input sizes, {i},{j}."
+
+            mes_res = multi_measurement([a, b, c])
+
             for a, b, c in mes_res.keys():
-                assert (a + b)%(2**i) == c, f"Quantum-quantum addition result was incorrect for input values {a} += {c} on input sizes, {i},{j}."
-                
-            
-        
+                assert (a + b) % (
+                    2**i
+                ) == c, f"Quantum-quantum addition result was incorrect for input values {a} += {c} on input sizes, {i},{j}."
+
         if i < 6:
             for j in range(1, 2**i):
                 a = QuantumFloat(i)
                 b = QuantumFloat(i)
-                
+
                 h(a)
-                
+
                 b[:] = a
-                
+
                 inpl_adder(j, a)
-                
+
                 statevector_arr = a.qs.compile().statevector_array()
                 angles = np.angle(
                     statevector_arr[
                         np.abs(statevector_arr) > 1 / 2 ** ((a.size) / 2 + 1)
                     ]
                 )
-                assert np.sum(np.abs(angles)) < 0.1, f"Classical-quantum adder produced a faulty phase shift on input size {i}."
-                
-                mes_res = multi_measurement([a,b])
-                
+                assert (
+                    np.sum(np.abs(angles)) < 0.1
+                ), f"Classical-quantum adder produced a faulty phase shift on input size {i}."
+
+                mes_res = multi_measurement([a, b])
+
                 for a, b in mes_res.keys():
-                    assert (b + j)%(2**i) == a, f"Classical-quantum addition result was incorrect for input values {a} += {c} on input size {i}."
-                    
+                    assert (b + j) % (
+                        2**i
+                    ) == a, f"Classical-quantum addition result was incorrect for input values {a} += {c} on input size {i}."
+
     for i in range(1, 7):
-        
-        for j in range(1, i+1):
+
+        for j in range(1, i + 1):
             a = QuantumFloat(j)
             b = QuantumFloat(i)
             c = QuantumFloat(i)
             qbl = QuantumBool()
-            
+
             h(qbl)
             h(a)
             h(b)
-            
+
             c[:] = b
-            
+
             with control(qbl):
                 inpl_adder(a, c)
-                
-                
+
             statevector_arr = a.qs.compile().statevector_array()
             angles = np.angle(
                 statevector_arr[
-                    np.abs(statevector_arr) > 1 / 2 ** ((a.size+ b.size) / 2 + 1)
+                    np.abs(statevector_arr) > 1 / 2 ** ((a.size + b.size) / 2 + 1)
                 ]
             )
-            assert np.sum(np.abs(angles)) < 0.1, f"Controlled quantum-quantum adder produced a faulty phase shift on input sizes, {i},{j}."
-            
-            mes_res = multi_measurement([a,b,c, qbl])
-            
+            assert (
+                np.sum(np.abs(angles)) < 0.1
+            ), f"Controlled quantum-quantum adder produced a faulty phase shift on input sizes, {i},{j}."
+
+            mes_res = multi_measurement([a, b, c, qbl])
+
             for a, b, c, qbl in mes_res.keys():
-                
+
                 if qbl:
-                    assert (a + b)%(2**i) == c, f"Controlled quantum-quantum addition result was incorrect for input values {a} += {c} on input sizes, {i},{j}."
+                    assert (a + b) % (
+                        2**i
+                    ) == c, f"Controlled quantum-quantum addition result was incorrect for input values {a} += {c} on input sizes, {i},{j}."
                 else:
-                    assert c == b, f"Controlled quantum-quantum addition behaviour was incorrect; an operation was performed without the control qubit in |1> state.Faulty input sizes: {i},{j}"
-        
+                    assert (
+                        c == b
+                    ), f"Controlled quantum-quantum addition behaviour was incorrect; an operation was performed without the control qubit in |1> state.Faulty input sizes: {i},{j}"
+
         if i < 6:
             for j in range(1, 2**i):
                 a = QuantumFloat(i)
                 b = QuantumFloat(i)
                 qbl = QuantumBool()
-                
+
                 h(qbl)
                 h(a)
-                
+
                 b[:] = a
-                
+
                 with control(qbl):
                     inpl_adder(j, a)
-                    
+
                 statevector_arr = a.qs.compile().statevector_array()
                 angles = np.angle(
                     statevector_arr[
                         np.abs(statevector_arr) > 1 / 2 ** ((a.size) / 2 + 1)
                     ]
-                )    
-                assert np.sum(np.abs(angles)) < 0.1, f"Controlled classical-quantum adder produced a faulty phase shift on input size {i}."
-                
-                
-                mes_res = multi_measurement([a,b, qbl])
-                
+                )
+                assert (
+                    np.sum(np.abs(angles)) < 0.1
+                ), f"Controlled classical-quantum adder produced a faulty phase shift on input size {i}."
+
+                mes_res = multi_measurement([a, b, qbl])
+
                 for a, b, qbl in mes_res.keys():
                     if qbl:
-                        assert (b + j)%(2**i) == a, f"Controlled classical-quantum addition result was incorrect for input values {b} += {j} on input size, {i}."
+                        assert (b + j) % (
+                            2**i
+                        ) == a, f"Controlled classical-quantum addition result was incorrect for input values {b} += {j} on input size, {i}."
                     else:
-                        assert b == a, f"Controlled classical-quantum addition behaviour was incorrect; an operation was performed without the control qubit in |1> state. Faulty input sizes: {i}"
+                        assert (
+                            b == a
+                        ), f"Controlled classical-quantum addition behaviour was incorrect; an operation was performed without the control qubit in |1> state. Faulty input sizes: {i}"

--- a/src/qrisp/misc/utility.py
+++ b/src/qrisp/misc/utility.py
@@ -765,7 +765,8 @@ def multi_measurement(qv_list, shots=None, backend=None):
         # Create array
         array_state = tuple(counts_values)
         try:
-            new_counts[array_state] = counts[list(counts.keys())[i]] / shots
+            no_of_shots_executed = sum(counts.values())
+            new_counts[array_state] = counts[list(counts.keys())[i]] / no_of_shots_executed
         except TypeError:
             raise Exception(
                 "Tried to create measurement outcome dic for QuantumVariable "

--- a/tests/test_cycling_function.py
+++ b/tests/test_cycling_function.py
@@ -50,4 +50,4 @@ def test_cycling_function():
 
     shift_amount[:] = {0: 1, -4 : 1, 1: 1}
     cyclic_shift(qa, shift_amount)
-    assert qa.get_measurement() == {OutcomeArray([7, 0, 1, 2, 3, 4, 5, 6]): 0.33333, OutcomeArray([4, 5, 6, 7, 0, 1, 2, 3]): 0.33333, OutcomeArray([0, 1, 2, 3, 4, 5, 6, 7]): 0.33333}
+    assert qa.get_measurement() == {OutcomeArray([7, 0, 1, 2, 3, 4, 5, 6]): 0.3333333333333333, OutcomeArray([4, 5, 6, 7, 0, 1, 2, 3]): 0.3333333333333333, OutcomeArray([0, 1, 2, 3, 4, 5, 6, 7]): 0.3333333333333333}

--- a/tests/test_iqm_backend.py
+++ b/tests/test_iqm_backend.py
@@ -1,0 +1,55 @@
+# Created by manzanillo
+import pytest
+from unittest.mock import patch
+from qrisp.interface import IQMBackend, VirtualBackend
+
+import pytest
+from unittest.mock import patch, MagicMock
+from qrisp.interface import IQMBackend
+
+# Mock the IQMProvider and transpile_to_IQM functions from qiskit_iqm
+@patch("iqm.qiskit_iqm.IQMProvider")
+@patch("iqm.qiskit_iqm.transpile_to_IQM")
+def test_IQMBackend(mock_transpile, mock_iqmprovider):
+    # Mock the server_url and token
+    server_url = "https://cocos.resonance.meetiqm.com/garnet"
+    api_token = "mock_api_token"
+
+    # Create a mock device instance
+    device_instance = "garnet"
+
+    # Create an instance of IQMBackend
+    backend = IQMBackend(api_token, device_instance)
+
+    # Check that the backend is an instance of VirtualBackend
+    assert isinstance(backend, VirtualBackend)
+
+    # Create a mock QASM string
+    from qrisp import QuantumCircuit
+    qc = QuantumCircuit(4, name = "test")
+
+    # Mock the result of the run method
+    mock_result = {"mock_key": 1}
+
+    # Use a side effect to return the mock result
+    mock_iqmprovider.return_value.get_backend.return_value.run.return_value.result.return_value.get_counts.side_effect = [mock_result]
+
+    # Call the run method
+    result = backend.run(qc, shots=1000, token=api_token)
+
+    # Check that the result is as expected
+    assert result == mock_result
+
+    # Check that the IQMProvider and transpile_to_IQM functions are called correctly
+    mock_iqmprovider.assert_called_once_with(server_url, token=api_token)
+    mock_transpile.assert_called_once()
+
+# Test that the API token is a string
+def test_IQMBackend_api_token_string_is_missing():
+    with pytest.raises(TypeError):
+        IQMBackend(123, "garnet")
+
+# Test that the device instance is a string
+def test_IQMBackend_device_instance_string_is_missing():
+    with pytest.raises(TypeError):
+        IQMBackend("mock_api_token", 123)

--- a/tests/test_qiskit_backend_client.py
+++ b/tests/test_qiskit_backend_client.py
@@ -72,7 +72,9 @@ def test_qiskit_backend_client():
     qc.measure(1, 0)
 
 
-    def sample_run_func(qc, shots, token = ""):
+    def sample_run_func(qc, shots = None, token = ""):
+        if shots is None:
+            shots = 10000
         return {"0": shots}
 
     test_virtual_backend = VirtualBackend(sample_run_func)


### PR DESCRIPTION
This PR adds
* documentation for how to use an IQM backend in Qrisp, and what parameters to provide
* input validation for API token, device id and availability of iqm relevant dependecies
* Define IQM depencies as an extra package that can be installed using `pip install qrisp[iqm]`

I further suggest to change the default number of shots (100.000) for the measurement to a smaller number as most physical devices have a maximum number of shot that is below that (e.g. for IQM devices it is 20.000). This would result in the user not needing to specify the number of shots when using `IQMBackend`. The alternative is (as I did currently) to mention the limit in the documentation and always provide a shots parameter.