### PR TITLE
Fixing ``Operation.inverse`` on composite gates with abstract parameters.

### DIFF
--- a/src/qrisp/circuit/operation.py
+++ b/src/qrisp/circuit/operation.py
@@ -279,6 +279,11 @@ class Operation:
                 res = inverse_circ.to_op(name=self.name[:-3])
             else:
                 res = inverse_circ.to_op(name=self.name + "_dg")
+            
+            res.params = list(self.params)
+            res.abstract_params = set(self.abstract_params)
+            res.permeability = dict(self.permeability)
+            res.is_qfree = self.is_qfree
 
         elif self.name == "qb_alloc":
             from qrisp.circuit import QubitDealloc

--- a/src/qrisp/circuit/operation.py
+++ b/src/qrisp/circuit/operation.py
@@ -282,8 +282,6 @@ class Operation:
             
             res.params = list(self.params)
             res.abstract_params = set(self.abstract_params)
-            res.permeability = dict(self.permeability)
-            res.is_qfree = self.is_qfree
 
         elif self.name == "qb_alloc":
             from qrisp.circuit import QubitDealloc

--- a/tests/core_tests/test_abstract_parameters.py
+++ b/tests/core_tests/test_abstract_parameters.py
@@ -92,3 +92,16 @@ def test_abstract_parameters():
 
     duration = time.time() - start_time
     print("Took " + str(duration/m) + " per binding iteration")
+
+    # Test the fix for https://github.com/eclipse-qrisp/Qrisp/issues/540
+    phi = Symbol("phi")
+    psi = Symbol("psi")
+
+    qv = QuantumVariable(2)
+    xxyy(phi, psi, qv[0], qv[1])
+
+    op = qv.qs.data[2].op
+
+    inv_op = op.inverse()
+
+    assert len(inv_ops.params)

--- a/tests/core_tests/test_abstract_parameters.py
+++ b/tests/core_tests/test_abstract_parameters.py
@@ -21,7 +21,7 @@ import time
 import random
 import numpy as np
 
-from qrisp.core import QuantumSession, QuantumVariable
+from qrisp.core import QuantumSession, QuantumVariable, xxyy
 from qrisp.circuit import RYGate, RXGate, transpile, HGate, ZGate, PGate, XGate, MCXGate
 from sympy import Symbol, simplify
 

--- a/tests/core_tests/test_abstract_parameters.py
+++ b/tests/core_tests/test_abstract_parameters.py
@@ -104,4 +104,4 @@ def test_abstract_parameters():
 
     inv_op = op.inverse()
 
-    assert len(inv_ops.params)
+    assert len(inv_op.params)


### PR DESCRIPTION
Consider the following code:

```python

from qrisp import *
from sympy import Symbol

phi = Symbol("phi")
psi = Symbol("psi")

qv = QuantumVariable(2)
xxyy(phi, psi, qv[0], qv[1])

op = qv.qs.data[2].op

inv_op = op.inverse()

print(inv_op.params)
```

Before the fix, the output would be an empty list, which cause issue such as https://github.com/eclipse-qrisp/Qrisp/issues/540.
This is now fixed. The inverse gate now carries precisely the same paramers as the original. This is a valid fix because the underlying definition circuit is already daggered, such that the parameters need to undergo no further transformation to reflect a properly daggered unitary.