### PR TITLE
Fix dynamic unitary tracing

### DIFF
--- a/src/qrisp/core/gate_application_functions.py
+++ b/src/qrisp/core/gate_application_functions.py
@@ -1224,10 +1224,30 @@ def unitary(unitary_array, qubits):
         The U3 matrix to apply.
     qubits : Qubit
         The Qubit to apply the gate on.
+
+    Examples
+    --------
+
+    The unitary can be used inside a :func:`~qrisp.jasp.jaspify` trace:
+
+    ::
+
+        import numpy as np
+        from qrisp import QuantumFloat, jaspify, measure, unitary
+
+        U = np.eye(2, dtype=np.complex128)
+
+        @jaspify
+        def main():
+            qf = QuantumFloat(1)
+            unitary(U, qf[0])
+            return measure(qf[0])
+
+        assert not bool(main())
     """
     import jax.numpy as jnp
 
-    mat = unitary_array
+    mat = jnp.asarray(unitary_array)
     coeff = 1 / jnp.sqrt(jnp.linalg.det(mat))
     gphase_angle = -jnp.angle(coeff) % (2 * jnp.pi)
     tmp_10 = jnp.abs((coeff * mat[1][0]))
@@ -1239,9 +1259,20 @@ def unitary(unitary_array, qubits):
     lam = phiplambda2 - phimlambda2
 
     arg_max = jnp.argmax(jnp.abs(mat).flatten())
-    from qrisp.simulator.unitary_management import u3matrix
-
-    temp_u3 = u3matrix(theta, phi, lam, 0).flatten()
+    theta_half = theta / 2
+    sin_theta_half = jnp.sin(theta_half)
+    cos_theta_half = jnp.cos(theta_half)
+    temp_u3 = jnp.stack(
+        [
+            jnp.stack([cos_theta_half, -jnp.exp(1j * lam) * sin_theta_half]),
+            jnp.stack(
+                [
+                    jnp.exp(1j * phi) * sin_theta_half,
+                    jnp.exp(1j * (phi + lam)) * cos_theta_half,
+                ]
+            ),
+        ]
+    ).flatten()
 
     gphase_angle = (-jnp.angle(temp_u3[arg_max] / mat.flatten()[arg_max])) % (
         2 * jnp.pi

--- a/tests/jax_tests/test_dynamic_unitary.py
+++ b/tests/jax_tests/test_dynamic_unitary.py
@@ -1,0 +1,33 @@
+"""
+********************************************************************************
+* Copyright (c) 2026 the Qrisp authors
+*
+* This program and the accompanying materials are made available under the
+* terms of the Eclipse Public License 2.0 which is available at
+* http://www.eclipse.org/legal/epl-2.0.
+*
+* This Source Code may also be made available under the following Secondary
+* Licenses when the conditions for such availability set forth in the Eclipse
+* Public License, v. 2.0 are satisfied: GNU General Public License, version 2
+* with the GNU Classpath Exception which is
+* available at https://www.gnu.org/software/classpath/license.html.
+*
+* SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+********************************************************************************
+"""
+
+import numpy as np
+
+from qrisp import QuantumFloat, jaspify, measure, unitary
+
+
+def test_unitary_jasp_trace():
+    unitary_array = np.eye(2, dtype=np.complex128)
+
+    @jaspify
+    def main():
+        qv = QuantumFloat(1)
+        unitary(unitary_array, qv[0])
+        return measure(qv[0])
+
+    assert not bool(main())


### PR DESCRIPTION
## Description

Fixes `unitary()` in JASP/dynamic mode by avoiding the NumPy-backed `u3matrix()` helper after the U3 angles have become JAX values.

## Related Issues

Closes #581

## Type of Change

- [ ] Feature (new functionality)
- [ ] Change Request (modification of existing functionality)
- [x] Bug Fix
- [ ] Refactoring (no behavior change)
- [ ] Performance improvement
- [x] Documentation
- [ ] CI / Build

## Breaking Change?
- [ ] Yes
- [x] No

If yes, describe the impact and migration path:


## What was changed?

- Replaced the temporary U3 reconstruction in `unitary()` with the equivalent `jax.numpy` expression, so traced parameters are not passed into NumPy.
- Added a JASP regression test for applying an identity unitary to one qubit in dynamic mode.
- Added a docstring example showing `unitary()` inside `@jaspify`.

## How was it tested?

| Test-ID | Status |
|---------|--------|
| T-001 `python -m black --check --target-version py311 src/qrisp/core/gate_application_functions.py tests/jax_tests/test_dynamic_unitary.py` | Passed |
| T-002 `.venv/bin/python -m py_compile src/qrisp/core/gate_application_functions.py tests/jax_tests/test_dynamic_unitary.py` | Passed |
| T-003 JAX-only JIT equivalence check for the rewritten U3 matrix formula vs the NumPy formula | Passed, `max_abs_diff 6.231037001318494e-08` |
| T-004 `git diff --check` / `git diff --cached --check` | Passed |
| T-005 `git diff --cached | gitleaks stdin --no-banner --redact --timeout 30` | Passed, no leaks found |
| T-006 `.venv/bin/python -m pytest tests/jax_tests/test_dynamic_unitary.py -q` | Blocked locally: this macOS x86_64 host cannot install the repo-pinned `jaxlib==0.7.1`; fallback `jax==0.4.38` fails Qrisp import before test collection at `from jax.api_util import debug_info` |

## Screenshots / Output (if applicable)

The local dependency blocker for T-006 is host-specific. `uv` reports no `jaxlib==0.7.1` wheel matching `macosx_12_0_x86_64`; the project CI runs on Ubuntu with Python 3.11.

## Checklist
- [x] My code follows the project's coding standards
- [x] I have performed a self-review
- [x] I have added/updated tests (referencing issue Test-IDs)
- [ ] All tests pass locally and in CI
- [x] I have updated the documentation
- [ ] I have added a changelog entry
- [x] Breaking changes are documented with migration path

## Reviewer Notes

The only intentionally unverified item is the focused pytest run on my local macOS x86_64 host because of the JAX wheel constraint above.
