### PR TITLE
Fix: Rutorial links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,9 +72,9 @@ def find_order(a, N):
     return qpe_res.get_measurement()
 ```
 
-To find out how this can be used to break encryption be sure to check the [tutorial](https://www.qrisp.eu/general/tutorial.html).
+To find out how this can be used to break encryption be sure to check the [tutorial](https://qrisp.eu/general/tutorial/Shor.html).
 
-Qrisp offers much more than just factoring! More examples, like simulating molecules at the quantum level or how to solve the Travelling Salesman Problem, can be found [here](https://www.qrisp.eu/general/tutorial.html).
+Qrisp offers much more than just factoring! More examples, like simulating molecules at the quantum level or how to solve the Travelling Salesman Problem, can be found [here](https://qrisp.eu/general/tutorial/index.html).
 
 ## Authors and Citation
 Qrisp was mainly devised and implemented by Raphael Seidel, supported by Sebastian Bock, Nikolay Tcholtchev, René Zander, Niklas Steinmann and Matic Petric.


### PR DESCRIPTION
# Fix Tutorial Links

Tutorial links now point to the Shor tutorial and the index of the tutorial. Before, we had

<img width="445" height="112" alt="image" src="https://github.com/user-attachments/assets/5eeaa454-05f9-412e-aea8-41ee390b88be" />
