### PR TITLE
run tests on pull requests

### DIFF
--- a/.github/workflows/qrisp_test.yml
+++ b/.github/workflows/qrisp_test.yml
@@ -1,6 +1,10 @@
 name: Qrisp unit tests via Pytest
 
-on: [push]
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
 
 jobs:
   build:


### PR DESCRIPTION
Changes the trigger in the GitHub workflow to run tests for pushes and pull requests targeting `main`. Also, running tests is limited to `main` to avoid duplicate runnings. To run tests for a branch, create a (draft) pull request for this branch.