### PR TITLE
Operators upgrades

### DIFF
--- a/src/qrisp/operators/qubit/jasp_measurement.py
+++ b/src/qrisp/operators/qubit/jasp_measurement.py
@@ -75,8 +75,14 @@ def get_jasp_measurement(
         # the ladder terms either need to completely agree or completely disagree
         for group in temp_groups:
             groups.extend(group.group_up(lambda a, b : a.ladders_agree(b) or not a.ladders_intersect(b)))
-    else:
-        groups = hamiltonian.group_up(lambda a, b: a.commute(b))    
+            
+    elif diagonalisation_method=="commuting":
+        temp_groups = hamiltonian.group_up(lambda a, b: a.commute_pauli(b))
+        groups = []
+        # In order for the change of basis function (below) to work properly,
+        # the ladder terms either need to completely agree or completely disagree
+        for group in temp_groups:
+            groups.extend(group.group_up(lambda a, b : a.ladders_agree(b) or not a.ladders_intersect(b)))
 
     samples = []
     meas_ops = []

--- a/src/qrisp/operators/qubit/jasp_measurement.py
+++ b/src/qrisp/operators/qubit/jasp_measurement.py
@@ -85,7 +85,7 @@ def get_jasp_measurement(
             groups.extend(group.group_up(lambda a, b : a.ladders_agree(b) or not a.ladders_intersect(b)))
 
     else:
-        raise Exception("Unknown diagonalisation method: {method}.")
+        raise Exception(f"Unknown diagonalisation method: {diagonalisation_method}.")
 
     samples = []
     meas_ops = []

--- a/src/qrisp/operators/qubit/jasp_measurement.py
+++ b/src/qrisp/operators/qubit/jasp_measurement.py
@@ -75,7 +75,7 @@ def get_jasp_measurement(
         # the ladder terms either need to completely agree or completely disagree
         for group in temp_groups:
             groups.extend(group.group_up(lambda a, b : a.ladders_agree(b) or not a.ladders_intersect(b)))
-            
+
     elif diagonalisation_method=="commuting":
         temp_groups = hamiltonian.group_up(lambda a, b: a.commute_pauli(b))
         groups = []
@@ -83,6 +83,9 @@ def get_jasp_measurement(
         # the ladder terms either need to completely agree or completely disagree
         for group in temp_groups:
             groups.extend(group.group_up(lambda a, b : a.ladders_agree(b) or not a.ladders_intersect(b)))
+
+    else:
+        raise Exception("Unknown diagonalisation method: {method}.")
 
     samples = []
     meas_ops = []

--- a/src/qrisp/operators/qubit/measurement.py
+++ b/src/qrisp/operators/qubit/measurement.py
@@ -174,7 +174,7 @@ class QubitOperatorMeasurement:
                 self.groups.extend(group.group_up(lambda a, b : a.ladders_agree(b) or not a.ladders_intersect(b)))
                 
         else:
-            raise Exception("Unknown diagonalisation method: {method}.")
+            raise Exception(f"Unknown diagonalisation method: {diagonalisation_method}.")
     
         self.stds = []
         self.change_of_basis_gates = []

--- a/src/qrisp/operators/qubit/measurement.py
+++ b/src/qrisp/operators/qubit/measurement.py
@@ -165,7 +165,12 @@ class QubitOperatorMeasurement:
             for group in temp_groups:
                 self.groups.extend(group.group_up(lambda a, b : a.ladders_agree(b) or not a.ladders_intersect(b)))
         else:
-            self.groups = hamiltonian.group_up(lambda a, b: a.commute(b))
+            temp_groups = hamiltonian.group_up(lambda a, b: a.commute_pauli(b))
+            self.groups = []
+            # In order for the change of basis function (below) to work properly,
+            # the ladder terms either need to completely agree or completely disagree
+            for group in temp_groups:
+                self.groups.extend(group.group_up(lambda a, b : a.ladders_agree(b) or not a.ladders_intersect(b)))
         
         self.stds = []
         self.change_of_basis_gates = []

--- a/src/qrisp/operators/qubit/measurement.py
+++ b/src/qrisp/operators/qubit/measurement.py
@@ -164,14 +164,18 @@ class QubitOperatorMeasurement:
             # the ladder terms either need to completely agree or completely disagree
             for group in temp_groups:
                 self.groups.extend(group.group_up(lambda a, b : a.ladders_agree(b) or not a.ladders_intersect(b)))
-        else:
+
+        elif diagonalisation_method=="commuting":
             temp_groups = hamiltonian.group_up(lambda a, b: a.commute_pauli(b))
             self.groups = []
             # In order for the change of basis function (below) to work properly,
             # the ladder terms either need to completely agree or completely disagree
             for group in temp_groups:
                 self.groups.extend(group.group_up(lambda a, b : a.ladders_agree(b) or not a.ladders_intersect(b)))
-        
+                
+        else:
+            raise Exception("Unknown diagonalisation method: {method}.")
+    
         self.stds = []
         self.change_of_basis_gates = []
         self.measurement_operators = []

--- a/src/qrisp/operators/qubit/qubit_term.py
+++ b/src/qrisp/operators/qubit/qubit_term.py
@@ -562,6 +562,33 @@ class QubitTerm:
                 return len(self.commutator(other).terms_dict) == 0
                 
         return sign_flip == 1
+    
+    def commute_pauli(self, other):
+        """
+        Checks if the Pauli factors of two QubitTerms commute and the ladder factors commute qubit-wise.
+
+        """
+        a = self.factor_dict
+        b = other.factor_dict
+
+        keys = set()
+        keys.update(set(a.keys()))
+        keys.update(set(b.keys()))
+
+        sign_flip = 1
+        
+        for key in keys:
+            factor_a = PAULI_TABLE[a.get(key, "I"), b.get(key, "I")]
+            factor_b = PAULI_TABLE[b.get(key, "I"), a.get(key, "I")]
+
+            if not factor_a == factor_b:
+                if factor_a[0] in ["I","X","Y","Z"] and factor_b[0] in ["I","X","Y","Z"]:
+                    if factor_a[1] == -factor_b[1]:
+                        sign_flip *= -1
+                else:
+                    return False
+                
+        return sign_flip == 1
 
     def commute_qw(self, other):
         """

--- a/tests/jax_tests/test_jasp_hamiltonian_simulation.py
+++ b/tests/jax_tests/test_jasp_hamiltonian_simulation.py
@@ -22,7 +22,6 @@ from qrisp.jasp import terminal_sampling
 
 def test_jasp_hamiltonian_simulation():
     
-    
     def test_hamiltonian(H):
         
         def main():
@@ -48,3 +47,38 @@ def test_jasp_hamiltonian_simulation():
     test_hamiltonian(H)
     H = a(0)*c(2)*a(3)*a(4) + c(0)*a(1)*a(3)*c(2)
     test_hamiltonian(H)
+
+
+from pyscf import gto
+from qrisp import *
+from qrisp.operators import FermionicOperator
+import numpy as np
+
+def test_jasp_qubit_hamiltonian_simulation():
+
+    # Finding the gound state energy of the Hydrogen molecule with QPE
+    @terminal_sampling
+    def main():
+
+        mol = gto.M(
+        atom = '''H 0 0 0; H 0 0 0.74''',
+        basis = 'sto-3g')
+
+        H = FermionicOperator.from_pyscf(mol).to_qubit_operator()
+
+        U = H.trotterization(forward_evolution=False, method='commuting')
+
+        qv = QuantumFloat(H.find_minimal_qubit_amount())
+        [x(qv[i]) for i in range(2)] # Prepare Hartree-Fock state, H2 molecule has 2 electrons
+
+        qpe_res = QPE(qv,U,precision=6,kwargs={"steps":3})
+        return qpe_res
+
+    meas_res = main()
+    
+    phi = list(meas_res.keys())[0]
+    E = 2*np.pi*(phi-1)
+    success_probability = meas_res[phi]
+
+    assert np.abs(E-(-1.865)) < 1e-3
+    assert success_probability > 0.9

--- a/tests/jax_tests/test_jasp_hamiltonian_simulation.py
+++ b/tests/jax_tests/test_jasp_hamiltonian_simulation.py
@@ -54,7 +54,7 @@ from qrisp import *
 from qrisp.operators import FermionicOperator
 import numpy as np
 
-def test_jasp_qubit_hamiltonian_simulation():
+def test_jasp_hamiltonian_simulation_H2():
 
     # Finding the gound state energy of the Hydrogen molecule with QPE
     @terminal_sampling

--- a/tests/operator_tests/test_measurement_method.py
+++ b/tests/operator_tests/test_measurement_method.py
@@ -85,6 +85,16 @@ def test_measurement_method(sample_size=100, seed=42, exhaustive = False):
 
     h(qv[0])
     
+
+    # Perform test for issue #165
+    qv = QuantumVariable(4)
+    x(qv[0])
+    x(qv[1])
+
+    H = A(0)*C(1)*C(2)*A(3) + P1(0)*P1(2) + P1(1)*P1(3)
+
+    assert H.get_measurement(qv,diagonalisation_method='commuting') == 0
+    assert H.get_measurement(qv,diagonalisation_method='commuting_qw') == 0
     
     
     


### PR DESCRIPTION
Fixes issue #165

Changed measurement and trotterization for QubitOperators such that for (diagonalisation_)method 'commuting', only Paulis are allowed to be (just) commuting. Ladders must commute qubit_wise.