### PR TITLE
Fix type of 'shots' in IQAE: must be int in static mode

### DIFF
--- a/src/qrisp/alg_primitives/iterative_qae.py
+++ b/src/qrisp/alg_primitives/iterative_qae.py
@@ -224,7 +224,7 @@ def quantum_step(k, N, init_function, state_function, oracle_function, mes_kwarg
     if check_for_tracing_mode():
         a_i = expectation_value(state_prep, shots=N)(k)
     else:
-        mes_kwargs["shots"] = N
+        mes_kwargs["shots"] = int(N)
         res_dict = state_prep(k).get_measurement(**mes_kwargs)
         a_i = res_dict.get(True, 0)
 


### PR DESCRIPTION
The refactored Backend will validate that `shots` in `get_measurement` is of type `int` or `None`. 
This PR fixes an issue caused by `shots` being of type `ArrayImpl` in IQAE.