### PR TITLE
Fix QiskitRuntimeBackend

### DIFF
--- a/src/qrisp/interface/provider_backends/qiskit_backend.py
+++ b/src/qrisp/interface/provider_backends/qiskit_backend.py
@@ -176,7 +176,7 @@ class QiskitRuntimeBackend(VirtualBackend):
             qiskit_qc = transpile(qiskit_qc, backend=backend)
             # Run Circuit with the Sampler Primitive
             qiskit_result = (
-                sampler.run(qiskit_qc, shots=shots)
+                sampler.run([qiskit_qc], shots=shots)
                 .result()
                 .quasi_dists[0]
                 .binary_probabilities()

--- a/src/qrisp/interface/provider_backends/qiskit_backend.py
+++ b/src/qrisp/interface/provider_backends/qiskit_backend.py
@@ -153,7 +153,7 @@ class QiskitRuntimeBackend(VirtualBackend):
     def __init__(self, backend=None, port=8079, token=""):
         from qiskit_ibm_runtime import QiskitRuntimeService, Sampler, Session, Estimator
 
-        service = QiskitRuntimeService(channel="ibm_quantum", token=token)
+        service = QiskitRuntimeService(channel="ibm_quantum_platform", token=token)
         if backend is None:
             backend = service.least_busy()
         else:

--- a/src/qrisp/interface/provider_backends/qiskit_backend.py
+++ b/src/qrisp/interface/provider_backends/qiskit_backend.py
@@ -151,7 +151,7 @@ class QiskitRuntimeBackend(VirtualBackend):
     """
 
     def __init__(self, backend=None, port=8079, token=""):
-        from qiskit_ibm_runtime import QiskitRuntimeService, Sampler, Session, Estimator
+        from qiskit_ibm_runtime import QiskitRuntimeService, Sampler, Session
 
         service = QiskitRuntimeService(channel="ibm_quantum_platform", token=token)
         if backend is None:

--- a/src/qrisp/interface/provider_backends/qiskit_backend.py
+++ b/src/qrisp/interface/provider_backends/qiskit_backend.py
@@ -155,9 +155,9 @@ class QiskitRuntimeBackend(VirtualBackend):
 
         service = QiskitRuntimeService(channel="ibm_quantum", token=token)
         if backend is None:
-            backend = service.get_backend("ibmq_qasm_simulator")
+            backend = service.least_busy()
         else:
-            backend = service.get_backend(backend)
+            backend = service.backend(backend)
 
         session = Session(service, backend)
         sampler = Sampler(session=session)

--- a/src/qrisp/interface/provider_backends/qiskit_backend.py
+++ b/src/qrisp/interface/provider_backends/qiskit_backend.py
@@ -159,8 +159,8 @@ class QiskitRuntimeBackend(VirtualBackend):
         else:
             backend = service.backend(backend)
 
-        session = Session(service, backend)
-        sampler = Sampler(session=session)
+        self.session = Session(backend)
+        sampler = Sampler(self.session)
 
         # Create the run method
         def run(qasm_str, shots=None, token=""):


### PR DESCRIPTION
The QiskitRuntimeBackend uses outdated calls to interface with the IBM backend.
This PR includes fixes that I could find while trying to make the module work for my use case.
See commit messages for more info.

fixes #161