### PR TITLE
Qswitch tree case number

### DIFF
--- a/tests/jax_tests/test_jasp_qswitch.py
+++ b/tests/jax_tests/test_jasp_qswitch.py
@@ -118,7 +118,110 @@ def test_jasp_qswitch_case_function():
     
     for i in [2,3,4,5]:
         assert np.round(meas_res[i],2) == 0.25
+
+
+def test_jasp_qswitch_case_list_cutoff():
+    from qrisp import QuantumFloat, h, qswitch, terminal_sampling
+    import numpy as np
     
+    # Some sample case functions
+    def f0(x): x += 1
+    def f1(x): x += 2
+    def f2(x): x += 3
+    case_function_list = [f0, f1, f2]
+    
+    @terminal_sampling
+    def main():
+        # Create operand and case variable
+        operand = QuantumFloat(4)
+        operand[:] = 1
+        case = QuantumFloat(2)
+        h(case)
+
+        # Execute switch_case function
+        qswitch(operand, case, case_function_list, "sequential")
+
+        return operand
+    
+    meas_res = main()
+    # {2.0: 0.25, 3.0: 0.25, 4.0: 0.25, 1.0: 0.25}
+    
+    for i in [2,3,4,1]:
+        assert np.round(meas_res[i],2) == 0.25
+
+    @terminal_sampling
+    def main():
+        # Create operand and case variable
+        operand = QuantumFloat(4)
+        operand[:] = 1
+        case = QuantumFloat(2)
+        h(case)
+
+        # Execute switch_case function
+        qswitch(operand, case, case_function_list, "tree")
+
+        return operand
+    
+    meas_res = main()
+    # {2.0: 0.25, 3.0: 0.25, 4.0: 0.25, 1.0: 0.25}
+    
+    for i in [2,3,4,1]:
+        assert np.round(meas_res[i],2) == 0.25
+    
+
+def test_jasp_qswitch_case_function_cutoff():
+    from qrisp import QuantumFloat, h, qswitch, terminal_sampling, control
+    import numpy as np
+    
+    # Some sample case function 
+    def case_function(i, x):
+        with control(i == 0):
+            x += 1
+        with control(i == 1):
+            x += 2
+        with control(i == 2):
+            x += 3
+        with control(i == 3):
+            x += 4
+    
+    @terminal_sampling
+    def main():
+        # Create operand and case variable
+        operand = QuantumFloat(4)
+        operand[:] = 1
+        case = QuantumFloat(2)
+        h(case)
+
+        # Execute switch_case function
+        qswitch(operand, case, case_function, "sequential", number=3)
+
+        return operand
+    
+    meas_res = main()
+    # {2.0: 0.25, 3.0: 0.25, 4.0: 0.25, 1.0: 0.25}
+    
+    for i in [2,3,4,1]:
+        assert np.round(meas_res[i],2) == 0.25
+
+    @terminal_sampling
+    def main():
+        # Create operand and case variable
+        operand = QuantumFloat(4)
+        operand[:] = 1
+        case = QuantumFloat(2)
+        h(case)
+
+        # Execute switch_case function
+        qswitch(operand, case, case_function, "tree", number=3)
+
+        return operand
+    
+    meas_res = main()
+    # {2.0: 0.25, 3.0: 0.25, 4.0: 0.25, 1.0: 0.25}
+    
+    for i in [2,3,4,1]:
+        assert np.round(meas_res[i],2) == 0.25
+
 
 def test_jasp_qswitch_case_hamiltonian_simulation():
     from qrisp import QuantumFloat, h, qswitch, terminal_sampling

--- a/tests/jax_tests/test_jasp_qswitch.py
+++ b/tests/jax_tests/test_jasp_qswitch.py
@@ -193,7 +193,7 @@ def test_jasp_qswitch_case_function_cutoff():
         h(case)
 
         # Execute switch_case function
-        qswitch(operand, case, case_function, "sequential", number=3)
+        qswitch(operand, case, case_function, "sequential", case_amount=3)
 
         return operand
     
@@ -212,7 +212,7 @@ def test_jasp_qswitch_case_function_cutoff():
         h(case)
 
         # Execute switch_case function
-        qswitch(operand, case, case_function, "tree", number=3)
+        qswitch(operand, case, case_function, "tree", case_amount=3)
 
         return operand
     

--- a/tests/test_qswitch.py
+++ b/tests/test_qswitch.py
@@ -137,11 +137,11 @@ def test_qswitch_case_list_cutoff():
          lambda arg: case_function_list(4,arg)]
 
     # Execute switch_case function
-    for mode, r in zip([1,4, "auto"], [1,4,5]):
+    for mode, r in zip([1,4, None], [1,4,5]):
         operand = QuantumFloat(4)
         case = QuantumFloat(4)
         h(case)
-        qswitch(operand, case, l, method = "tree", number=mode)
+        qswitch(operand, case, l, method = "tree", case_amount=mode)
         res = multi_measurement([case, operand])
 
         for i in range(16):
@@ -162,7 +162,7 @@ def test_qswitch_case_function_cutoff():
         operand = QuantumFloat(4)
         case = QuantumFloat(4)
         h(case)
-        qswitch(operand, case, case_function_list, method = "tree", number=r)
+        qswitch(operand, case, case_function_list, method = "tree", case_amount=r)
         res = multi_measurement([case, operand])
 
         for i in range(16):

--- a/tests/test_qswitch.py
+++ b/tests/test_qswitch.py
@@ -16,7 +16,7 @@
 ********************************************************************************
 """
 
-from qrisp import inpl_mult, h, QuantumFloat, qswitch, multi_measurement
+from qrisp import inpl_mult, h, QuantumFloat, qswitch, multi_measurement, x
 def test_qswitch_case_list():
 
     # Some sample case functions
@@ -120,3 +120,53 @@ def test_qswitch_case_function():
     # Simulate
     assert multi_measurement([case, operand]) == {(0, 2): 0.25, (1, 3): 0.25, (2, 1): 0.25, (3, 1): 0.125, (3, 3): 0.125}
     # Yields {(0, 2): 0.25, (1, 3): 0.25, (2, 1): 0.25, (3, 1): 0.125, (3, 3): 0.125}
+
+
+
+def test_qswitch_case_list_cutoff(): 
+        
+    def case_function_list(i, arg):
+        for j, b in enumerate(bin(i)[:1:-1]):
+            if b== "1":
+                x(arg[j])
+
+    l = [lambda arg: case_function_list(0,arg),
+         lambda arg: case_function_list(1,arg),
+         lambda arg: case_function_list(2,arg),
+         lambda arg: case_function_list(3,arg),
+         lambda arg: case_function_list(4,arg)]
+
+    # Execute switch_case function
+    for mode, r in zip([1,4, "auto"], [1,4,5]):
+        operand = QuantumFloat(4)
+        case = QuantumFloat(4)
+        h(case)
+        qswitch(operand, case, l, method = "tree", number=mode)
+        res = multi_measurement([case, operand])
+
+        for i in range(16):
+            if r <= i:
+                assert res[(i,0)] == 0.0625
+            else:
+                assert res[(i,i)] == 0.0625
+
+def test_qswitch_case_function_cutoff(): 
+        
+    def case_function_list(i, arg):
+        for j, b in enumerate(bin(i)[:1:-1]):
+            if b== "1":
+                x(arg[j])
+
+    # Execute switch_case function
+    for r in [4,7,8]:
+        operand = QuantumFloat(4)
+        case = QuantumFloat(4)
+        h(case)
+        qswitch(operand, case, case_function_list, method = "tree", number=r)
+        res = multi_measurement([case, operand])
+
+        for i in range(16):
+            if r <= i:
+                assert res[(i,0)] == 0.0625
+            else:
+                assert res[(i,i)] == 0.0625


### PR DESCRIPTION
Adds an argument to the `qswitch` to specify the number of cases. Defaults to `None` to automatically set the number of cases. In the case where the case number is not a power of two,  the tree traversal properly terminates saving resources compared to a full tree traversal.