### PR TITLE
fix: support sympy 1.14 quantum tensor products

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ import setuptools
 
 REQUIREMENTS = [
                 "numpy>=2.0",
-                "sympy<=1.13",
+                "sympy>=1.13",
                 "qiskit>=0.44.0",
                 "matplotlib>=3.5.1",
                 "scipy>=1.10.0",

--- a/src/qrisp/algorithms/quantum_backtracking/backtracking_tree.py
+++ b/src/qrisp/algorithms/quantum_backtracking/backtracking_tree.py
@@ -20,7 +20,7 @@ from itertools import product
 
 import numpy as np
 import networkx as nx
-from sympy.physics.quantum import Ket, OrthogonalKet
+from sympy.physics.quantum import Ket, OrthogonalKet, TensorProduct
 
 from qrisp.alg_primitives import QFT
 from qrisp import (
@@ -1540,14 +1540,10 @@ class QuantumBacktrackingTree:
                     if abs(amplitude) < 1e-5:
                         continue
 
-                    external_ket_expr = 1
-                    # Generate the ket expression for the external qvs
-                    for label in external_label_const:
-                        external_ket_expr *= OrthogonalKet(label)
-
                     # Add the corresponding state
-                    res_state += (
-                        amplitude * OrthogonalKet(str(path)) * external_ket_expr
+                    res_state += amplitude * TensorProduct(
+                        OrthogonalKet(str(path)),
+                        *(OrthogonalKet(label) for label in external_label_const),
                     )
 
         return res_state

--- a/src/qrisp/misc/utility.py
+++ b/src/qrisp/misc/utility.py
@@ -1674,7 +1674,7 @@ def get_sympy_state(qs, decimals):
         simplify,
         sin,
     )
-    from sympy.physics.quantum import Ket, OrthogonalKet
+    from sympy.physics.quantum import Ket, OrthogonalKet, TensorProduct
 
     from qrisp.simulator import statevector_sim
 
@@ -1794,14 +1794,19 @@ def get_sympy_state(qs, decimals):
 
         int_string = bin_rep(ind, len(compiled_qc.qubits))
 
-        labels = []
+        state_kets = []
         for qv in qv_list:
             bit_string = ""
             for qb in qv.reg:
                 bit_string += int_string[compiled_qc.qubits.index(qb)]
 
             label = qv.decoder(int(bit_string[::-1], 2))
-            ket_expr = ket_expr * OrthogonalKet((label))
+            state_kets.append(OrthogonalKet((label)))
+
+        if len(state_kets) == 1:
+            ket_expr *= state_kets[0]
+        else:
+            ket_expr *= TensorProduct(*state_kets)
 
         res += ket_expr
 


### PR DESCRIPTION
Fixes #560.

## Summary

This updates Qrisp's symbolic ket composition to work with SymPy 1.14 and relaxes the package constraint so `sympy==1.14.0` can be installed.

SymPy 1.14 no longer allows composing quantum states with `Ket * Ket`; it now raises errors such as:

```text
TypeError: Multiplication of two kets is not allowed. Use TensorProduct instead.
```

## Changes

- Use `TensorProduct(...)` when composing multiple `OrthogonalKet` states in `QuantumBacktrackingTree`.
- Use `TensorProduct(...)` when rendering multi-register symbolic statevectors in `get_sympy_state`.
- Relax the package requirement from `sympy<=1.13` to `sympy>=1.13`.

## Validation

Installed the package in a local editable environment with `sympy==1.14.0`, then ran the failures listed in the issue:

```bash
./.venv/bin/python -m pytest \
  tests/algorithms_tests/test_backtracking.py::test_backtracking \
  tests/jax_tests/test_HHL_demo.py::test_HHL_demo \
  tests/primitives_tests/arithmetic_tests/test_comparisons.py::test_quantum_modulus_comparison \
  -q
```

Result:

```text
3 passed
```

Also checked the edited files compile:

```bash
PYTHONPYCACHEPREFIX=/private/tmp/qrisp-pycache ./.venv/bin/python -m compileall \
  src/qrisp/algorithms/quantum_backtracking/backtracking_tree.py \
  src/qrisp/misc/utility.py \
  setup.py
```
