### PR TITLE
Jasp prefix control now works in non-Jasp

### DIFF
--- a/src/qrisp/jasp/program_control/prefix_control.py
+++ b/src/qrisp/jasp/program_control/prefix_control.py
@@ -100,7 +100,10 @@ def q_while_loop(cond_fun, body_fun, init_val):
     """
 
     if not check_for_tracing_mode():
-        return while_loop(cond_fun, body_fun, init_val)
+        val = init_val
+        while cond_fun(val):
+            val = body_fun(val)
+        return val
 
     def new_cond_fun(val):
         temp_qc = qs.abs_qc
@@ -296,6 +299,12 @@ def q_cond(pred, true_fun, false_fun, *operands):
         # True
 
     """
+
+    if not check_for_tracing_mode():
+        if pred:
+            return true_fun(*operands)
+        else:
+            return false_fun(*operands)
 
     def new_true_fun(*operands):
         qs.start_tracing(operands[1])


### PR DESCRIPTION
This PR addresses the issue that the Jasp prefix control causes errors when used without tracing, e.g.:

```
from qrisp import *

def main():

    qv = QuantumVariable(1)

    k = 3

    def body_fun(i, qv):
        rx(np.pi/4,qv)
        return qv
    
    result = q_fori_loop(0,10,body_fun,qv)

    return result.get_measurement()


main()
```

Yields:
> AttributeError: 'list' object has no attribute 'tracer'


This behavior necessitates workarounds such as 
```
    # Jasp mode
    if check_for_tracing_mode():
        x_cond = q_cond
    else:
        def x_cond(pred, true_fun, false_fun, *operands):
            if pred:
                return true_fun(*operands)
            else:
                return false_fun(*operands)
```

as used in, e.g., the qswitch by @cjn10 . 