### PR TITLE
Refactoring the core components of the codebase (example PR)

### DIFF
--- a/src/qrisp/circuit/quantum_circuit.py
+++ b/src/qrisp/circuit/quantum_circuit.py
@@ -16,10 +16,13 @@
 ********************************************************************************
 """
 
+from hashlib import sha256
 from typing import Dict, List, Set
 
 import numpy as np
 import sympy
+from qiskit import QuantumCircuit as QiskitQuantumCircuit
+from qiskit.visualization import circuit_drawer
 
 import qrisp.circuit.standard_operations as ops
 from qrisp.circuit import Clbit, Instruction, Operation, Qubit
@@ -511,12 +514,9 @@ class QuantumCircuit:
         self.data = temp_data
         return res
 
-    # TO-DO write qiskit independent printer
+    # TODO write qiskit independent printer
 
-    # Printing method
     def __str__(self):
-
-        from qiskit.visualization.circuit_visualization import circuit_drawer
 
         from qrisp.interface import convert_to_qiskit
 
@@ -1055,8 +1055,6 @@ class QuantumCircuit:
         from qrisp.interface import convert_to_qiskit
 
         qiskit_qc = convert_to_qiskit(self, transpile=False)
-
-        from qiskit.visualization import circuit_drawer
 
         return circuit_drawer(qiskit_qc, output="latex_source", **kwargs)
 
@@ -1710,7 +1708,6 @@ class QuantumCircuit:
         return statevector_sim(self)
 
     def __hash__(self):
-        from hashlib import sha256
 
         res = 0
 
@@ -1756,13 +1753,13 @@ class QuantumCircuit:
         return hash(res)
 
     @classmethod
-    def from_qasm_str(self, qasm_string):
+    def from_qasm_str(cls, qasm_string: str) -> "QuantumCircuit":
         """
         Loads a QuantumCircuit from a QASM String.
 
         Parameters
         ----------
-        qasm_string : string
+        qasm_string : str
             A string obeying the syntax of the OpenQASM specification.
 
         Returns
@@ -1772,22 +1769,17 @@ class QuantumCircuit:
 
         """
 
-        from qiskit import QuantumCircuit
-
-        qiskit_qc = QuantumCircuit().from_qasm_str(qasm_string)
-
-        from qrisp import QuantumCircuit
-
-        return QuantumCircuit.from_qiskit(qiskit_qc)
+        qiskit_qc = QiskitQuantumCircuit().from_qasm_str(qasm_string)
+        return cls.from_qiskit(qiskit_qc)
 
     @classmethod
-    def from_qasm_file(self, filename):
+    def from_qasm_file(cls, filename: str) -> "QuantumCircuit":
         """
         Loads a QuantumCircuit from a QASM file.
 
         Parameters
         ----------
-        filename : string
+        filename : str
             A string pointing to a file obeying the OpenQASM syntax.
 
         Returns
@@ -1796,16 +1788,12 @@ class QuantumCircuit:
             The corresponding QuantumCircuit.
 
         """
-        from qiskit import QuantumCircuit
 
-        qiskit_qc = QuantumCircuit().from_qasm_file(filename)
-
-        from qrisp import QuantumCircuit
-
-        return QuantumCircuit.from_qiskit(qiskit_qc)
+        qiskit_qc = QiskitQuantumCircuit().from_qasm_file(filename)
+        return cls.from_qiskit(qiskit_qc)
 
     @classmethod
-    def from_qiskit(self, qiskit_qc):
+    def from_qiskit(cls, qiskit_qc):
         """
         Class method to create QuantumCircuits from Qiskit QuantumCircuits.
 

--- a/tests/circuit_tests/test_quantum_circuit.py
+++ b/tests/circuit_tests/test_quantum_circuit.py
@@ -17,6 +17,7 @@
 """
 
 import pytest
+
 from qrisp.circuit.quantum_circuit import QuantumCircuit
 
 
@@ -48,6 +49,30 @@ class TestQuantumCircuitInitialization:
             QuantumCircuit(num_clbits=2.5)
 
     # TODO: Add more tests for other aspects of initialization
+
+    def test_fan_out_example(self):
+        """Test the fan-out example in the QuantumCircuit docstring."""
+
+        qc_0 = QuantumCircuit(4)
+        qc_0.cx(0, range(1, 4))
+
+        assert len(qc_0.data) == 3
+        assert all(str(instruction)[:2] == "cx" for instruction in qc_0.data)
+
+        qc_1 = QuantumCircuit(4)
+        qc_1.h(0)
+        qc_1.append(qc_0.to_gate(name="fan-out"), qc_1.qubits)
+
+        assert len(qc_1.data) == 2
+        assert str(qc_1.data[0])[:1] == "h"
+        assert str(qc_1.data[1])[:7] == "fan-out"
+
+        qc_1.measure(qc_1.qubits)
+        assert len(qc_1.data) == 6
+        for i in range(2, 6):
+            assert str(qc_1.data[i])[:7] == "measure"
+
+    # TODO: Add more tests for other examples in the docstring
 
 
 class TestQuantumCircuitMethods:
@@ -163,31 +188,3 @@ class TestQuantumCircuitMethods:
             qc_to_extend.extend(extension_qc, translation_dic)
 
     # TODO: Add more tests for other methods of QuantumCircuit
-
-
-class TestQuantumCircuitDocstringsExamples:
-    """A test class for the examples in the QuantumCircuit docstrings."""
-
-    def test_fan_out_example(self):
-        """Test the fan-out example in the QuantumCircuit docstring."""
-
-        qc_0 = QuantumCircuit(4)
-        qc_0.cx(0, range(1, 4))
-
-        assert len(qc_0.data) == 3
-        assert all(str(instruction)[:2] == "cx" for instruction in qc_0.data)
-
-        qc_1 = QuantumCircuit(4)
-        qc_1.h(0)
-        qc_1.append(qc_0.to_gate(name="fan-out"), qc_1.qubits)
-
-        assert len(qc_1.data) == 2
-        assert str(qc_1.data[0])[:1] == "h"
-        assert str(qc_1.data[1])[:7] == "fan-out"
-
-        qc_1.measure(qc_1.qubits)
-        assert len(qc_1.data) == 6
-        for i in range(2, 6):
-            assert str(qc_1.data[i])[:7] == "measure"
-
-    # TODO: Add more tests for other examples in the docstrings


### PR DESCRIPTION
**Context:** This PR introduces several improvements to the `QuantumCircuit` class. It is intended to be the first in a series of PRs aimed at gradually improving the robustness, scalability, and maintainability of the codebase.

The work originally started while addressing a `pylance` warning in the `extend` method of `QuantumCircuit`, which revealed a few additional issues and opportunities for improvement.

**Description of the Change:** Here is a list of changes:

- The first docstring example of `QuantumCircuit` has been fixed, updated, and tested. The same was done for the docstring example of the `extend` method.

- A test file for the `QuantumCircuit` class has been created. Although `QuantumCircuit` is one of the most user-facing core components of Qrisp, it previously did not have a dedicated test file.
This PR introduces a minimal test structure covering the code touched here, but additional tests will be added in future PRs.

- *Breaking change*: the default value of the `translation_dic` parameter in the `extend` method is now `None` instead of `"id"`. Using `"id"` as a default value suggested that a string was an intended argument type, while the docstring clearly describes a dictionary-based interface. In practice, the previous implementation only handled `"id"` and failed for any other string. The new behavior makes the expected type explicit and avoids misleading defaults.

- Minor improvements, including formatting cleanup and additional type annotations.

**Benefits:** 

- Improved correctness and consistency

- Better test coverage for a core component

- Clearer typing and improved IDE/static analysis support

- More maintainable code going forward

**Possible Drawbacks:** None that I can think of (except for the breaking change above)

**Related GitHub Issues:** None.
