### PR TITLE
Scalable Resource Computation for 2048 Bit Shor's algorithm

### DIFF
--- a/src/qrisp/jasp/interpreter_tools/interpreters/cl_func_interpreter.py
+++ b/src/qrisp/jasp/interpreter_tools/interpreters/cl_func_interpreter.py
@@ -322,7 +322,7 @@ def process_while(eqn, context_dic):
         
         return eval_jaxpr(converted_cond_jaxpr)(*flattened_invalues)
 
-    outvalues = while_loop(cond_fun, body_fun, invalues)[eqn.params["body_nconsts"]:]
+    outvalues = while_loop(cond_fun, body_fun, invalues)[overall_constant_amount:]
     
     insert_outvalues(eqn, context_dic, outvalues)
 

--- a/src/qrisp/jasp/interpreter_tools/interpreters/profiling_interpreter.py
+++ b/src/qrisp/jasp/interpreter_tools/interpreters/profiling_interpreter.py
@@ -206,7 +206,7 @@ def make_profiling_eqn_evaluator(profiling_dic, meas_behavior):
 
             def cond_fun(val):
                 
-                constants = val[eqn.params["body_nconsts"]:overall_constant_amount]
+                constants = val[:eqn.params["cond_nconsts"]]
                 carries = val[overall_constant_amount:]
                 
                 res = eval_jaxpr(
@@ -216,7 +216,7 @@ def make_profiling_eqn_evaluator(profiling_dic, meas_behavior):
                 return res
 
             outvalues = jax.lax.while_loop(cond_fun, body_fun, tuple(invalues))[overall_constant_amount:]
-
+            
             insert_outvalues(eqn, context_dic, outvalues)
 
         elif eqn.primitive.name == "cond":


### PR DESCRIPTION
During a discussion I had with @PietropaoloFrisoni, I noticed another bug within ``count_ops``. After fixing this, we can finally compute resources for Erik's dynamic implementation of Shor's algorithm! @cjn10 @renezander90 

Below is a script that computes the resources of 2048 bit Shor within about 30 minutes of computation. It uses some parallelization tricks but it's relatively straight forward. The result is:

``{'cx': 25959118388, 't': 4873045316, 'h': 7301650406, 'cz': 2431767202, 's': 2431767202, 't_dg': 4876215620, 'x': 2431783586, 'measure': 4863538500, 'p': 25159680}``

Here is the script:

```python

"""
Parallel Resource Estimation for Shor's Algorithm using Qrisp & JAX
===================================================================

The Windowed Approach:
----------------------
This script parallelizes the resource estimation by decomposing the main loop of the 
Quantum Phase Estimation (QPE) routine. Instead of tracing the entire loop [0, 2*n) 
sequentially, we split the index range into independent "windows".

How it works:
1. Domain Decomposition: The control register is divided into N chunks.
2. Parallel Execution: Each chunk is assigned to a separate thread.
   - Thread A handles indices [0, k)
   - Thread B handles indices [k, 2k)
   - etc.
3. GIL & JAX: We leverage the fact that qrisp.count_ops uses jax.jit under the hood. 
   JAX releases the Python Global Interpreter Lock (GIL) during compilation and execution, 
   allowing these threads to run in true parallel on the CPU.
4. Aggregation: Since the quantum gates generated in each window are independent 
   (accumulating into the total count), we can simply sum the results from all threads.

"""
from qrisp import *
import threading
from concurrent.futures import ThreadPoolExecutor
import collections

# Set the bit-width for the integer to be factored (RSA-2048 equivalent context)
bit_amount = 2048

@count_ops(meas_behavior = "1")
def shor_ops_kernel(window_start, window_end, execute_qft):
    """
    Constructs a partial circuit for Shor's algorithm to estimate resources for a specific 
    window of control qubits.
    """
    
    # Static BigIntegers are used here to generate the circuit structure. 
    # Valid arbitrary large numbers are chosen to ensure realistic modular arithmetic circuit generation.
    N = BigInteger.create_static(235631536157114456342564256245612834570231584290653478071265348961345986731456, size=bit_amount//32)
    a = BigInteger.create_static(234812345034507764157891234987614235897632459871234568912534987126359876254523, size=bit_amount//32)
    
    # Initialize the modular arithmetic environment
    qm = QuantumModulus(N)
    qpe_res = QuantumFloat(2*bit_amount)
    
    # Only the first chunk needs to apply the initial Hadamards.
    # This prevents double-counting gates when aggregating results.
    with control(window_start == 0):
        h(qpe_res)
    
    # Resource Estimation Loop:
    # We iterate through the full register size to maintain the correct arithmetic structure (squaring 'a'),
    # but we only apply the expensive controlled-multiplication gates within this thread's assigned window.
    for i in jrange(qpe_res.size):
        
        # 'active_window' creates a control environment that is only True for indices 
        # assigned to this specific thread. Outside this window, no quantum gates are counted
        # within this thread.
        active_window = (i >= window_start) & (i < window_end)
        
        with control(active_window): 
             with control(qpe_res[i]):
                qm *= a
        
        # Squaring 'a' happens structurally in every iteration to advance the sequence,
        # but since we are counting ops, the compiler sees this as classical pre-computation 
        # relative to the quantum circuit generation unless it involves quantum types.
        a = (a*a) % N

    # The Inverse QFT and measurement are only performed by the final thread 
    # to complete the circuit estimation.
    with control(execute_qft):
        QFT(qpe_res, inv = True)
        measure(qpe_res)

# JIT WARM-UP ROUTINE
# We execute the kernel once on the main thread before spawning the pool.
# This ensures that the initial JAX tracing/compilation cache is populated safely.
# Simultaneous tracing from multiple threads can lead to race conditions or redundant compilation.
shor_ops_kernel(0, 2, False)

# --- Parallel Execution Configuration ---
num_threads = 16
# Divide the total qubit register (2 * N_bits) evenly among threads
chunk_size = (2*bit_amount) // num_threads

futures = []
ops_dict = collections.defaultdict(int)

print(f"Starting resource estimation for {bit_amount}-bit Shor's Algorithm with {num_threads} threads...")

with ThreadPoolExecutor(max_workers=num_threads) as executor:
    for i in range(num_threads):
        # Calculate the index window for this thread
        window_start = i * chunk_size
        # Ensure the last thread covers any remainder indices
        window_end = (i + 1) * chunk_size if i != num_threads - 1 else 2*bit_amount
        
        # Only the last thread adds the QFT cost
        execute_qft = (i == (num_threads - 1))
        
        futures.append(executor.submit(shor_ops_kernel, window_start, window_end, execute_qft))

    # Aggregation:
    # Collect results as they finish and sum the operation counts.
    for future in futures:
        result_dict = future.result()
        for k, v in result_dict.items():
            ops_dict[k] += v

print("Total Operation Counts:")
print(dict(ops_dict))
```