### PR TITLE
Bump version for IQMBackend integration

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = qrisp
-version = 0.4.12
+version = 0.4.13
 author = Raphael Seidel
 author_email = raphael.seidel@fokus.fraunhofer.de
 description = A high-level quantum programming language


### PR DESCRIPTION
This PR bumps the version of the package for pip. This was not yet added to the IQM Resonance integration branch.