### PR TITLE
Bugfix switch_case.py

### DIFF
--- a/src/qrisp/alg_primitives/switch_case.py
+++ b/src/qrisp/alg_primitives/switch_case.py
@@ -82,7 +82,7 @@ def qswitch(operand, case, case_function_list, method = "sequential"):
             def conjugator(case, control_qbl):
                 mcx(case,
                     control_qbl,
-                    method='baluaca',
+                    method='balauca',
                     ctrl_state=i)
 
             for i in range(len(case_function_list)):


### PR DESCRIPTION
typo in mcx reference: "baluaca" -> "balauca"