### PR TITLE
Update `QubitOperator` example

### DIFF
--- a/src/qrisp/operators/qubit/qubit_operator.py
+++ b/src/qrisp/operators/qubit/qubit_operator.py
@@ -131,10 +131,15 @@ class QubitOperator(Hamiltonian):
         from qrisp.operators import A,C,Z,Y
         from qrisp import QuantumVariable
         O = A(0)*C(1)*Z(2)*A(3) + Y(3)
-        U = O.trotterization()
-        qv = QuantumVariable(4)
+        
         t = Symbol("t")
-        U(qv, t = t)
+        def state_prep(t):
+            qv = QuantumVariable(4)
+            U = O.trotterization()
+            U(qv, t = t)
+            return qv
+        
+        qv = state_prep(t)
         
     >>> print(qv.qs)
     QuantumCircuit:
@@ -167,8 +172,8 @@ class QubitOperator(Hamiltonian):
     
     Call the simulator:
         
-    >>> print(qv.get_measurement(subs_dic = {t : 0.5}))
-    {'0000': 0.77015, '0001': 0.22985}
+    >>> O.expectation_value(state_prep)(0.5)  # Calculate the expectation value
+    0.007990479428765712
 
     """
 


### PR DESCRIPTION
According to [this page](https://qrisp.eu/reference/Operators/generated/qrisp.operators.qubit.QubitOperator.get_measurement.html#qrisp.operators.qubit.QubitOperator.get_measurement) of the docs, `get_measurement` is a deprecated method of the `QubitOperator` class. 

The example on [this page](https://qrisp.eu/reference/Operators/QubitOperator.html#qubitoperator) is updated to using the recommended method. 