### PR TITLE
Fix problems with import

### DIFF
--- a/src/qrisp/algorithms/vqe/problems/__init__.py
+++ b/src/qrisp/algorithms/vqe/problems/__init__.py
@@ -1,0 +1,21 @@
+"""
+\********************************************************************************
+* Copyright (c) 2025 the Qrisp authors
+*
+* This program and the accompanying materials are made available under the
+* terms of the Eclipse Public License 2.0 which is available at
+* http://www.eclipse.org/legal/epl-2.0.
+*
+* This Source Code may also be made available under the following Secondary
+* Licenses when the conditions for such availability set forth in the Eclipse
+* Public License, v. 2.0 are satisfied: GNU General Public License, version 2
+* with the GNU Classpath Exception which is
+* available at https://www.gnu.org/software/classpath/license.html.
+*
+* SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+********************************************************************************/
+"""
+
+from qrisp.algorithms.vqe.problems.electronic_structure import *
+from qrisp.algorithms.vqe.problems.heisenberg import *
+


### PR DESCRIPTION
If one imports the VQE algorithm as in the example given here https://qrisp.eu/reference/Algorithms/vqe/VQEProblem.html it fails as it cannot import from here:
`from qrisp.algorithms.vqe.problems import *`

This can be fixed by making the problems directory a module.