### PR TITLE
Jit based rt simulation

### DIFF
--- a/tests/jax_tests/test_HHL_demo.py
+++ b/tests/jax_tests/test_HHL_demo.py
@@ -317,11 +317,17 @@ def test_HHL_demo():
         # quantum variables, while most other evaluation modes require
         # classical return values.
         return qrisp.measure(x)
+    
+    try:
+        import catalyst
+    except ImportError:
+        return
 
     jaspr = qrisp.make_jaspr(main)()
     qir_str = jaspr.to_qir()
     # Print only the first few lines - the whole string is very long.
     print(qir_str[:200])
+
 
     ############################################################
 


### PR DESCRIPTION
Purely classical subroutines decorated with jax.jit are now compiled to binary by the jaspify decorator.