### PR TITLE
Making QuantumFloat.signed always static

### DIFF
--- a/src/qrisp/core/quantum_variable.py
+++ b/src/qrisp/core/quantum_variable.py
@@ -339,8 +339,20 @@ class QuantumVariable:
         except ValueError:
             pass
 
+        # The following lists are used to indicate to the 
+        # (un)flattening mechanism of Jax which attributes
+        # of the QuantumVariable should be considered static
+        # and which are dynamic.
+        # For instance, in the case of QuantumFloat,
+        # the exponent is dynamic and the signed boolean is
+        # static.
+        # For reference check:
+        # https://docs.jax.dev/en/latest/custom_pytrees.html
+
         # Specify the traced attributes (None for base type QuantumVariable)
         self.traced_attributes = []
+        # Specify the static attributes (None for base type QuantumVariable)
+        self.static_attributes = []
 
     def __or__(self, other):
         from qrisp import mcx, x, cx

--- a/src/qrisp/qtypes/quantum_float.py
+++ b/src/qrisp/qtypes/quantum_float.py
@@ -304,7 +304,8 @@ class QuantumFloat(QuantumVariable):
         else:
             super().__init__(msize, qs, name=name)
 
-        self.traced_attributes = ["exponent", "signed"]
+        self.traced_attributes = ["exponent"]
+        self.static_attributes = ["signed"]
 
     @property
     def msize(self):

--- a/tests/jax_tests/test_jasp_QuantumFloat.py
+++ b/tests/jax_tests/test_jasp_QuantumFloat.py
@@ -20,7 +20,7 @@ def test_jasp_QuantumFloat():
 
     # Test decoder for QuantumFloat (Issue #271) 
     from qrisp import QuantumFloat, h
-    from qrisp.jasp import terminal_sampling
+    from qrisp.jasp import terminal_sampling, qache, make_jaspr
 
     @terminal_sampling
     def main():
@@ -32,3 +32,26 @@ def test_jasp_QuantumFloat():
     
     res = main()
     assert res == {-2.0: 0.0625, -1.75: 0.0625, -1.5: 0.0625, -1.25: 0.0625, -1.0: 0.0625, -0.75: 0.0625, -0.5: 0.0625, -0.25: 0.0625, 0.0: 0.0625, 0.25: 0.0625, 0.5: 0.0625, 0.75: 0.0625, 1.0: 0.0625, 1.25: 0.0625, 1.5: 0.0625, 1.75: 0.0625}
+    
+    # Test that the signed attribute behaves statically and the exponent 
+    # attribute dynamically.
+    
+    @qache
+    def inner(qf):
+        assert isinstance(qf.signed, bool)
+        assert not isinstance(qf.exponent, int)
+        return qf.signed
+
+    @make_jaspr
+    def main():
+        a = QuantumFloat(3, -1, signed = True)
+        inner(a)
+        inner(a)
+        b = QuantumFloat(3, -1, signed = False)
+        inner(b)
+        inner(b)
+
+        assert a.signed == True
+        assert b.signed == False
+
+


### PR DESCRIPTION
Previously, the ``signed`` attribute of QuantumFloat could be dynamic or static. It would however always be converted to dynamic if a "Jax tracing context threshold" was passed. This led to [some confusion](https://github.com/eclipse-qrisp/Qrisp/issues/347#issuecomment-3723440449). After a discussion, we agreed that there is not really any reason that motivates having the ``signed`` attribute dynamic. It is now changed to be always static and will also stay like this when passing the tracing context threshold.