### PR TITLE
Block encoding

### DIFF
--- a/documentation/source/reference/Operators/QubitOperator.rst
+++ b/documentation/source/reference/Operators/QubitOperator.rst
@@ -19,6 +19,7 @@ Methods
    QubitOperator.get_measurement
    QubitOperator.ground_state_energy
    QubitOperator.hermitize
+   QubitOperator.pauli_block_encoding
    QubitOperator.to_array
    QubitOperator.to_sparse_matrix
    QubitOperator.to_pauli

--- a/documentation/source/reference/Operators/generated/qrisp.operators.qubit.QubitOperator.pauli_block_encoding.rst
+++ b/documentation/source/reference/Operators/generated/qrisp.operators.qubit.QubitOperator.pauli_block_encoding.rst
@@ -1,0 +1,6 @@
+﻿qrisp.operators.qubit.QubitOperator.pauli\_block\_encoding
+==========================================================
+
+.. currentmodule:: qrisp.operators.qubit
+
+.. automethod:: QubitOperator.pauli_block_encoding


### PR DESCRIPTION
- Adds reversed keyword to QubitOperator.from_matrix method. If set to True, the endianness is reversed. This is useful, e.g., for quantum linear systems solvers (HHL, CKS) to avoid swaps.

- Add QubitOperator.pauli_block_encoding method. This method returns a tuple (U_func, G_func , n) representing a block encoding of the operator based on its Pauli decomposition.