### PR TITLE
q_switch fix

### DIFF
--- a/src/qrisp/alg_primitives/program_control/quantum_switch.py
+++ b/src/qrisp/alg_primitives/program_control/quantum_switch.py
@@ -326,7 +326,7 @@ def _q_switch_q(
         # Function mode
         if is_function_mode:
 
-            def leaf(d: int, anc, ca, i, *oper):
+            def leaf(d: int, anc, ca, i, oper):
                 with control(anc[d]):
                     branches(i, *oper)
 
@@ -348,7 +348,7 @@ def _q_switch_q(
                 with control(anc[d]):
                     branches(i + 1, *oper)
 
-            def last_leaf(d: int, anc, ca, i, *oper):
+            def last_leaf(d: int, anc, ca, i, oper):
                 with control(anc[d]):
                     branches(i, *oper)
 
@@ -364,7 +364,7 @@ def _q_switch_q(
 
             if check_for_tracing_mode():
 
-                def leaf(d: int, anc, ca, i, *oper):
+                def leaf(d: int, anc, ca, i, oper):
                     def apply_leaf(A, B):
                         with control(anc[d]):
                             A(*oper)
@@ -398,7 +398,7 @@ def _q_switch_q(
 
             else:
 
-                def leaf(d: int, anc, ca, i, *oper):
+                def leaf(d: int, anc, ca, i, oper):
                     with control(anc[d]):
                         branches[i](*oper)
 
@@ -420,7 +420,7 @@ def _q_switch_q(
                     with control(anc[d]):
                         branches[i + 1](*oper)
 
-            def last_leaf(d: int, anc, ca, i, *oper):
+            def last_leaf(d: int, anc, ca, i, oper):
                 def apply(f):
                     with control(anc[d]):
                         f(*oper)
@@ -434,45 +434,45 @@ def _q_switch_q(
             )
 
         def body_fun(pos, val):
-            anc, ca, *oper = val
+            anc, ca, oper = val
 
             # Apply leaf
-            leaf(n - 1, anc, ca, 2 * pos, *oper)
+            leaf(n - 1, anc, ca, 2 * pos, oper)
 
             # Jump to next leaf
             q = bitwise_count_diff(pos, pos + 1)
             for j in xrange(0, q - 1, 1):
-                up(n - j - 1, anc, ca, *oper)
-            bounce(n - q, anc, ca, *oper)
+                up(n - j - 1, anc, ca, oper)
+            bounce(n - q, anc, ca, oper)
             for j in xrange(0, q - 1, 1):
-                down(n - (q - 1) + j, anc, ca, *oper)
+                down(n - (q - 1) + j, anc, ca, oper)
 
-            return anc, ca, *oper
+            return anc, ca, oper
 
         anc = QuantumVariable(n)
         # x(anc[0])
 
         # Go to first node
         for j in xrange(0, n, 1):
-            down(j, anc, index, *operands)
+            down(j, anc, index, operands)
 
         # Perform leafs and jumps
 
         _, _, _ = x_fori_loop(
-            0, -(-branch_amount // 2) - 1, body_fun, (anc, index, *operands)
+            0, -(-branch_amount // 2) - 1, body_fun, (anc, index, operands)
         )
 
         # Perfrom last leaf
         x_cond(
             branch_amount % 2 == 0,
-            lambda: leaf(n - 1, anc, index, branch_amount - 2, *operands),
-            lambda: last_leaf(n - 1, anc, index, branch_amount - 1, *operands),
+            lambda: leaf(n - 1, anc, index, branch_amount - 2, operands),
+            lambda: last_leaf(n - 1, anc, index, branch_amount - 1, operands),
         )
 
         # Go back from last node
         diff = 2**n - branch_amount
         for j in xrange(0, n, 1):
-            up(n - j - 1, anc, index, *operands)
+            up(n - j - 1, anc, index, operands)
 
             def bf():
                 # with control(anc[n-j-2]):

--- a/tests/jax_tests/test_jasp_q_switch.py
+++ b/tests/jax_tests/test_jasp_q_switch.py
@@ -64,6 +64,40 @@ def test_jasp_q_switch_quantum_index():
         assert res == index_val
 
 
+def test_jasp_q_switch_multiple_operands():
+    from qrisp import QuantumFloat, jaspify, measure, q_switch
+
+    @jaspify
+    def main(index_val):
+
+        def f0(x, y): pass
+
+        def f1(x ,y): 
+            x += 1
+            y += 1
+
+        def f2(x, y): 
+            x += 2
+            y += 2
+
+        def f3(x, y): 
+            x += 3
+            y += 3
+
+        index = QuantumFloat(2)
+        index[:] = index_val
+        branches = [f0, f1, f2, f3]
+        operand1 = QuantumFloat(2)
+        operand2 = QuantumFloat(2)
+
+        q_switch(index, branches, operand1, operand2)
+        return measure(operand1), measure(operand2)
+
+    for index_val in range(4):
+        res = main(index_val)
+        assert res[0] + res[1] == 2 * index_val
+
+
 def test_jasp_q_switch_hamiltonian_simulation():
     from qrisp import QuantumFloat, h, q_switch, terminal_sampling
     import numpy as np

--- a/tests/primitives_tests/test_q_switch.py
+++ b/tests/primitives_tests/test_q_switch.py
@@ -20,7 +20,7 @@ from qrisp import inpl_mult, h, QuantumFloat, q_switch, multi_measurement, x
 
 # classical indexed switch tests
 
-def test_jasp_q_switch_classical_index():
+def test_q_switch_classical_index():
 
     def main(index_val):
 
@@ -41,7 +41,7 @@ def test_jasp_q_switch_classical_index():
 
 # quantum indexed switch tests
 
-def test_jasp_q_switch_quantum_index():
+def test_q_switch_quantum_index():
     from qrisp import QuantumFloat, q_switch
 
     def main(index_val):
@@ -61,6 +61,39 @@ def test_jasp_q_switch_quantum_index():
     for index_val in range(4):
         res = main(index_val)
         assert res[index_val] == 1.0
+
+
+def test_q_switch_multiple_operands():
+    from qrisp import QuantumFloat, jaspify, multi_measurement, q_switch
+
+    def main(index_val):
+
+        def f0(x, y): pass
+
+        def f1(x ,y): 
+            x += 1
+            y += 1
+
+        def f2(x, y): 
+            x += 2
+            y += 2
+
+        def f3(x, y): 
+            x += 3
+            y += 3
+            
+        index = QuantumFloat(2)
+        index[:] = index_val
+        branches = [f0, f1, f2, f3]
+        operand1 = QuantumFloat(2)
+        operand2 = QuantumFloat(2)
+
+        q_switch(index, branches, operand1, operand2)
+        return multi_measurement([operand1, operand2])
+
+    for index_val in range(4):
+        res = main(index_val)
+        assert res[(index_val, index_val)] == 1.0
 
 
 def test_q_switch_branches_list():


### PR DESCRIPTION
Fixes a bug when using q_switch with multiple operands:

```
from qrisp import *

def f0(x,y):
    x+=1

def f1(x,y):
    y+=2

@terminal_sampling
def main():
    a = QuantumFloat(2)
    b = QuantumFloat(2)
    index = QuantumFloat(1)
    h(index)
    q_switch(index,[f0,f1], a, b)

    return a,b 

main()
```
> TypeError: _q_switch_q.<locals>.down() takes 4 positional arguments but 5 were given