### PR TITLE
Fix number of iterations for grover example in documentation

### DIFF
--- a/documentation/source/general/tutorial/tutorial.ipynb
+++ b/documentation/source/general/tutorial/tutorial.ipynb
@@ -529,12 +529,13 @@
     }
    ],
    "source": [
+    "from math import pi\n",
     "from qrisp.grover import diffuser\n",
     "\n",
     "qf = QuantumFloat(3, -1, signed=True)\n",
     "\n",
     "n = qf.size\n",
-    "iterations = int((2**n / 2) ** 0.5)\n",
+    "iterations = int(0.25 * pi * (2**n / 2) ** 0.5)\n",
     "\n",
     "h(qf)\n",
     "\n",


### PR DESCRIPTION
There was essentially a factor of $\pi/4$ missing. This does not matter for the concrete example due to the low resolution of the search space (4 bits) but it would be noticable at slightly higher numbers of bits (try e.g. `qf = QuantumFloat(5, -2, signed=True)` where you see a severe degradation of success probability.

The "correct" number of rotations would be more like this

```python
M = 2
N = 2**n
θ = 2*asin(sqrt(M/N))
iterations = round(π/(2*θ) - 0.5)
```

Using the usual small angle approximation $x\approx\sin(x)$ this simplifies to the code I submitted. I guess simplicity is desired here.