### PR TITLE
Catch unallowed values in `BigInteger`

### DIFF
--- a/src/qrisp/alg_primitives/arithmetic/jasp_arithmetic/jasp_bigintiger.py
+++ b/src/qrisp/alg_primitives/arithmetic/jasp_arithmetic/jasp_bigintiger.py
@@ -153,10 +153,6 @@ class BigInteger:
         Constructs a fixed-width BigInteger with exactly `size` limbs, interpreting
         the input modulo 2^(32*size). JIT-friendly.
 
-        .. warning::
-
-            When called with a negative value, the function will treat it as zero.
-
         Parameters
         ----------
         n : int or float or jnp.integer or jnp.floating


### PR DESCRIPTION
As discussed on Discord. 

```py
from qrisp import BigInteger

# Create a BigInteger
# The size is the amount of 32-bit integers, size=4 yields a 128-bit integer
x = BigInteger.create_static(-128, size=4)

print(x())
```
The above code block fails with `ValueError: Input must be non-negative, got -128`. 

~The above code block fails with `JaxRuntimeError: Input must be non-negative. (check failed)`. Same if I replace `create` with `create_dynamic`~ 

