### PR TITLE
Upgrade to jax, jaxlib 0.6.2

### DIFF
--- a/.github/workflows/qrisp_test.yml
+++ b/.github/workflows/qrisp_test.yml
@@ -12,7 +12,7 @@ jobs:
     timeout-minutes: 60
     strategy:
       matrix:
-        python-version: ["3.10.*"]
+        python-version: ["3.11.*"]
 
     steps:
       - uses: actions/checkout@v3

--- a/setup.py
+++ b/setup.py
@@ -33,8 +33,8 @@ REQUIREMENTS = [
                 "pyyaml",
                 "requests",
                 "psutil",
-                "jax==0.6.0",
-                "jaxlib==0.6.0"]
+                "jax==0.6.2",
+                "jaxlib==0.6.2"]
 
 
 with open("README.md", "r", encoding="utf-8") as fh:

--- a/src/qrisp/circuit/operation.py
+++ b/src/qrisp/circuit/operation.py
@@ -22,7 +22,7 @@ import numpy as np
 from sympy.core.expr import Expr
 from sympy import lambdify
 from jax.core import Tracer
-from jaxlib.xla_extension import ArrayImpl
+from jax._src.array import ArrayImpl
 
 
 def adaptive_substitution(expr, subs_dic, precision=10):

--- a/src/qrisp/core/session_merging_tools.py
+++ b/src/qrisp/core/session_merging_tools.py
@@ -17,7 +17,7 @@
 """
 
 import weakref
-from jaxlib.xla_extension import ArrayImpl
+from jax._src.array import ArrayImpl
 
 # This module contains the necessary tools to merge QuantumSessions
 

--- a/src/qrisp/environments/control_environment.py
+++ b/src/qrisp/environments/control_environment.py
@@ -17,7 +17,7 @@
 """
 
 from jax.core import ShapedArray
-from jaxlib.xla_extension import ArrayImpl
+from jax._src.array import ArrayImpl
 from jax.extend.core import ClosedJaxpr
 
 from qrisp.circuit import Qubit, QuantumCircuit, XGate

--- a/src/qrisp/jasp/evaluation_tools/catalyst_interface.py
+++ b/src/qrisp/jasp/evaluation_tools/catalyst_interface.py
@@ -107,8 +107,7 @@ def jaspr_to_catalyst_function(jaspr):
 
     # Initiate Catalyst backend info
     device = qml.device("lightning.qubit", wires=0)
-    device_capabilities = catalyst.device.get_device_capabilities(device)
-    backend_info = catalyst.device.extract_backend_info(device, device_capabilities)
+    backend_info = catalyst.device.extract_backend_info(device)
 
     def catalyst_function(*args):
         # Initiate the backend

--- a/src/qrisp/jasp/jasp_expression/control_transform.py
+++ b/src/qrisp/jasp/jasp_expression/control_transform.py
@@ -252,7 +252,7 @@ def control_jaspr(jaspr):
 
     from qrisp.jasp import Jaspr, AbstractQubit
 
-    ctrl_qubit_var = Var(suffix=str(control_var_count[0]), aval=AbstractQubit())
+    ctrl_qubit_var = Var(aval=AbstractQubit())
     control_var_count[0] += 1
 
     new_eqns = []
@@ -306,7 +306,7 @@ def multi_control_jaspr(jaspr, num_ctrl, ctrl_state):
     from qrisp.jasp import make_jaspr
 
     ctrl_vars = [
-        Var(suffix=str(control_var_count[0] + _), aval=AbstractQubit())
+        Var(aval=AbstractQubit())
         for _ in range(num_ctrl)
     ]
     control_var_count[0] += num_ctrl

--- a/src/qrisp/jasp/jasp_expression/inv_transform.py
+++ b/src/qrisp/jasp/jasp_expression/inv_transform.py
@@ -168,7 +168,7 @@ def invert_jaspr(jaspr):
     
     for i in range(len(op_eqs)):
         op_eqs[i].invars[-1] = current_abs_qc
-        current_abs_qc = Var(suffix=str(qc_var_count[0]), aval=AbstractQuantumCircuit())
+        current_abs_qc = Var(aval=AbstractQuantumCircuit())
         qc_var_count[0] += 1
         op_eqs[i].outvars[-1] = current_abs_qc
     

--- a/src/qrisp/jasp/program_control/jrange_iterator.py
+++ b/src/qrisp/jasp/program_control/jrange_iterator.py
@@ -17,7 +17,7 @@
 """
 
 import jax.numpy as jnp
-from jaxlib.xla_extension import ArrayImpl
+from jax._src.array import ArrayImpl
 from jax import jit
 
 from qrisp.jasp.tracing_logic import check_for_tracing_mode


### PR DESCRIPTION
Some minor changes for compatibility with jax, jaxlib 0.6.2.
This is required for catalyst 0.13.