### PR TITLE
Update python versions in docs

### DIFF
--- a/documentation/source/general/setup.rst
+++ b/documentation/source/general/setup.rst
@@ -3,7 +3,7 @@
 Setup
 =====
 
-Qrisp is written in pure Python implying it can be installed conveniently with `PyPi <https://pypi.org/>`_. Currently Python version 3.8 - 3.11 have been confirmed to work with Qrisp.
+Qrisp is written in pure Python implying it can be installed conveniently with `PyPi <https://pypi.org/>`_. Currently Python version 3.10 - 3.12 have been confirmed to work with Qrisp.
 
 Simply execute:
 


### PR DESCRIPTION
This is a minor PR to update Qrisp's compatibility with different python versions. The [setup page](https://qrisp.eu/general/setup.html) is inconsistent with the information available in the readme. 