### PR TITLE
Add tree qswitch

### DIFF
--- a/src/qrisp/alg_primitives/switch_case.py
+++ b/src/qrisp/alg_primitives/switch_case.py
@@ -16,12 +16,14 @@
 ********************************************************************************/
 """
 
-from qrisp.core import QuantumArray
+from qrisp.core import QuantumArray, QuantumVariable, x
 from qrisp.qtypes import QuantumBool
 from qrisp.environments import conjugate, control
 from qrisp.alg_primitives import demux
 from qrisp.core.gate_application_functions import mcx
-from qrisp.jasp import check_for_tracing_mode, jrange
+from qrisp.jasp import check_for_tracing_mode, jrange, q_fori_loop, q_cond
+import numpy as np
+import jax.numpy as jnp
 
 def qswitch(operand, case, case_function_list, method = "sequential"):
     """
@@ -132,6 +134,118 @@ def qswitch(operand, case, case_function_list, method = "sequential"):
         
         enable[0].flip()
         enable.delete()
+
+    elif method == "tree":
+        n = case.size
+
+        def bounce(d: int, anc, ca, oper):
+            with control(anc[d-1]):
+                x(anc[d])
+            with control(anc[d]):
+                x(anc[d+1])
+            with control(anc[d-1]):
+                with control(ca[n-1-d]):
+                    x(anc[d+1])
+
+        def down(d: int, anc, ca, oper):
+            with control(anc[d]):
+                x(ca[n-1-d])
+                with control(ca[n-1-d]):
+                    x(anc[d+1])
+                x(ca[n-1-d])
+
+        def up(d: int, anc, ca, oper):
+            with control(anc[d]):
+                with control(ca[n-1-d]):
+                    x(anc[d+1])
+
+        # Jasp mode
+        if check_for_tracing_mode():
+            xrange = jrange
+            x_fori_loop = q_fori_loop
+            def bitwise_count_diff(a, b): return jnp.bitwise_count(jnp.bitwise_xor(a, b))
+
+        # Normal mode
+        else:
+            xrange = range
+
+            def x_fori_loop(lower, upper, body_fun, init_val):
+                val = init_val
+                for i in range(lower, upper):
+                    val = body_fun(i, val)
+                return val
+
+            def bitwise_count_diff(a, b): return np.bitwise_count(np.bitwise_xor(a, b))
+
+        # Function mode
+        if callable(case_function_list):
+            def leaf(d: int, anc, ca, oper, i):
+                with control(anc[d+1]):
+                    case_function_list(i, oper)
+                with control(anc[d]):
+                    x(anc[d+1])
+                with control(anc[d+1]):
+                    case_function_list(i+1, oper)
+
+        # List mode
+        elif isinstance(case_function_list, list):
+            if check_for_tracing_mode():
+                def leaf(d: int, anc, ca, oper, i):
+                    def apply_leaf(A, B):
+                        with control(anc[d+1]):
+                            A(oper)
+                        with control(anc[d]):
+                            x(anc[d+1])
+                        with control(anc[d+1]):
+                            B(oper)
+                    for j in range(0, len(case_function_list), 2):
+                        q_cond(j == i, apply_leaf, lambda a,
+                               b: None, case_function_list[j], case_function_list[j+1])
+
+            else:
+                def leaf(d: int, anc, ca, oper, i):
+                    with control(anc[d+1]):
+                        case_function_list[i](oper)
+                    with control(anc[d]):
+                        x(anc[d+1])
+                    with control(anc[d+1]):
+                        case_function_list[i+1](oper)
+
+        else:
+            raise TypeError("Argument 'case_fun' must be a list or a callable(i, x)")
+
+        def body_fun(pos, val):
+            anc, ca, oper = val
+
+            # Apply leaf
+            leaf(n-1, anc, ca, oper, 2*pos)
+
+            # Jump to next leaf
+            q = bitwise_count_diff(pos, pos+1)
+            for j in xrange(0, q-1, 1):
+                up(n - j - 1, anc, ca, oper)
+            bounce(n - q, anc, ca, oper)
+            for j in xrange(0, q-1, 1):
+                down(n - (q-1) + j, anc, ca, oper)
+
+            return anc, ca, oper
+
+        anc = QuantumVariable(n+1)
+        x(anc[0])
+
+        # Go to first node
+        for j in xrange(0, n, 1):
+            down(j, anc, case, operand)
+
+        # Perform leafs and jumps
+        anc, case, operand = x_fori_loop(0, 2**(n-1) - 1, body_fun, (anc, case, operand))
+
+        # Perfrom last leaf
+        leaf(n-1, anc, case, operand, 2**n - 2)
+
+        # Go back from last node
+        for j in xrange(0, n, 1):
+            up(n - j - 1, anc, case, operand)
     
     else:
         raise Exception("Don't know compile method {method} for switch-case structure.")

--- a/tests/jax_tests/test_jasp_qswitch.py
+++ b/tests/jax_tests/test_jasp_qswitch.py
@@ -36,7 +36,26 @@ def test_jasp_qswitch_case_list():
         h(case)
 
         # Execute switch_case function
-        qswitch(operand, case, case_function_list)
+        qswitch(operand, case, case_function_list, "sequential")
+
+        return operand
+    
+    meas_res = main()
+    # {2.0: 0.25, 3.0: 0.25, 4.0: 0.25, 5.0: 0.25}
+    
+    for i in [2,3,4,5]:
+        assert np.round(meas_res[i],2) == 0.25
+
+    @terminal_sampling
+    def main():
+        # Create operand and case variable
+        operand = QuantumFloat(4)
+        operand[:] = 1
+        case = QuantumFloat(2)
+        h(case)
+
+        # Execute switch_case function
+        qswitch(operand, case, case_function_list, "tree")
 
         return operand
     
@@ -71,7 +90,26 @@ def test_jasp_qswitch_case_function():
         h(case)
 
         # Execute switch_case function
-        qswitch(operand, case, case_function)
+        qswitch(operand, case, case_function, "sequential")
+
+        return operand
+    
+    meas_res = main()
+    # {2.0: 0.25, 3.0: 0.25, 4.0: 0.25, 5.0: 0.25}
+    
+    for i in [2,3,4,5]:
+        assert np.round(meas_res[i],2) == 0.25
+
+    @terminal_sampling
+    def main():
+        # Create operand and case variable
+        operand = QuantumFloat(4)
+        operand[:] = 1
+        case = QuantumFloat(2)
+        h(case)
+
+        # Execute switch_case function
+        qswitch(operand, case, case_function, "tree")
 
         return operand
     

--- a/tests/test_qswitch.py
+++ b/tests/test_qswitch.py
@@ -17,7 +17,7 @@
 """
 
 from qrisp import inpl_mult, h, QuantumFloat, qswitch, multi_measurement
-def test_qswitch():
+def test_qswitch_case_list():
 
     # Some sample case functions
     def f0(x): x += 1
@@ -47,6 +47,75 @@ def test_qswitch():
     
     # Execute switch_case function
     qswitch(operand, case, case_function_list, method = "parallel")
+    
+    # Simulate
+    assert multi_measurement([case, operand]) == {(0, 2): 0.25, (1, 3): 0.25, (2, 1): 0.25, (3, 1): 0.125, (3, 3): 0.125}
+    # Yields {(0, 2): 0.25, (1, 3): 0.25, (2, 1): 0.25, (3, 1): 0.125, (3, 3): 0.125}
+
+    # Create operand and case variable
+    operand = QuantumFloat(4)
+    operand[:] = 1
+    case = QuantumFloat(2)
+    h(case)
+    
+    # Execute switch_case function
+    qswitch(operand, case, case_function_list, method = "tree")
+    
+    # Simulate
+    assert multi_measurement([case, operand]) == {(0, 2): 0.25, (1, 3): 0.25, (2, 1): 0.25, (3, 1): 0.125, (3, 3): 0.125}
+    # Yields {(0, 2): 0.25, (1, 3): 0.25, (2, 1): 0.25, (3, 1): 0.125, (3, 3): 0.125}
+
+def test_qswitch_case_function():
+
+    # Some sample case functions
+    def f0(x): x += 1
+    def f1(x): inpl_mult(x, 3, treat_overflow = False)
+    def f2(x): pass
+    def f3(x): h(x[1])
+    def case_function_list(i, x):
+        if i == 0:
+            f0(x)
+        if i == 1:
+            f1(x)
+        if i == 2:
+            f2(x)
+        if i == 3:
+            f3(x)
+    
+    # Create operand and case variable
+    operand = QuantumFloat(4)
+    operand[:] = 1
+    case = QuantumFloat(2)
+    h(case)
+    
+    # Execute switch_case function
+    qswitch(operand, case, case_function_list)
+    
+    # Simulate
+    assert multi_measurement([case, operand]) == {(0, 2): 0.25, (1, 3): 0.25, (2, 1): 0.25, (3, 1): 0.125, (3, 3): 0.125}
+    # Yields {(0, 2): 0.25, (1, 3): 0.25, (2, 1): 0.25, (3, 1): 0.125, (3, 3): 0.125}
+    
+    # Create operand and case variable
+    operand = QuantumFloat(4)
+    operand[:] = 1
+    case = QuantumFloat(2)
+    h(case)
+    
+    # Execute switch_case function
+    qswitch(operand, case, case_function_list, method = "parallel")
+    
+    # Simulate
+    assert multi_measurement([case, operand]) == {(0, 2): 0.25, (1, 3): 0.25, (2, 1): 0.25, (3, 1): 0.125, (3, 3): 0.125}
+    # Yields {(0, 2): 0.25, (1, 3): 0.25, (2, 1): 0.25, (3, 1): 0.125, (3, 3): 0.125}
+
+    # Create operand and case variable
+    operand = QuantumFloat(4)
+    operand[:] = 1
+    case = QuantumFloat(2)
+    h(case)
+    
+    # Execute switch_case function
+    qswitch(operand, case, case_function_list, method = "tree")
     
     # Simulate
     assert multi_measurement([case, operand]) == {(0, 2): 0.25, (1, 3): 0.25, (2, 1): 0.25, (3, 1): 0.125, (3, 3): 0.125}


### PR DESCRIPTION
Adds an additional implementation of the `qswitch` based on [arXiv:2407.17966v1](https://arxiv.org/pdf/2407.17966v1). The implementation works with jasp or without and with a function or list.