### PR TITLE
Enhancing quantum amplitude estimation

### DIFF
--- a/src/qrisp/alg_primitives/qae.py
+++ b/src/qrisp/alg_primitives/qae.py
@@ -16,13 +16,21 @@
 ********************************************************************************
 """
 
-from qrisp.alg_primitives.qpe import QPE
+from qrisp.core import QuantumVariable, QuantumArray
+from qrisp.qtypes import QuantumFloat
 from qrisp.alg_primitives.amplitude_amplification import amplitude_amplification
+from qrisp.alg_primitives.qpe import QPE
+from typing import Any, Callable
 
 
 def QAE(
-    args, state_function, oracle_function, kwargs_oracle={}, precision=None, target=None
-):
+    args: QuantumVariable | QuantumArray | list[QuantumVariable | QuantumArray],
+    state_function: Callable,
+    oracle_function: Callable,
+    kwargs_oracle: dict[str, Any] | None = None,
+    precision: int | None = None,
+    target: QuantumFloat | None = None,
+) -> QuantumFloat:
     r"""
     This method implements the canonical quantum amplitude estimation (QAE) algorithm by `Brassard et al. <https://arxiv.org/abs/quant-ph/0005055>`_.
 
@@ -30,33 +38,41 @@ def QAE(
 
     * Given a unitary operator :math:`\mathcal{A}`, let :math:`\ket{\Psi}=\mathcal{A}\ket{0}`.
     * Write :math:`\ket{\Psi}=\ket{\Psi_1}+\ket{\Psi_0}` as a superposition of the orthogonal good and bad components of :math:`\ket{\Psi}`.
-    * Find an estimate for :math:`a=\langle\Psi_1|\Psi_1\rangle`, the probability that a measurement of $\ket{\Psi}$ yields a good state.
+    * Find an estimate for :math:`a=\langle\Psi_1|\Psi_1\rangle`, the probability that a measurement of :math:`\ket{\Psi}` yields a good state.
 
     Parameters
     ----------
     args : QuantumVariable | QuantumArray | list[QuantumVariable | QuantumArray]
-        The (list of) QuantumVariables which represent the state,
-        the quantum amplitude estimation is performed on.
-    state_function : function
-        A Python function preparing the state :math:`\ket{\Psi}`.
-        This function will receive the variables in the list ``args`` as arguments in the
-        course of this algorithm.
-    oracle_function : function
+        The quantum variable, array, or collection thereof on which quantum amplitude estimation 
+        is performed. These variables must initially be in the zero state (:math:`\ket{0}`). 
+        The QAE algorithm will internally apply the ``state_function`` to these variables 
+        to prepare the initial state :math:`\ket{\Psi}`.
+    state_function : Callable
+        A Python function preparing the state :math:`\ket{\Psi}` from the zero state.
+        This function is applied internally by the algorithm. 
+        The required signature of this function depends on the input ``args``: 
+
+        - if ``args`` is a single variable or array, it receives that single object. 
+        - if ``args`` is a list, the elements are unpacked and passed as separate 
+          positional arguments (e.g., for ``args=[qv1, qv2]``, the signature 
+          must be ``state_function(qv1, qv2)``).
+
+    oracle_function : Callable
         A Python function tagging the good state :math:`\ket{\Psi_1}`.
-        This function will receive the variables in the list ``args`` as arguments in the
-        course of this algorithm.
+        Like ``state_function``, its required signature matches the structure of ``args``:
+        it takes a single argument if ``args`` is a single object, or unpacked 
+        positional arguments if ``args`` is a list.
     kwargs_oracle : dict, optional
-        A dictionary containing keyword arguments for the oracle. The default is {}.
+        A dictionary containing keyword arguments for the oracle. The default is None.
     precision : int, optional
-        The precision of the estimation. The default is None.
+        The precision of the estimation (the number of evaluation qubits). The default is None.
     target : QuantumFloat, optional
         A target QuantumFloat to perform the estimation into. The default is None.
-        If given neither a precision nor a target, an Exception will be raised.
+        If neither ``precision`` nor ``target`` is provided, a ValueError will be raised.
 
     Returns
     -------
-
-    res : QuantumFloat
+    QuantumFloat
         A QuantumFloat encoding the angle :math:`\theta` as a fraction of :math:`\pi`,
         such that :math:`\tilde{a}=\sin^2(\theta)` is an estimate for :math:`a`.
 
@@ -68,6 +84,11 @@ def QAE(
             |a-\tilde{a}|\leq\frac{2\pi}{M}+\frac{\pi^2}{M^2}
 
         with probability of at least :math:`8/\pi^2`.
+
+    Raises
+    ------
+    ValueError
+        If neither ``precision`` nor ``target`` is provided.
 
     Examples
     --------
@@ -170,6 +191,18 @@ def QAE(
 
     """
 
+    if kwargs_oracle is None:
+        kwargs_oracle = {}
+        
+    if precision is None and target is None:
+        raise ValueError(
+            "Tried to call Quantum Amplitude Estimation without specifying "
+            "either 'precision' or 'target'."
+        )
+    
+    if isinstance(args, (QuantumVariable, QuantumArray)):
+        args = [args]
+    
     state_function(*args)
     res = QPE(
         args,

--- a/src/qrisp/alg_primitives/qae.py
+++ b/src/qrisp/alg_primitives/qae.py
@@ -43,24 +43,24 @@ def QAE(
     Parameters
     ----------
     args : QuantumVariable | QuantumArray | list[QuantumVariable | QuantumArray]
-        The quantum variable, array, or collection thereof on which quantum amplitude estimation 
-        is performed. These variables must initially be in the zero state (:math:`\ket{0}`). 
-        The QAE algorithm will internally apply the ``state_function`` to these variables 
+        The quantum variable, array, or collection thereof on which quantum amplitude estimation
+        is performed. These variables must initially be in the zero state (:math:`\ket{0}`).
+        The QAE algorithm will internally apply the ``state_function`` to these variables
         to prepare the initial state :math:`\ket{\Psi}`.
     state_function : Callable
         A Python function preparing the state :math:`\ket{\Psi}` from the zero state.
-        This function is applied internally by the algorithm. 
-        The required signature of this function depends on the input ``args``: 
+        This function is applied internally by the algorithm.
+        The required signature of this function depends on the input ``args``:
 
-        - if ``args`` is a single variable or array, it receives that single object. 
-        - if ``args`` is a list, the elements are unpacked and passed as separate 
-          positional arguments (e.g., for ``args=[qv1, qv2]``, the signature 
+        - if ``args`` is a single variable or array, it receives that single object.
+        - if ``args`` is a list, the elements are unpacked and passed as separate
+          positional arguments (e.g., for ``args=[qv1, qv2]``, the signature
           must be ``state_function(qv1, qv2)``).
 
     oracle_function : Callable
         A Python function tagging the good state :math:`\ket{\Psi_1}`.
         Like ``state_function``, its required signature matches the structure of ``args``:
-        it takes a single argument if ``args`` is a single object, or unpacked 
+        it takes a single argument if ``args`` is a single object, or unpacked
         positional arguments if ``args`` is a list.
     kwargs_oracle : dict, optional
         A dictionary containing keyword arguments for the oracle. The default is None.
@@ -193,16 +193,16 @@ def QAE(
 
     if kwargs_oracle is None:
         kwargs_oracle = {}
-        
+
     if precision is None and target is None:
         raise ValueError(
             "Tried to call Quantum Amplitude Estimation without specifying "
             "either 'precision' or 'target'."
         )
-    
+
     if isinstance(args, (QuantumVariable, QuantumArray)):
         args = [args]
-    
+
     state_function(*args)
     res = QPE(
         args,

--- a/src/qrisp/alg_primitives/qae.py
+++ b/src/qrisp/alg_primitives/qae.py
@@ -16,15 +16,17 @@
 ********************************************************************************
 """
 
+from collections.abc import Callable, Sequence
+from typing import Any
+
 from qrisp.core import QuantumVariable, QuantumArray
 from qrisp.qtypes import QuantumFloat
 from qrisp.alg_primitives.amplitude_amplification import amplitude_amplification
 from qrisp.alg_primitives.qpe import QPE
-from typing import Any, Callable
 
 
 def QAE(
-    args: QuantumVariable | QuantumArray | list[QuantumVariable | QuantumArray],
+    args: QuantumVariable | QuantumArray | Sequence[QuantumVariable | QuantumArray],
     state_function: Callable,
     oracle_function: Callable,
     kwargs_oracle: dict[str, Any] | None = None,
@@ -42,7 +44,7 @@ def QAE(
 
     Parameters
     ----------
-    args : QuantumVariable | QuantumArray | list[QuantumVariable | QuantumArray]
+    args : QuantumVariable | QuantumArray | Sequence[QuantumVariable | QuantumArray]
         The quantum variable, array, or collection thereof on which quantum amplitude estimation
         is performed. These variables must initially be in the zero state (:math:`\ket{0}`).
         The QAE algorithm will internally apply the ``state_function`` to these variables
@@ -53,7 +55,7 @@ def QAE(
         The required signature of this function depends on the input ``args``:
 
         - if ``args`` is a single variable or array, it receives that single object.
-        - if ``args`` is a list, the elements are unpacked and passed as separate
+        - if ``args`` is a sequence, the elements are unpacked and passed as separate
           positional arguments (e.g., for ``args=[qv1, qv2]``, the signature
           must be ``state_function(qv1, qv2)``).
 
@@ -61,7 +63,7 @@ def QAE(
         A Python function tagging the good state :math:`\ket{\Psi_1}`.
         Like ``state_function``, its required signature matches the structure of ``args``:
         it takes a single argument if ``args`` is a single object, or unpacked
-        positional arguments if ``args`` is a list.
+        positional arguments if ``args`` is a sequence.
     kwargs_oracle : dict, optional
         A dictionary containing keyword arguments for the oracle. The default is None.
     precision : int, optional
@@ -122,7 +124,7 @@ def QAE(
     **Numerical integration**
 
 
-    Here, we demonstarate how to use QAE for numerical integration.
+    Here, we demonstrate how to use QAE for numerical integration.
 
     Consider a continuous function $f\colon[0,1]\rightarrow[0,1]$. We wish to evaluate
 

--- a/tests/jax_tests/test_jasp_QAE.py
+++ b/tests/jax_tests/test_jasp_QAE.py
@@ -16,59 +16,114 @@
 ********************************************************************************
 """
 
-def test_jasp_QAE():
-    from qrisp import QuantumFloat, ry, z, QAE
-    from qrisp.jasp import terminal_sampling
-    import numpy as np
+import numpy as np
+from qrisp import (
+    QuantumBool,
+    QuantumFloat,
+    QuantumArray,
+    control,
+    z,
+    h,
+    ry,
+    QAE,
+)
+from qrisp.jasp import terminal_sampling, jrange
+
+
+def test_jasp_QAE_single_variable():
+    """Tests QAE with a single QuantumVariable."""
 
     def state_function(qb):
-        ry(np.pi/4,qb)
+        ry(np.pi / 4, qb)
 
-    def oracle_function(qb):   
+    def oracle_function(qb):
         z(qb)
 
     @terminal_sampling
-    def main():
-        qb = QuantumFloat(1)
+    def main_jasp():
+        qb = QuantumBool()
         res = QAE([qb], state_function, oracle_function, precision=3)
         return res
 
-    meas_res = main()
-    
-    assert np.round(meas_res[0.125],2) == 0.5
-    assert np.round(meas_res[0.875],2) == 0.5
+    mes_res = main_jasp()
+
+    assert np.isclose(mes_res.get(0.125, 0.0), 0.5)
+    assert np.isclose(mes_res.get(0.875, 0.0), 0.5)
 
 
-def test_QAE_integration():
-    from qrisp import QuantumFloat, QuantumBool, control, z, h, ry, QAE
-    from qrisp.jasp import terminal_sampling, jrange
-    import numpy as np
+def test_jasp_QAE_quantum_array():
+    """Test that QAE correctly handles QuantumArray inputs."""
 
-    # We compute the integral of f(x)=(sin(x))^2 from 0 to 1
+    def state_function(qa):
+        ry(np.pi / 4, qa[0])
+
+    def oracle_function(qa):
+        z(qa[0])
+
+    @terminal_sampling
+    def main_jasp():
+        qa = QuantumArray(QuantumBool(), shape=(2,))
+        res = QAE(qa, state_function, oracle_function, precision=3)
+        return res
+
+    mes_res = main_jasp()
+
+    assert np.isclose(mes_res.get(0.125, 0.0), 0.5)
+    assert np.isclose(mes_res.get(0.875, 0.0), 0.5)
+
+
+def test_jasp_QAE_multiple_variables():
+    """Tests that QAE correctly handles lists of separate variables."""
+
+    def state_function(qb0, qb1):
+        ry(np.pi / 4, qb0)
+
+    def oracle_function(qb0, qb1):
+        z(qb0)
+
+    @terminal_sampling
+    def main_jasp():
+        qb0 = QuantumBool()
+        qb1 = QuantumBool()
+        res = QAE([qb0, qb1], state_function, oracle_function, precision=3)
+        return res
+
+    mes_res = main_jasp()
+
+    assert np.isclose(mes_res.get(0.125, 0.0), 0.5)
+    assert np.isclose(mes_res.get(0.875, 0.0), 0.5)
+
+
+def test_jasp_QAE_integration():
+    """Tests QAE on a more complex scenario: computing the integral of f(x) = (sin(x))^2."""
+
     def state_function(inp, tar):
-        h(inp) # Distribution
-    
+        h(inp)  # Distribution
+
         N = 2**inp.size
         for k in jrange(inp.size):
             with control(inp[k]):
-                ry(2**(k+1)/N,tar)
-    
+                ry(2 ** (k + 1) / N, tar)
+
     def oracle_function(inp, tar):
         z(tar)
 
     @terminal_sampling
-    def main():
-        n = 6 # 2^n sampling points for integration
-        inp = QuantumFloat(n,-n)
+    def main_jasp():
+        n = 6  # 2^n sampling points for integration
+        inp = QuantumFloat(n, -n)
         tar = QuantumFloat(1)
         input_list = [inp, tar]
 
-        prec = 6 # precision
+        prec = 6  # precision
         res = QAE(input_list, state_function, oracle_function, precision=prec)
         return res
-    
-    meas_res = main()
-    theta = np.pi*max(meas_res, key=meas_res.get)
-    a = np.sin(theta)**2  
 
-    assert np.abs(a-0.26430) < 1e-4
+    meas_res = main_jasp()
+
+    # Get the most probable state and calculate the amplitude
+    theta = np.pi * max(meas_res, key=meas_res.get)
+    a = np.sin(theta) ** 2
+
+    # Verify the integral matches the analytical expectation within tolerance
+    assert np.abs(a - 0.26430) < 1e-4

--- a/tests/primitives_tests/test_QAE.py
+++ b/tests/primitives_tests/test_QAE.py
@@ -40,7 +40,63 @@ def test_QAE_single_variable():
         z(qb)
 
     qb = QuantumBool()
+    res = QAE(qb, state_function, oracle_function, precision=3)
+
+    mes_res = res.get_measurement()
+
+    assert np.isclose(mes_res.get(0.125, 0.0), 0.5)
+    assert np.isclose(mes_res.get(0.875, 0.0), 0.5)
+
+
+def test_QAE_single_variable_list():
+    """Tests QAE with a single QuantumVariable in a list."""
+
+    def state_function(qb):
+        ry(np.pi / 4, qb)
+
+    def oracle_function(qb):
+        z(qb)
+
+    qb = QuantumBool()
     res = QAE([qb], state_function, oracle_function, precision=3)
+
+    mes_res = res.get_measurement()
+
+    assert np.isclose(mes_res.get(0.125, 0.0), 0.5)
+    assert np.isclose(mes_res.get(0.875, 0.0), 0.5)
+
+
+def test_QAE_multiple_variables_list():
+    """Tests QAE with multiple QuantumVariables in a list."""
+
+    def state_function(qb0, qb1):
+        ry(np.pi / 4, qb0)
+
+    def oracle_function(qb0, qb1):
+        z(qb0)
+
+    qb0 = QuantumBool()
+    qb1 = QuantumBool()
+    res = QAE([qb0, qb1], state_function, oracle_function, precision=3)
+
+    mes_res = res.get_measurement()
+
+    assert np.isclose(mes_res.get(0.125, 0.0), 0.5)
+    assert np.isclose(mes_res.get(0.875, 0.0), 0.5)
+
+
+def test_QAE_multiple_variables_tuple():
+    """Tests QAE with multiple QuantumVariables in a tuple."""
+
+    def state_function(qb0, qb1):
+        ry(np.pi / 4, qb0)
+
+    def oracle_function(qb0, qb1):
+        z(qb0)
+
+    qb0 = QuantumBool()
+    qb1 = QuantumBool()
+    res = QAE((qb0, qb1), state_function, oracle_function, precision=3)
 
     mes_res = res.get_measurement()
 
@@ -101,7 +157,7 @@ def test_QAE_missing_parameters_raises_error():
         QAE([qb], state_function, oracle_function, precision=None, target=None)
 
 
-def test_QAE_integration():
+def test_QAE_numerical_integration():
     """Tests QAE on a more complex scenario: computing the integral of f(x) = (sin(x))^2."""
 
     def state_function(inp, tar):

--- a/tests/primitives_tests/test_QAE.py
+++ b/tests/primitives_tests/test_QAE.py
@@ -16,46 +16,127 @@
 ********************************************************************************
 """
 
-def test_QAE():
-    from qrisp import QuantumBool, ry, z, QAE
-    import numpy as np
+import numpy as np
+import pytest
+from qrisp import (
+    QuantumBool,
+    QuantumFloat,
+    QuantumArray,
+    control,
+    ry,
+    z,
+    h,
+    QAE,
+)
+
+
+def test_QAE_single_variable():
+    """Tests QAE with a single QuantumVariable."""
 
     def state_function(qb):
-        ry(np.pi/4,qb)
+        ry(np.pi / 4, qb)
 
-    def oracle_function(qb):   
+    def oracle_function(qb):
+        z(qb)
+
+    qb = QuantumBool()
+    res = QAE([qb], state_function, oracle_function, precision=3)
+
+    mes_res = res.get_measurement()
+
+    assert np.isclose(mes_res.get(0.125, 0.0), 0.5)
+    assert np.isclose(mes_res.get(0.875, 0.0), 0.5)
+
+
+def test_QAE_quantum_array():
+    """Test that QAE correctly handles QuantumArray inputs."""
+
+    def state_function(qa):
+        ry(np.pi / 4, qa[0])
+
+    def oracle_function(qa):
+        z(qa[0])
+
+    qa = QuantumArray(QuantumBool(), shape=(2,))
+    res = QAE(qa, state_function, oracle_function, precision=3)
+
+    mes_res = res.get_measurement()
+
+    assert np.isclose(mes_res.get(0.125, 0.0), 0.5)
+    assert np.isclose(mes_res.get(0.875, 0.0), 0.5)
+
+
+def test_QAE_multiple_variables():
+    """Tests that QAE correctly correctly handles lists of separate variables."""
+
+    def state_function(qb0, qb1):
+        ry(np.pi / 4, qb0)
+
+    def oracle_function(qb0, qb1):
+        z(qb0)
+
+    qb0 = QuantumBool()
+    qb1 = QuantumBool()
+
+    res = QAE([qb0, qb1], state_function, oracle_function, precision=3)
+
+    mes_res = res.get_measurement()
+
+    assert np.isclose(mes_res.get(0.125, 0.0), 0.5)
+    assert np.isclose(mes_res.get(0.875, 0.0), 0.5)
+
+
+def test_QAE_missing_parameters_raises_error():
+    """Tests that QAE raises an error if neither precision nor target is provided."""
+
+    def state_function(qb):
+        ry(np.pi / 4, qb)
+
+    def oracle_function(qb):
         z(qb)
 
     qb = QuantumBool()
 
-    res = QAE([qb], state_function, oracle_function, precision=3)
-    assert res.get_measurement() == {0.125: 0.5, 0.875: 0.5}
+    with pytest.raises(ValueError, match="either 'precision' or 'target'"):
+        QAE([qb], state_function, oracle_function, precision=None, target=None)
 
 
 def test_QAE_integration():
-    from qrisp import QuantumFloat, QuantumBool, control, z, h, ry, QAE
-    import numpy as np
+    """Tests QAE on a more complex scenario: computing the integral of f(x) = (sin(x))^2."""
 
-    # We compute the integral of f(x)=(sin(x))^2 from 0 to 1
     def state_function(inp, tar):
-        h(inp) # Distribution
-    
+        h(inp)  # Distribution
+
         N = 2**inp.size
         for k in range(inp.size):
             with control(inp[k]):
-                ry(2**(k+1)/N,tar)
-    
+                ry(2 ** (k + 1) / N, tar)
+
     def oracle_function(inp, tar):
         z(tar)
 
-    n = 6 # 2^n sampling points for integration
-    inp = QuantumFloat(n,-n)
+    n = 6  # 2^n sampling points for integration
+    inp = QuantumFloat(n, -n)
     tar = QuantumBool()
     input_list = [inp, tar]
 
-    prec = 3 # precision
+    prec = 3  # precision
     res = QAE(input_list, state_function, oracle_function, precision=prec)
-    print(res)
-    assert res.get_measurement() == {0.125: 0.31334, 0.875: 0.31334, 0.25: 0.12557, 0.75: 0.12557, 0.0: 0.05096, 0.375: 0.02632, 0.625: 0.02632, 0.5: 0.01858}
 
+    mes_res = res.get_measurement()
+    expected_results = {
+        0.125: 0.31334,
+        0.875: 0.31334,
+        0.25: 0.12557,
+        0.75: 0.12557,
+        0.0: 0.05096,
+        0.375: 0.02632,
+        0.625: 0.02632,
+        0.5: 0.01858,
+    }
 
+    # Verify each state matches the expected probability within a safe tolerance
+    for state, expected_prob in expected_results.items():
+        assert np.isclose(
+            mes_res.get(state, 0.0), expected_prob, atol=1e-4
+        ), f"Failed on state {state}: expected {expected_prob}, got {mes_res.get(state, 0.0)}"


### PR DESCRIPTION
## Description

Improves `QAE` with type annotations, a mutable-default-argument bug fix (`kwargs_oracle={}`→`None`), a bug fix for direct `QuantumArray` input (missing list wrapping), and an explicit `ValueError` when neither `precision` nor `target` is provided. Expands the existing single-case tests in both standard and Jasp mode into a suite covering all supported input shapes and error handling.

## Related Issues

Closes #
Related to #

## Type of Change

- [ ] Feature (new functionality)
- [ ] Change Request (modification of existing functionality)
- [x] Bug Fix
- [ ] Refactoring (no behavior change)
- [ ] Performance improvement
- [x] Documentation
- [ ] CI / Build

## Breaking Change?
- [ ] Yes
- [x] No

## What was changed?

- **qae.py**:
  - Added type annotations to all parameters and return type (`-> QuantumFloat`)
  - Fixed mutable default argument: `kwargs_oracle={}` → `kwargs_oracle=None` (handled safely inside the function)
  - Fixed bug: `QuantumVariable`/`QuantumArray` passed directly as `args` was not wrapped in a list — added `if isinstance(args, (QuantumVariable, QuantumArray)): args = [args]`
  - Added explicit `ValueError` (with descriptive message) when neither `precision` nor `target` is provided, replacing the implicit downstream error
  - Added `Raises` section; improved `state_function`/`oracle_function` parameter descriptions to document argument unpacking behaviour
- **test_QAE.py**:
  - Refactored single `test_QAE` into 4 focused tests: `_single_variable`, `_quantum_array`, `_multiple_variables`, `_missing_parameters_raises_error`
  - Replaced fragile exact-dict equality assertion with `np.isclose`-based per-state checks in `test_QAE_integration`; removed stray `print(res)`
  - Moved imports to module level; cleaned up formatting
- **test_jasp_QAE.py**:
  - Refactored `test_jasp_QAE` and `test_QAE_integration` into 4 focused Jasp tests: `_single_variable`, `_quantum_array`, `_multiple_variables`, `_integration`

## How was it tested?

| Test-ID | Status |
|---------|--------|
| `test_QAE_single_variable` | ✅ |
| `test_QAE_quantum_array` | ✅ |
| `test_QAE_multiple_variables` | ✅ |
| `test_QAE_missing_parameters_raises_error` | ✅ |
| `test_QAE_integration` | ✅ |
| `test_jasp_QAE_single_variable` | ✅ |
| `test_jasp_QAE_quantum_array` | ✅ |
| `test_jasp_QAE_multiple_variables` | ✅ |
| `test_jasp_QAE_integration` | ✅ |

## Checklist
- [x] My code follows the project's coding standards
- [x] I have performed a self-review
- [x] I have added/updated tests (referencing issue Test-IDs)
- [ ] All tests pass locally and in CI
- [ ] I have updated the documentation
- [ ] I have added a changelog entry
- [ ] Breaking changes are documented with migration path

## Reviewer Notes

- The `QuantumArray` list-wrapping fix mirrors the same fix applied in `enhanced_aa` for `amplitude_amplification` — the two PRs are consistent.
- The ValueError for missing precision/target replaces a previously implicit error from inside QPE; the message is intentionally explicit to aid debugging.