### PR TITLE
Specification in `prepare`

### DIFF
--- a/src/qrisp/alg_primitives/state_preparation/prepare_func.py
+++ b/src/qrisp/alg_primitives/state_preparation/prepare_func.py
@@ -54,28 +54,6 @@ def prepare(qv, target_array, reversed: bool = False, method: str = "auto"):
 
         \ket{0} \equiv \ket{q_0 = 0, q_1 = 0}, \quad \ket{1} \equiv \ket{q_0 = 1, q_1 = 0}, \dotsc
 
-    .. note::
-
-        This primitive is not yet compatible with QuantumEnvironments
-        (e.g. ``invert`` or ``control``) in Jasp mode when using the qswitch method.
-        Trying to use it within such environments, for example by writing:
-
-        ::
-
-            from qrisp.jasp.evaluation_tools import terminal_sampling
-
-            @terminal_sampling
-            def circuit():
-
-                (...)
-
-                with invert():
-                    prepare(..., method="qswitch")
-
-        currently results in an error.
-
-        Furthermore, it is currently not possible to prepare a state by providing a
-        quantum variable with 64 or more qubits.
 
     Parameters
     ----------
@@ -154,6 +132,29 @@ def prepare(qv, target_array, reversed: bool = False, method: str = "auto"):
     The output indicates that the magnitudes of the amplitudes for the basis states
     :math:`\ket{1}`, :math:`\ket{2}`, and :math:`\ket{3}` are in the ratio :math:`1 : 2 : 3`,
     exactly matching the input vector :math:`b = (0,1,2,3)` up to normalization.
+
+    .. note::
+
+        This primitive is not yet compatible with QuantumEnvironments
+        (e.g. ``invert`` or ``control``) in Jasp mode when using the ``qswitch`` method.
+        Trying to use it within such environments, for example by writing:
+
+        ::
+
+            from qrisp.jasp.evaluation_tools import terminal_sampling
+
+            @terminal_sampling
+            def circuit():
+
+                (...)
+
+                with invert():
+                    prepare(..., method="qswitch")
+
+        currently results in an error.
+
+        Furthermore, it is currently not possible to prepare
+        a state with 64 or more qubits using the ``qswitch`` method.
 
     """
 


### PR DESCRIPTION
We clarify in the docstring of `prepare` that it is not yet compatible with certain QuantumEviroments.

For the record, I am slightly changing the `QuantumVariable` class in [this PR](https://github.com/eclipse-qrisp/Qrisp/pull/417)  (replacing, for example, mutable data structures used as class attributes with `ContextVars`). 

Since the release is very close, this is a minimum source of information for users. 