### PR TITLE
Fix ammend_inpl_adder Jasp compatibility and Jaspify inpl_adder_test

### DIFF
--- a/src/qrisp/alg_primitives/arithmetic/adders/adder_tools.py
+++ b/src/qrisp/alg_primitives/arithmetic/adders/adder_tools.py
@@ -18,6 +18,7 @@
 
 from qrisp.qtypes import QuantumFloat, QuantumVariable
 from qrisp.jasp import check_for_tracing_mode
+from qrisp.environments import control
 
 
 def ammend_inpl_adder(raw_inpl_adder, ammend_cl_int=True):
@@ -32,7 +33,26 @@ def ammend_inpl_adder(raw_inpl_adder, ammend_cl_int=True):
     ):
 
         if check_for_tracing_mode():
-            return raw_inpl_adder(qf2, qf1)
+            if not isinstance(qf2, QuantumVariable):
+                raw_inpl_adder(qf2, qf1)
+                return
+
+            a_reg = qf2.reg  # DynamicQubitArray in Jasp mode
+            b_reg = qf1.reg  # DynamicQubitArray in Jasp mode
+            a_size = a_reg.size
+            b_size = b_reg.size
+
+            # a is shorter: pad a with ancilla zeros, then add
+            with control(a_size < b_size):
+                padding = QuantumVariable(b_size - a_size, name="add_ammend_anc*")
+                raw_inpl_adder(a_reg + padding.reg, b_reg)
+                padding.delete(verify=False)
+
+            # a is longer or equal: truncate or pass a directly
+            with control(a_size >= b_size):
+                raw_inpl_adder(a_reg[:b_size], b_reg)
+
+            return
 
         if isinstance(qf1, QuantumFloat) and isinstance(qf2, QuantumFloat) and False:
             qs = qf1.qs

--- a/src/qrisp/alg_primitives/arithmetic/adders/gidney/qq_gidney_adder.py
+++ b/src/qrisp/alg_primitives/arithmetic/adders/gidney/qq_gidney_adder.py
@@ -38,7 +38,7 @@ def qq_gidney_adder(a, b, c_in=None, c_out=None, ctrl=None):
 
     if len(b) == 1:
         if ctrl is not None:
-            mcx([ctrl, a[0]], b)
+            mcx([ctrl, a[0]], b[0])
         else:
             cx(a[0], b[0])
         if c_in is not None:
@@ -47,7 +47,7 @@ def qq_gidney_adder(a, b, c_in=None, c_out=None, ctrl=None):
             if ctrl is not None:
                 cx(c_in, b[0])
             else:
-                mcx([c_in, b[0]], b)
+                cx(c_in, b[0])
         return
 
     if ctrl is not None:

--- a/src/qrisp/misc/utility.py
+++ b/src/qrisp/misc/utility.py
@@ -2127,7 +2127,7 @@ def cnot_depth_indicator(op):
         raise Exception(f"Gate {op.name} not implemented")
 
 
-def inpl_adder_test(inpl_adder):
+def inpl_adder_test(inpl_adder, test_jasp=False):
     """
     This function runs tests on a desired inplace addition function.
     An inplace addition function is a function mapping (a, b) to (a, a+b),
@@ -2139,6 +2139,10 @@ def inpl_adder_test(inpl_adder):
     inpl_adder : callable
         A quantum inplace addition function that can either act on single QuantumVariables or on lists of Qubits
         by adding the first one to the second.
+    test_jasp : bool, optional
+        If True, additionally runs quantum-quantum and classical-quantum tests in
+        dynamic (Jasp) mode using ``boolean_simulation``. The adder must be
+        Jasp-traceable for this to pass. The default is False.
 
     Returns
     -------
@@ -2156,6 +2160,12 @@ def inpl_adder_test(inpl_adder):
 
         inpl_adder_test(cuccaro_adder)
         print("The cuccaro adder passed the tests without errors.")
+
+    To also test in dynamic (Jasp) mode:
+
+    ::
+
+        inpl_adder_test(cuccaro_adder, test_jasp=True)
 
     And now a new user-defined qcla adder:
     ::
@@ -2305,6 +2315,51 @@ def inpl_adder_test(inpl_adder):
                         assert (
                             b == a
                         ), f"Controlled classical-quantum addition behaviour was incorrect; an operation was performed without the control qubit in |1> state. Faulty input sizes: {i}"
+
+    if test_jasp:
+        from qrisp.core.gate_application_functions import measure
+        from qrisp.jasp.evaluation_tools import boolean_simulation
+
+        # Quantum–Quantum test
+        @boolean_simulation
+        def qq(i, j, asize, bsize):
+            a = QuantumFloat(asize)
+            a[:] = i
+            b = QuantumFloat(bsize)
+            b[:] = j
+            inpl_adder(a, b)
+            return measure(a), measure(b)
+
+        for asize in range(1, 7):
+            for bsize in range(1, 7):
+                for i in range(2**asize):
+                    for j in range(2**bsize):
+                        a_out, b_out = qq(i, j, asize, bsize)
+                        assert a_out == i, (
+                            f"Jasp QQ: first operand was modified. "
+                            f"asize={asize}, bsize={bsize}, i={i}, j={j}"
+                        )
+                        assert b_out == (i % (2**bsize) + j) % (2**bsize), (
+                            f"Jasp QQ: wrong result. "
+                            f"asize={asize}, bsize={bsize}, i={i}, j={j}"
+                        )
+
+        # Classical–Quantum test
+        @boolean_simulation
+        def cq(cl_val, j, bsize):
+            b = QuantumFloat(bsize)
+            b[:] = j
+            inpl_adder(cl_val, b)
+            return measure(b)
+
+        for bsize in range(1, 6):
+            for cl_val in range(1, 2**bsize):
+                for j in range(2**bsize):
+                    b_out = cq(cl_val, j, bsize)
+                    assert b_out == (cl_val + j) % (2**bsize), (
+                        f"Jasp CQ: wrong result. "
+                        f"bsize={bsize}, cl_val={cl_val}, j={j}"
+                    )
 
 
 def batched_measurement(variables, backend, shots=None):

--- a/tests/primitives_tests/arithmetic_tests/test_cuccaro_adder.py
+++ b/tests/primitives_tests/arithmetic_tests/test_cuccaro_adder.py
@@ -19,7 +19,10 @@
 from qrisp import *
 import pytest
 
-import pytest
+
+def test_cuccaro_adder_jasp():
+    inpl_adder_test(cuccaro_adder, test_jasp=True)
+
 
 @pytest.mark.parametrize("input_a, input_b, expected_a, expected_b", [
     # both inputs are quantum in static mode, inputs are of unequal size

--- a/tests/primitives_tests/arithmetic_tests/test_sc_gidney_adder.py
+++ b/tests/primitives_tests/arithmetic_tests/test_sc_gidney_adder.py
@@ -18,7 +18,20 @@
 
 import numpy as np
 
-from qrisp import QuantumFloat, gidney_adder, h, cx, multi_measurement, QuantumBool, control
+from qrisp import (
+    QuantumFloat,
+    gidney_adder,
+    h,
+    cx,
+    multi_measurement,
+    QuantumBool,
+    control,
+    inpl_adder_test,
+)
+
+
+def test_gidney_adder_jasp():
+    inpl_adder_test(gidney_adder, test_jasp=True)
 
 
 def test_sc_gidney_adder():
@@ -58,8 +71,26 @@ def test_sc_gidney_adder():
                     assert (k[1] + j)%(2**n) == k[0]
                 else:
                     assert k[1] == k[0]
-                    
-    
+
+        # QQ controlled: exercises the len(b)==1 + ctrl path in qq_gidney_adder
+        for j in range(2**n):
+            a = QuantumFloat(n)
+            b = QuantumFloat(n)
+            c = QuantumFloat(n)
+            ctrl = QuantumBool()
+            a[:] = j
+            h(ctrl)
+            h(b)
+            cx(b, c)
+            with ctrl:
+                gidney_adder(a, b)
+            mes_res = multi_measurement([b, c, ctrl])
+            for b_out, c_out, ctrl_out in mes_res.keys():
+                if ctrl_out:
+                    assert (c_out + j) % (2**n) == b_out
+                else:
+                    assert c_out == b_out
+
     n = 6
     b = QuantumFloat(n)
     d = b.duplicate()


### PR DESCRIPTION
## Description

- Fixes `ammend_inpl_adder` to correctly handle unequal-size and classical inputs in Jasp (dynamic) tracing mode
- Extends `inpl_adder_test` with a `test_jasp` flag that runs QQ and CQ correctness checks via `boolean_simulation`.
- Fixes a pre-existing bug in `qq_gidney_adder` for 1-qubit controlled addition.

## Related Issues

Closes #499
Closes #500

## Type of Change

- [ ] Feature (new functionality)
- [x] Change Request (modification of existing functionality)
- [x] Bug Fix
- [ ] Refactoring (no behavior change)
- [ ] Performance improvement
- [ ] Documentation
- [ ] CI / Build

## Breaking Change?

- [ ] Yes
- [x] No

## What was changed?

- `adder_tools.py`: Replace the early-return stub in Jasp mode with proper size-equalization logic using dynamic control blocks
- `qq_gidney_adder.py`: Fix `len(b)==1` + controlled path where `mcx` target was passed as `QuantumVariable` instead of single qubit `b[0]`
- `utility.py`: Add `test_jasp=False` parameter to `inpl_adder_test` with QQ and CQ `boolean_simulation` sub-tests covering all register size combinations.
- `test_sc_gidney_adder.py`: Add `test_gidney_adder_jasp` and a QQ controlled regression test that catches the `len(b)==1` bug
- `test_cuccaro_adder.py`: Add `test_cuccaro_adder_jasp`

## How was it tested?

| Test-ID | Status |
|---------|--------|
| `test_cuccaro_adder_jasp` | ✅ |
| `test_cuccaro_adder.py` (all tests) | ✅ |
| `test_gidney_adder_jasp` | ✅ |
| `test_sc_gidney_adder` (all tests) | ✅ |
| `test_fourier_adder` | ✅ |
| `test_remaud_adder` (all tests) | ✅ |

## Reviewer Notes

- Three pre-existing test failures in the arithmetic suite (`test_inpl_matrix_multiplication_example`, `test_matrix_multiplication_example` and `test_quantum_arithmetic`) are unrelated to this PR.

## Screenshots / Output (if applicable)

None

## Checklist
- [x] My code follows the project's coding standards
- [x] I have performed a self-review
- [x] I have added/updated tests (referencing issue Test-IDs)
- [ ] All tests pass locally and in CI
- [x] I have updated the documentation
- [ ] I have added a changelog entry
- [ ] Breaking changes are documented with migration path

## Reviewer Notes

<!-- Anything specific the reviewer should focus on? -->