### PR TITLE
Add concurrency option to CI

### DIFF
--- a/.github/workflows/qrisp_test.yml
+++ b/.github/workflows/qrisp_test.yml
@@ -5,6 +5,10 @@ on:
   pull_request:
     branches: [main]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
https://docs.github.com/en/actions/how-tos/write-workflows/choose-when-workflows-run/control-workflow-concurrency

This PR allows the option to cancel WIP jobs in a PR when there are multiple jobs running per commit. The `cancel-in-progress: true` line will only favor running a job for the latest commit. 