### PR TITLE
Fix Jasp barrier tracing

### DIFF
--- a/src/qrisp/core/gate_application_functions.py
+++ b/src/qrisp/core/gate_application_functions.py
@@ -1409,6 +1409,9 @@ def barrier(qubits):
     if isinstance(qubits, Qubit):
         qubits = [qubits]
 
+    if check_for_tracing_mode():
+        return qubits
+
     append_operation(std_ops.Barrier(len(qubits)), qubits)
 
     return qubits

--- a/tests/jax_tests/test_jaspify.py
+++ b/tests/jax_tests/test_jaspify.py
@@ -74,6 +74,17 @@ def test_jasp_simulation():
 
     assert main(4) == 9
 
+
+def test_barrier_is_ignored_during_jasp_tracing():
+    @jaspify
+    def main():
+        qv = QuantumVariable(1)
+        barrier(qv)
+        return measure(qv[0])
+
+    assert main() == False
+
+
 def test_parity_simulation():
     """Test parity function simulation with scalar inputs."""
     


### PR DESCRIPTION
Fixes #375.

`barrier` is a visual marker, so this makes it a no-op while Jasp tracing is active. That avoids calling `len()` on a traced qubit array and keeps the existing circuit barrier behavior outside tracing.

Validation:
- `.venv/bin/python -m pytest tests/jax_tests/test_jaspify.py -q`
- `git diff --check`