### PR TITLE
Batched backend

### DIFF
--- a/documentation/source/reference/Backend Interface/BatchedBackend.rst
+++ b/documentation/source/reference/Backend Interface/BatchedBackend.rst
@@ -1,0 +1,9 @@
+.. _BatchedBackend:
+
+BatchedBackend
+==============
+
+.. currentmodule:: qrisp.interface
+
+.. autoclass:: BatchedBackend
+

--- a/documentation/source/reference/Backend Interface/index.rst
+++ b/documentation/source/reference/Backend Interface/index.rst
@@ -8,6 +8,7 @@ Backend Interface
    BackendServer
    BackendClient
    VirtualBackend
+   BatchedBackend
    DockerSimulators
    QiskitBackend
    IQMBackend

--- a/documentation/source/reference/Utilities.rst
+++ b/documentation/source/reference/Utilities.rst
@@ -8,6 +8,7 @@ Utilities
    :toctree: generated/
 
    multi_measurement
+   batched_measurement
    gate_wrap
    custom_control
    lifted

--- a/documentation/source/reference/generated/qrisp.batched_measurement.rst
+++ b/documentation/source/reference/generated/qrisp.batched_measurement.rst
@@ -1,0 +1,6 @@
+﻿qrisp.batched\_measurement
+==========================
+
+.. currentmodule:: qrisp
+
+.. autofunction:: batched_measurement

--- a/src/qrisp/circuit/compilation_acceleration.py
+++ b/src/qrisp/circuit/compilation_acceleration.py
@@ -17,6 +17,7 @@
 """
 
 import numpy as np
+import threading
 
 from qrisp.circuit.quantum_circuit import QuantumCircuit
 
@@ -28,13 +29,15 @@ class CompilationAccelerator:
 
     def __enter__(self):
 
+        
         self.original_xla_mode = QuantumCircuit.xla_mode
 
-        QuantumCircuit.xla_mode = self.xla_mode
+        if threading.current_thread() is threading.main_thread():
+            QuantumCircuit.xla_mode = self.xla_mode
 
     def __exit__(self, exception_type, exception_value, traceback):
-
-        QuantumCircuit.xla_mode = self.original_xla_mode
+        if threading.current_thread() is threading.main_thread():
+            QuantumCircuit.xla_mode = self.original_xla_mode
 
 
 fast_append = CompilationAccelerator

--- a/src/qrisp/circuit/quantum_circuit.py
+++ b/src/qrisp/circuit/quantum_circuit.py
@@ -206,7 +206,6 @@ class QuantumCircuit:
     qubit_index_counter = np.zeros(1, dtype=int)
     clbit_index_counter = np.zeros(1, dtype=int)
     xla_mode = 0
-    lock_acceleration = False
 
     def __init__(self, num_qubits=0, num_clbits=0, name=None):
         object.__setattr__(self, "data", [])

--- a/src/qrisp/circuit/quantum_circuit.py
+++ b/src/qrisp/circuit/quantum_circuit.py
@@ -206,6 +206,7 @@ class QuantumCircuit:
     qubit_index_counter = np.zeros(1, dtype=int)
     clbit_index_counter = np.zeros(1, dtype=int)
     xla_mode = 0
+    lock_acceleration = False
 
     def __init__(self, num_qubits=0, num_clbits=0, name=None):
         object.__setattr__(self, "data", [])

--- a/src/qrisp/interface/__init__.py
+++ b/src/qrisp/interface/__init__.py
@@ -18,6 +18,8 @@
 
 from qrisp.interface.qunicorn import *
 from qrisp.interface.virtual_backend import *
+from qrisp.interface.batched_backend import *
 from qrisp.interface.converter import *
 from qrisp.interface.docker_backends import *
 from qrisp.interface.provider_backends import *
+

--- a/src/qrisp/interface/batched_backend.py
+++ b/src/qrisp/interface/batched_backend.py
@@ -1,0 +1,166 @@
+"""
+********************************************************************************
+* Copyright (c) 2025 the Qrisp authors
+*
+* This program and the accompanying materials are made available under the
+* terms of the Eclipse Public License 2.0 which is available at
+* http://www.eclipse.org/legal/epl-2.0.
+*
+* This Source Code may also be made available under the following Secondary
+* Licenses when the conditions for such availability set forth in the Eclipse
+* Public License, v. 2.0 are satisfied: GNU General Public License, version 2
+* with the GNU Classpath Exception which is
+* available at https://www.gnu.org/software/classpath/license.html.
+*
+* SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+********************************************************************************
+"""
+
+from qrisp.interface import VirtualBackend
+import time
+
+class BatchedBackend(VirtualBackend):
+    """
+    This class tackles the problem that many physical backends have a high-overhead
+    regarding individual circuit execution. This overhead typically comes
+    from finite network latency, authentication procedures, compilation steps etc.
+    Typically this overhead is remedied through supporting the execution of 
+    batches of circuits, which however doesn't really fit that well into the Qrisp
+    programming model, which shields the user from handling individual circuits
+    and automatically decodes the measurement results into human readable labels.
+    
+    In order to bridge these worlds and still allow automatic decoding, the
+    ``BatchedBackend`` allows Qrisp users to evaluate measurements from a 
+    multi-threading perspective. The idea is here that the circuit
+    batch is collected through several threads, which each execute Qrisp code
+    until a individual backend call is required. This backend call is then saved
+    until the batch is complete. The batch can then be sent through the ``.dispatch``
+    method, which resumes each thread to execute the post-processing logic.
+    
+    
+    Parameters
+    ----------
+    batch_run_func : function
+        A function that recieves a list of tuples in the form 
+        list[tuple[QuantumCircuit, int]], which represents the quantum circuits
+        and the corresponding shots to execute on the backend. It should return
+        a list of dictionaries, where each dictionary corresponds to the measurement
+        results of the appropriate backend call.
+    
+    Examples
+    --------
+    
+    We set up a BatchedBackend, which sequentially executes the QuantumCircuits
+    on the Qrisp simulator.
+    
+    ::
+        from qrisp import *
+        from qrisp.interface import BatchedBackend
+        
+        def run_func_batch(batch):
+            \"\"\"
+            Parameters
+            ----------
+            batch : list[tuple[QuantumCircuit, int]]
+                The circuit and shot batch indicating the backend queries.
+        
+            Returns
+            -------
+            results : list[dict[string, int]]
+                The list of results.
+        
+            \"\"\"
+            
+            results = []
+            for i in range(len(batch)):
+                qc = batch[i][0]
+                shots = batch[i][1]
+                results.append(qc.run(shots = shots))
+                
+            return results
+        
+        # Set up batched backend
+        bb = BatchedBackend(run_func_batch)
+    
+    Create some backend calls
+    
+    ::
+        
+        a = QuantumFloat(4)
+        b = QuantumFloat(3)
+        a[:] = 1
+        b[:] = 2
+        c = a + b
+    
+        d = QuantumFloat(4)
+        e = QuantumFloat(3)
+        d[:] = 2
+        e[:] = 3
+        f = d + e
+
+    Create threads
+    
+    ::
+        
+        import threading
+
+        results = []
+        def eval_measurement(qv):
+            results.append(H.expectation_value(lambda : qv, backend = bb)())
+
+        thread_0 = threading.Thread(target = eval_measurement, args = (c,))
+        thread_1 = threading.Thread(target = eval_measurement, args = (f,))
+        
+    Start the threads and subsequently dispatch the batch.
+    
+    ::
+        
+        # Start the threads
+        thread_0.start()
+        thread_1.start()
+
+        # Call the dispatch routine
+        # The min_calls keyword will make it wait 
+        # until the batch has a size of 2
+        bb.dispatch(min_calls = 2)
+
+        # Wait for the threads to join
+        thread_0.join()
+        thread_1.join()
+    
+        # Inspect the results
+        print(results)
+    
+    """
+    
+    def __init__(self, batch_run_func):
+        
+        self.batch_run_func = batch_run_func
+        self.batch = []
+        self.results_available = False
+        self.results = {}
+        
+    def run(self, qc, shots):
+        
+        self.batch.append((qc, shots))
+        
+        while not self.results_available:
+            time.sleep(0.01)
+        result = self.results[id(qc)]
+        del self.results[id(qc)]
+        return result
+
+    def dispatch(self, min_calls = 0):
+        
+        while len(self.batch) < min_calls:
+            time.sleep(0.01)
+        
+        run_func_results = self.batch_run_func(self.batch)
+        self.results = {id(self.batch[i][0]) : run_func_results[i] for i in range(len(self.batch))}
+        self.batch = []
+        self.results_available = True
+        
+        while len(self.results):
+            time.sleep(0.01)
+        
+        self.results_available = False

--- a/src/qrisp/interface/batched_backend.py
+++ b/src/qrisp/interface/batched_backend.py
@@ -54,22 +54,20 @@ class BatchedBackend(VirtualBackend):
     on the Qrisp simulator.
     
     ::
+        
         from qrisp import *
         from qrisp.interface import BatchedBackend
         
         def run_func_batch(batch):
-            \"\"\"
-            Parameters
-            ----------
-            batch : list[tuple[QuantumCircuit, int]]
-                The circuit and shot batch indicating the backend queries.
+            # Parameters
+            # ----------
+            # batch : list[tuple[QuantumCircuit, int]]
+            #     The circuit and shot batch indicating the backend queries.
         
-            Returns
-            -------
-            results : list[dict[string, int]]
-                The list of results.
-        
-            \"\"\"
+            # Returns
+            # -------
+            # results : list[dict[string, int]]
+            #     The list of results.
             
             results = []
             for i in range(len(batch)):

--- a/src/qrisp/interface/batched_backend.py
+++ b/src/qrisp/interface/batched_backend.py
@@ -104,7 +104,7 @@ class BatchedBackend(VirtualBackend):
 
         results = []
         def eval_measurement(qv):
-            results.append(H.expectation_value(lambda : qv, backend = bb)())
+            results.append(qv.get_measurement(backend = bb))
 
         thread_0 = threading.Thread(target = eval_measurement, args = (c,))
         thread_1 = threading.Thread(target = eval_measurement, args = (f,))

--- a/src/qrisp/interface/batched_backend.py
+++ b/src/qrisp/interface/batched_backend.py
@@ -137,6 +137,11 @@ class BatchedBackend(VirtualBackend):
     
         # Inspect the results
         print(results)
+
+    This is automated by the :meth:`batched_measurement <qrisp.batched_measurement>`:
+
+    >>> batched_measurement([c,f], batched_backend=bb)
+    [{3: 1.0}, {5: 1.0}]
     
     """
     

--- a/src/qrisp/misc/utility.py
+++ b/src/qrisp/misc/utility.py
@@ -2280,13 +2280,13 @@ def batched_measurement(variables, batched_backend, shots=None):
 
     import threading
 
-    results = []
-    def eval_measurement(qv):
-        results.append(qv.get_measurement(backend = batched_backend, shots = shots))
+    results = [0]*len(variables)
+    def eval_measurement(qv, i):
+        results[i] = qv.get_measurement(backend = batched_backend, shots = shots)
 
     threads = []
-    for var in variables:
-        thread = threading.Thread(target = eval_measurement, args = (var,))
+    for i, var in enumerate(variables):
+        thread = threading.Thread(target = eval_measurement, args = (var, i, ))
         threads.append(thread)
 
     # Start the threads

--- a/src/qrisp/misc/utility.py
+++ b/src/qrisp/misc/utility.py
@@ -2212,7 +2212,7 @@ def inpl_adder_test(inpl_adder):
 
 def batched_measurement(variables, batched_backend, shots=None):
     """
-    This functions facilitates the measurement of multiple QuantumVariables with a BatchedBackend.
+    This functions facilitates the measurement of multiple :ref:`QuantumVariables <QuantumVariable>` with a :ref:`BatchedBackend`.
 
     Parameters
     ----------
@@ -2227,6 +2227,54 @@ def batched_measurement(variables, batched_backend, shots=None):
     -------
     results : list[dict]
         The list of results.
+
+    Examples
+    --------
+
+    We set up a BatchedBackend, which sequentially executes the QuantumCircuits
+    on the Qrisp simulator.
+
+    ::
+
+        from qrisp import *
+        from qrisp.interface import BatchedBackend
+
+        def run_func_batch(batch):
+            # Parameters
+            # ----------
+            # batch : list[tuple[QuantumCircuit, int]]
+            #     The circuit and shot batch indicating the backend queries.
+
+            # Returns
+            # -------
+            # results : list[dict[string, int]]
+            #     The list of results.
+
+            results = []
+            for i in range(len(batch)):
+                qc = batch[i][0]
+                shots = batch[i][1]
+            results.append(qc.run(shots = shots))
+
+            return results
+
+        # Set up batched backend
+        bb = BatchedBackend(run_func_batch)
+
+        a = QuantumFloat(4)
+        b = QuantumFloat(3)
+        a[:] = 1
+        b[:] = 2
+        c = a + b
+
+        d = QuantumFloat(4)
+        e = QuantumFloat(3)
+        d[:] = 2
+        e[:] = 3
+        f = d + e
+
+        batched_measurement([c,f], batched_backend=bb)
+        # Yields: [{3: 1.0}, {5: 1.0}]
     
     """
 

--- a/tests/operator_tests/test_measurement_method.py
+++ b/tests/operator_tests/test_measurement_method.py
@@ -96,6 +96,45 @@ def test_measurement_method(sample_size=100, seed=42, exhaustive = False):
     assert H.get_measurement(qv,diagonalisation_method='commuting') == 0
     assert H.get_measurement(qv,diagonalisation_method='commuting_qw') == 0
     
+    # Test BatchedBackend
+    
+    def run_func_batch(batch):
+        """
+        Parameters
+        ----------
+        batch : list[tuple[QuantumCircuit, int]]
+            The circuit and shot batch indicating the backend queries.
+
+        Returns
+        -------
+        results : list[dict[string, int]]
+            The list of results.
+
+        """
+        
+        results = []
+        for i in range(len(batch)):
+            qc = batch[i][0]
+            shots = batch[i][1]
+            results.append(qc.run(shots = shots))
+            
+        return results
+
+    from qrisp.interface import BatchedBackend
+
+    d = QuantumFloat(4)
+    e = QuantumFloat(3)
+    d[:] = 2
+    e[:] = 2
+    f = d + e
+
+    H = Z(0)*Z(1)*Z(2)*Z(3) + X(0)*X(1)*X(2)*X(3)
+
+    # Set up batched backend
+    bb = BatchedBackend(run_func_batch)
+
+    ev = H.expectation_value(lambda : c, backend = bb)()
+    
     
     
     

--- a/tests/operator_tests/test_measurement_method.py
+++ b/tests/operator_tests/test_measurement_method.py
@@ -133,7 +133,7 @@ def test_measurement_method(sample_size=100, seed=42, exhaustive = False):
     # Set up batched backend
     bb = BatchedBackend(run_func_batch)
 
-    ev = H.expectation_value(lambda : c, backend = bb)()
+    ev = H.expectation_value(lambda : f, backend = bb)()
     
     
     

--- a/tests/test_batched_backend.py
+++ b/tests/test_batched_backend.py
@@ -1,0 +1,100 @@
+"""
+********************************************************************************
+* Copyright (c) 2025 the Qrisp authors
+*
+* This program and the accompanying materials are made available under the
+* terms of the Eclipse Public License 2.0 which is available at
+* http://www.eclipse.org/legal/epl-2.0.
+*
+* This Source Code may also be made available under the following Secondary
+* Licenses when the conditions for such availability set forth in the Eclipse
+* Public License, v. 2.0 are satisfied: GNU General Public License, version 2
+* with the GNU Classpath Exception which is
+* available at https://www.gnu.org/software/classpath/license.html.
+*
+* SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+********************************************************************************
+"""
+
+import pytest
+import time
+
+from qrisp import *
+
+def test_batched_backend():
+    
+    def run_func_batch(batch):
+        """
+        Parameters
+        ----------
+        batch : list[tuple[QuantumCircuit, int]]
+            The circuit and shot batch indicating the backend queries.
+    
+        Returns
+        -------
+        results : list[dict[string, int]]
+            The list of results.
+    
+        """
+        
+        results = []
+        for i in range(len(batch)):
+            qc = batch[i][0]
+            shots = batch[i][1]
+            results.append(qc.run(shots = shots))
+            
+        return results
+    
+    from qrisp.interface import BatchedBackend
+    # Create some backend calls        
+    a = QuantumFloat(4)
+    b = QuantumFloat(3)
+    a[:] = 1
+    b[:] = 2
+    c = a + b
+    
+    d = QuantumFloat(4)
+    e = QuantumFloat(3)
+    d[:] = 2
+    e[:] = 2
+    f = d + e
+    
+    
+    from qrisp.operators import Z
+    H = Z(0)*Z(1)*Z(2)*Z(3)
+    
+    # Set up batched backend
+    bb = BatchedBackend(run_func_batch)
+    
+    # Create threads
+    import threading
+    
+    results = []
+    def eval_measurement(qv):
+        results.append(H.expectation_value(lambda : qv, backend = bb)())
+    
+    thread_0 = threading.Thread(target = eval_measurement, args = (c,))
+    thread_1 = threading.Thread(target = eval_measurement, args = (f,))
+    
+    # Start the threads
+    thread_0.start()
+    thread_1.start()
+    
+    # Call the dispatch routine
+    # The min_calls keyword will make it wait 
+    # until the batch has a size of 2
+    bb.dispatch(min_calls = 2)
+    
+    # Wait for the threads to join
+    thread_0.join()
+    thread_1.join()
+    
+    # Inspect the results
+    assert sum(results) == 0
+    
+    
+    
+    
+    
+    
+            

--- a/tests/test_batched_backend.py
+++ b/tests/test_batched_backend.py
@@ -60,9 +60,6 @@ def test_batched_backend():
     f = d + e
     
     
-    from qrisp.operators import Z
-    H = Z(0)*Z(1)*Z(2)*Z(3)
-    
     # Set up batched backend
     bb = BatchedBackend(run_func_batch)
     
@@ -71,7 +68,7 @@ def test_batched_backend():
     
     results = []
     def eval_measurement(qv):
-        results.append(H.expectation_value(lambda : qv, backend = bb)())
+        results.append(qv.get_measurement(backend = bb))
     
     thread_0 = threading.Thread(target = eval_measurement, args = (c,))
     thread_1 = threading.Thread(target = eval_measurement, args = (f,))
@@ -90,7 +87,8 @@ def test_batched_backend():
     thread_1.join()
     
     # Inspect the results
-    assert sum(results) == 0
+    assert {3 : 1.0} in results
+    assert {4 : 1.0} in results
     
     
     


### PR DESCRIPTION
This class tackles the problem that many physical backends have a high overhead regarding individual circuit execution. This overhead typically comes from finite network latency, authentication procedures, compilation steps etc. Typically this overhead is remedied through supporting the execution of batches of circuits, which however doesn't really fit that well into the Qrisp programming model, which shields the user from handling individual circuits and automatically decodes the measurement results into human readable labels.
    
In order to bridge these worlds and still allow automatic decoding, the ``BatchedBackend`` allows Qrisp users to evaluate measurements from a multi-threading perspective. The idea is here that the circuit batch is collected through several threads, which each execute Qrisp code until a individual backend call is required. This backend call is then saved until the batch is complete. The batch can then be sent through the ``.dispatch`` method, which resumes each thread to execute the post-processing logic.

Besides these features, this PR implements batched measurement behavior for QubitOperator expectation_value measurements.

Example: 

```
def run_func_batch(batch):
    """
    Parameters
    ----------
    batch : list[tuple[QuantumCircuit, int]]
        The circuit and shot batch indicating the backend queries.

    Returns
    -------
    results : list[dict[string, int]]
        The list of results.

    """
    
    results = []
    for i in range(len(batch)):
        qc = batch[i][0]
        shots = batch[i][1]
        results.append(qc.run(shots = shots))
        
    return results

from qrisp import *
from qrisp.interface import BatchedBackend
# Create some backend calls        
a = QuantumFloat(4)
b = QuantumFloat(3)
a[:] = 1
b[:] = 2
c = a + b

d = QuantumFloat(4)
e = QuantumFloat(3)
d[:] = 2
e[:] = 2
f = d + e

# Set up batched backend
bb = BatchedBackend(run_func_batch)

# Create threads
import threading

results = []
def eval_measurement(qv):
    results.append(qv.get_measurement())

thread_0 = threading.Thread(target = eval_measurement, args = (c,))
thread_1 = threading.Thread(target = eval_measurement, args = (f,))

# Start the threads
thread_0.start()
thread_1.start()

# Call the dispatch routine
# The min_calls keyword will make it wait 
# until the batch has a size of 2
bb.dispatch(min_calls = 2)

# Wait for the threads to join
thread_0.join()
thread_1.join()

# Inspect the results
print(results)
```
