### PR TITLE
Update versions for `actions/setup-python` and `actions/checkout`

### DIFF
--- a/.github/workflows/qrisp_test.yml
+++ b/.github/workflows/qrisp_test.yml
@@ -18,9 +18,9 @@ jobs:
         python-version: ["3.11.*"]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v5
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies


### PR DESCRIPTION
I noticed the following warning in [my fork of Qrisp](https://github.com/purva-thakre/Qrisp/actions/runs/22918487548). 

> Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: actions/checkout@v3, actions/setup-python@v4. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026. Please check if updated versions of these actions are available that support Node.js 24. To opt into Node.js 24 now, set the FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true environment variable on the runner or in your workflow file. Once Node.js 24 becomes the default, you can temporarily opt out by setting ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

<img width="1580" height="178" alt="Screenshot from 2026-03-10 20-46-14" src="https://github.com/user-attachments/assets/6cdf7295-0ea4-4bf3-9c5b-8ce0631f3012" />

I think this is related to actions/setup-python and actions/checkout using outdated versions.  

#346 should automate upgrades like this in the future. 

Relevant links:
- https://github.com/actions/setup-python
- https://github.com/actions/checkout
