### PR TITLE
Composite gate interpreter

### DIFF
--- a/src/qrisp/jasp/interpreter_tools/interpreters/__init__.py
+++ b/src/qrisp/jasp/interpreter_tools/interpreters/__init__.py
@@ -24,3 +24,4 @@ from qrisp.jasp.interpreter_tools.interpreters.terminal_sampling_interpreter imp
 from qrisp.jasp.interpreter_tools.interpreters.profiling_interpreter import *
 from qrisp.jasp.interpreter_tools.interpreters.qc_extraction_interpreter import *
 from qrisp.jasp.interpreter_tools.interpreters.post_processing_interpreter import *
+from qrisp.jasp.interpreter_tools.interpreters.composite_gate_interpreter import *

--- a/src/qrisp/jasp/interpreter_tools/interpreters/composite_gate_interpreter.py
+++ b/src/qrisp/jasp/interpreter_tools/interpreters/composite_gate_interpreter.py
@@ -46,7 +46,7 @@ def _apply_op(op, qubit_tracers, abs_qst):
     if op.definition is None:
         return quantum_gate_p.bind(*qubit_tracers, abs_qst, gate=op)
 
-    defn = op.definition
+    defn = op.definition.transpile()
     for instr in defn.data:
         qubit_indices = [defn.qubits.index(qb) for qb in instr.qubits]
         sub_qubits = [qubit_tracers[i] for i in qubit_indices]

--- a/src/qrisp/jasp/interpreter_tools/interpreters/composite_gate_interpreter.py
+++ b/src/qrisp/jasp/interpreter_tools/interpreters/composite_gate_interpreter.py
@@ -98,6 +98,12 @@ def decompose_eqn_evaluator(eqn, context_dic):
         exec_eqn(new_eqn, context_dic)
         return False
 
+    elif eqn.primitive.name == "scan":
+        new_eqn = _copy_eqn(eqn)
+        new_eqn.params["jaxpr"] = _decompose_sub_jaxpr(eqn.params["jaxpr"])
+        exec_eqn(new_eqn, context_dic)
+        return False
+
     return True  # fall back to default execution
 
 

--- a/src/qrisp/jasp/interpreter_tools/interpreters/composite_gate_interpreter.py
+++ b/src/qrisp/jasp/interpreter_tools/interpreters/composite_gate_interpreter.py
@@ -1,0 +1,119 @@
+"""
+********************************************************************************
+* Copyright (c) 2026 the Qrisp authors
+*
+* This program and the accompanying materials are made available under the
+* terms of the Eclipse Public License 2.0 which is available at
+* http://www.eclipse.org/legal/epl-2.0.
+*
+* This Source Code may also be made available under the following Secondary
+* Licenses when the conditions for such availability set forth in the Eclipse
+* Public License, v. 2.0 are satisfied: GNU General Public License, version 2
+* with the GNU Classpath Exception which is
+* available at https://www.gnu.org/software/classpath/license.html.
+*
+* SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+********************************************************************************
+"""
+
+from jax.extend.core import JaxprEqn
+
+from qrisp.jasp.interpreter_tools import exec_eqn, reinterpret, extract_invalues, insert_outvalues
+from qrisp.jasp.primitives import quantum_gate_p
+
+
+def _copy_eqn(eqn):
+    return JaxprEqn(
+        primitive=eqn.primitive,
+        invars=list(eqn.invars),
+        outvars=list(eqn.outvars),
+        params=dict(eqn.params),
+        source_info=eqn.source_info,
+        effects=eqn.effects,
+        ctx=eqn.ctx,
+    )
+
+
+def _apply_op(op, qubit_tracers, abs_qst):
+    """Recursively inline a gate.
+
+    - Primitive gates (op.definition is None) are bound directly via quantum_gate_p.
+    - Composite gates are expanded by iterating their definition circuit and
+      recursively calling _apply_op for each sub-instruction.
+    """
+    if op.definition is None:
+        return quantum_gate_p.bind(*qubit_tracers, abs_qst, gate=op)
+
+    defn = op.definition
+    for instr in defn.data:
+        qubit_indices = [defn.qubits.index(qb) for qb in instr.qubits]
+        sub_qubits = [qubit_tracers[i] for i in qubit_indices]
+        abs_qst = _apply_op(instr.op, sub_qubits, abs_qst)
+
+    return abs_qst
+
+
+def decompose_eqn_evaluator(eqn, context_dic):
+    """Equation evaluator that recursively decomposes composite quantum gates.
+
+    Whenever a quantum_gate_p equation carries a composite gate (one that has
+    a circuit definition), the gate is expanded in-place.
+
+    For jit/while/cond equations whose sub-jaxprs may themselves contain
+    composite gates, the sub-jaxprs are recursively transformed before the
+    equation is re-executed.
+
+    All other equations are passed through unchanged.
+    """
+    if eqn.primitive == quantum_gate_p and eqn.params["gate"].definition is not None:
+        gate = eqn.params["gate"]
+        invalues = extract_invalues(eqn, context_dic)
+        qubit_tracers = invalues[: gate.num_qubits]
+        abs_qst = invalues[-1]
+
+        abs_qst = _apply_op(gate, qubit_tracers, abs_qst)
+        insert_outvalues(eqn, context_dic, abs_qst)
+        return False  # equation handled; skip default exec_eqn
+
+    elif eqn.primitive.name == "jit":
+        new_eqn = _copy_eqn(eqn)
+        new_eqn.params["jaxpr"] = _decompose_sub_jaxpr(eqn.params["jaxpr"])
+        exec_eqn(new_eqn, context_dic)
+        return False
+
+    elif eqn.primitive.name == "while":
+        new_eqn = _copy_eqn(eqn)
+        new_eqn.params["body_jaxpr"] = _decompose_sub_jaxpr(eqn.params["body_jaxpr"])
+        new_eqn.params["cond_jaxpr"] = _decompose_sub_jaxpr(eqn.params["cond_jaxpr"])
+        exec_eqn(new_eqn, context_dic)
+        return False
+
+    elif eqn.primitive.name == "cond":
+        new_eqn = _copy_eqn(eqn)
+        new_eqn.params["branches"] = tuple(
+            _decompose_sub_jaxpr(branch) for branch in eqn.params["branches"]
+        )
+        exec_eqn(new_eqn, context_dic)
+        return False
+
+    return True  # fall back to default execution
+
+
+def _decompose_sub_jaxpr(jaxpr):
+    """Apply decompose_composite_gates to a sub-jaxpr (ClosedJaxpr or Jaspr)."""
+    from qrisp.jasp import Jaspr
+    from jax.extend.core import ClosedJaxpr
+
+    if isinstance(jaxpr, Jaspr):
+        return decompose_composite_gates(jaxpr)
+    elif isinstance(jaxpr, ClosedJaxpr):
+        inner = reinterpret(jaxpr.jaxpr, decompose_eqn_evaluator)
+        return ClosedJaxpr(inner, jaxpr.consts)
+    else:
+        return jaxpr
+
+
+def decompose_composite_gates(jaspr):
+    """Return a new Jaspr with all composite (non-primitive) gates recursively inlined."""
+    from qrisp.jasp import Jaspr
+    return Jaspr(reinterpret(jaspr, decompose_eqn_evaluator))

--- a/src/qrisp/jasp/interpreter_tools/interpreters/composite_gate_interpreter.py
+++ b/src/qrisp/jasp/interpreter_tools/interpreters/composite_gate_interpreter.py
@@ -16,6 +16,8 @@
 ********************************************************************************
 """
 
+from functools import lru_cache
+
 from jax.extend.core import JaxprEqn
 
 from qrisp.jasp.interpreter_tools import exec_eqn, reinterpret, extract_invalues, insert_outvalues
@@ -99,6 +101,7 @@ def decompose_eqn_evaluator(eqn, context_dic):
     return True  # fall back to default execution
 
 
+@lru_cache(maxsize=int(1e5))
 def _decompose_sub_jaxpr(jaxpr):
     """Apply decompose_composite_gates to a sub-jaxpr (ClosedJaxpr or Jaspr)."""
     from qrisp.jasp import Jaspr
@@ -113,6 +116,7 @@ def _decompose_sub_jaxpr(jaxpr):
         return jaxpr
 
 
+@lru_cache(maxsize=int(1e5))
 def decompose_composite_gates(jaspr):
     """Return a new Jaspr with all composite (non-primitive) gates recursively inlined."""
     from qrisp.jasp import Jaspr

--- a/src/qrisp/jasp/mlir/quake_lowering/pass3a_ranked_tensor.py
+++ b/src/qrisp/jasp/mlir/quake_lowering/pass3a_ranked_tensor.py
@@ -1,0 +1,523 @@
+"""
+********************************************************************************
+* Copyright (c) 2026 the Qrisp authors
+*
+* This program and the accompanying materials are made available under the
+* terms of the Eclipse Public License 2.0 which is available at
+* http://www.eclipse.org/legal/epl-2.0.
+*
+* This Source Code may also be made available under the following Secondary
+* Licenses when the conditions for such availability set forth in the Eclipse
+* Public License, v. 2.0 are satisfied: GNU General Public License, version 2
+* with the GNU Classpath Exception which is
+* available at https://www.gnu.org/software/classpath/license.html.
+*
+* SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+********************************************************************************
+"""
+
+"""
+Ranked Tensor → CC Array Lowering
+=================================
+
+Lowers ranked tensor constants (``tensor<NxT>``) and their element accesses
+to CC memory operations (``cc.alloca``, ``cc.compute_ptr``, ``cc.load``),
+matching native CUDA-Q output.
+
+Additionally rewrites function signatures and call sites so that rank-1
+tensor arguments are passed as ``!cc.ptr<!cc.array<T x N>>`` pointers,
+enabling dynamic indexing across function boundaries without copying.
+
+Pipeline within this pass
+-------------------------
+1. **Collect signature rewrites** — determine which functions have rank-1
+   tensor arguments that need conversion to CC array pointers.
+2. **Rewrite function definitions** — change ``tensor<NxT>`` block args to
+   ``!cc.ptr<!cc.array<T x N>>``.
+3. **Process each function body** — materialize local tensor constants into
+   CC arrays (populating an ``array_map``), rewrite tensor access patterns,
+   and rewrite outgoing calls using the populated ``array_map`` so that
+   already-materialized arrays are passed directly (no redundant copies).
+
+Handles both static and dynamic array indexing.
+"""
+
+from xdsl.dialects import arith, func as func_dialect, tensor
+from xdsl.dialects.builtin import (
+    DenseIntOrFPElementsAttr,
+    FloatAttr,
+    FunctionType,
+    IndexType,
+    IntegerAttr,
+    IntegerType,
+    TensorType,
+    Float64Type,
+    Float32Type,
+    Float16Type,
+    i64,
+)
+from xdsl.ir import Block, Region, SSAValue
+from xdsl.rewriter import Rewriter
+
+from qrisp.jasp.mlir.quake_lowering.cc_dialect import (
+    CcAllocaOp,
+    CcArrayType,
+    CcCastOp,
+    CcComputePtrOp,
+    CcLoadOp,
+    CcPtrType,
+    CcStoreOp,
+    CcLoopOp,
+    CcConditionOp,
+    CcContinueOp,
+)
+
+
+# MLIR's sentinel for "dynamic dimension/offset"
+_MLIR_DYNAMIC = -9223372036854775808
+
+
+# ===================================================================
+# Public entry point
+# ===================================================================
+
+
+def lower_ranked_tensors(module) -> None:
+    """In-place pass: lower ranked tensor constants + accesses to CC arrays.
+
+    Pipeline:
+    1. Collect which functions need signature changes (tensor<NxT> → ptr)
+    2. Rewrite function definitions (change block arg types)
+    3. Process each function body (materialize + rewrite accesses + rewrite calls)
+    """
+    # Step 1: Determine which functions need signature changes.
+    func_rewrites = _collect_signature_rewrites(module)
+
+    # Step 2: Rewrite function definitions (tensor args → ptr args).
+    for op in list(module.body.blocks[0].ops):
+        if op.name == "func.func" and op.sym_name.data in func_rewrites:
+            _rewrite_func_def(op, func_rewrites[op.sym_name.data])
+
+    # Step 3: Process each function body (materialize + rewrite + calls).
+    for op in list(module.body.blocks[0].ops):
+        if op.name == "func.func":
+            _process_func(op, func_rewrites)
+
+
+# ===================================================================
+# Step 1: Collect signature rewrites
+# ===================================================================
+
+
+def _collect_signature_rewrites(module) -> dict:
+    """Determine which functions have rank-1 tensor args needing ptr conversion."""
+    func_rewrites = {}
+    for op in list(module.body.blocks[0].ops):
+        if op.name != "func.func":
+            continue
+        ftype = op.function_type
+        rewrites = []
+        for i, inp_type in enumerate(ftype.inputs):
+            if isinstance(inp_type, TensorType) and len(inp_type.get_shape()) == 1:
+                arr_type = CcArrayType(inp_type.element_type, inp_type.get_shape()[0])
+                rewrites.append((i, inp_type, arr_type, CcPtrType(arr_type)))
+        if rewrites:
+            func_rewrites[op.sym_name.data] = rewrites
+    return func_rewrites
+
+
+# ===================================================================
+# Step 2: Rewrite function definitions
+# ===================================================================
+
+
+def _rewrite_func_def(func_op, rewrites: list) -> None:
+    """Change tensor args to ptr args in a function definition."""
+    ftype = func_op.function_type
+    new_inputs = list(ftype.inputs)
+    block = func_op.body.blocks[0]
+
+    for arg_idx, _, _, ptr_type in rewrites:
+        new_inputs[arg_idx] = ptr_type
+        Rewriter.replace_value_with_new_type(block.args[arg_idx], ptr_type)
+
+    func_op.function_type = FunctionType.from_lists(new_inputs, list(ftype.outputs))
+
+
+# ===================================================================
+# Step 3: Process function bodies
+# ===================================================================
+
+
+def _process_func(func_op, func_rewrites: dict) -> None:
+    """Process a function: materialize arrays, rewrite accesses, rewrite calls."""
+    func_array_map: dict[SSAValue, tuple[SSAValue, any, int]] = {}
+    _process_block_recursive(func_op.body, func_array_map, func_rewrites)
+
+
+def _process_block_recursive(region: Region, array_map: dict, func_rewrites: dict) -> None:
+    """Recursively process all blocks."""
+    for block in region.blocks:
+        _process_block(block, array_map)
+        _rewrite_calls_in_block(block, func_rewrites, array_map)
+        # Second dead-constant sweep: call rewriting may have removed the last
+        # use of a tensor constant that Phase 3 inside _process_block couldn't
+        # erase yet (because the call site still held a reference).
+        _erase_dead_tensor_constants(block)
+        for op in list(block.ops):
+            if isinstance(op, CcLoopOp):
+                _rewrite_cc_loop_tensor_args(op, array_map)
+                for nested_region in op.regions:
+                    _process_block_recursive(nested_region, array_map, func_rewrites)
+            else:
+                for nested_region in op.regions:
+                    _process_block_recursive(nested_region, array_map, func_rewrites)
+
+
+def _erase_dead_tensor_constants(block: Block) -> None:
+    """Erase ranked-1 tensor constants that have no remaining uses."""
+    for op in list(block.ops):
+        if (isinstance(op, arith.ConstantOp)
+                and _is_ranked_1_tensor(op.result.type)
+                and not any(op.result.uses)):
+            Rewriter.erase_op(op, safe_erase=False)
+
+
+def _process_block(block: Block, array_map: dict) -> None:
+    """Materialize arrays, rewrite accesses."""
+    # Phase 0: Register ptr-typed block arguments.
+    for arg in block.args:
+        if isinstance(arg.type, CcPtrType) and isinstance(arg.type.element_type, CcArrayType):
+            inner = arg.type.element_type
+            array_map[arg] = (arg, inner.element_type, inner.size.value.data)
+
+    # Phase 1: Materialize ranked tensor constants (only if they have uses).
+    for op in list(block.ops):
+        if isinstance(op, arith.ConstantOp) and _is_ranked_1_tensor(op.result.type):
+            if any(op.result.uses):
+                _materialize_array(op, block, array_map)
+
+    # Phase 2: Rewrite tensor access patterns.
+    for op in list(block.ops):
+        if op.name == "tensor.extract":
+            _rewrite_tensor_extract(op, block, array_map)
+        elif op.name == "tensor.extract_slice":
+            _rewrite_extract_slice_chain(op, block, array_map)
+
+    # Phase 3: Erase dead tensor constants.
+    for op in list(block.ops):
+        if (isinstance(op, arith.ConstantOp)
+                and _is_ranked_1_tensor(op.result.type)
+                and not any(op.result.uses)):
+            Rewriter.erase_op(op, safe_erase=False)
+
+
+# ===================================================================
+# CC Loop tensor arg rewriting
+# ===================================================================
+
+
+def _rewrite_cc_loop_tensor_args(loop_op: CcLoopOp, array_map: dict) -> None:
+    """Rewrite tensor<NxT> loop-carried values in a cc.loop to !cc.ptr<!cc.array<T x N>>.
+
+    The key insight: after the function signature rewrite (Step 2), the init
+    operands to the loop may already have been changed to ptr types, but the
+    loop's internal block arguments still have the old tensor types. We detect
+    this by looking at the **while-region block arg types** (which reflect what
+    the loop was originally created with).
+
+    This updates:
+    - The cc.loop's init operands (replace tensor value with ptr from array_map)
+    - Block args in while, body, and step regions
+    - The cc.loop's result types
+    """
+    # Look at the while-region block args to find which are still tensor types
+    if not loop_op.while_region.blocks:
+        return
+
+    while_block = loop_op.while_region.blocks[0]
+    tensor_arg_indices = []
+    for i, arg in enumerate(while_block.args):
+        if _is_ranked_1_tensor(arg.type):
+            tensor_arg_indices.append(i)
+
+    if not tensor_arg_indices:
+        return
+
+    # For each tensor arg, determine the ptr type and find the source in array_map
+    arguments = list(loop_op.arguments)
+    rewrites = {}  # index -> (ptr_value, ptr_type, elem_type, size)
+    for idx in tensor_arg_indices:
+        # Get the tensor type from the block arg
+        tensor_type = while_block.args[idx].type
+        size = tensor_type.get_shape()[0]
+        elem_type = tensor_type.element_type
+        arr_type = CcArrayType(elem_type, size)
+        ptr_type = CcPtrType(arr_type)
+
+        # The init operand may already be a ptr (if the function arg was rewritten)
+        init_val = arguments[idx]
+        if isinstance(init_val.type, CcPtrType) and isinstance(init_val.type.element_type, CcArrayType):
+            # Already a ptr — use it directly
+            ptr_val = init_val
+        elif init_val in array_map:
+            ptr_val = array_map[init_val][0]
+        else:
+            # Try to find it by identity in array_map
+            ptr_val = None
+            for mapped_tensor, (mapped_ptr, _, _) in array_map.items():
+                if mapped_tensor is init_val:
+                    ptr_val = mapped_ptr
+                    break
+            if ptr_val is None:
+                # Cannot find a ptr for this tensor - skip
+                continue
+
+        rewrites[idx] = (ptr_val, ptr_type, elem_type, size)
+
+    if not rewrites:
+        return
+
+    # 1. Update the init operands of the cc.loop
+    new_arguments = list(loop_op.arguments)
+    for idx, (ptr_val, ptr_type, elem_type, size) in rewrites.items():
+        new_arguments[idx] = ptr_val
+    loop_op.operands = new_arguments
+
+    # 2. Update block args in all three regions (while, body, step)
+    for region in loop_op.regions:
+        if not region.blocks:
+            continue
+        block = region.blocks[0]
+        for idx, (ptr_val, ptr_type, elem_type, size) in rewrites.items():
+            if idx < len(block.args):
+                old_arg = block.args[idx]
+                Rewriter.replace_value_with_new_type(old_arg, ptr_type)
+                # Register in array_map so nested accesses can find it
+                array_map[old_arg] = (old_arg, elem_type, size)
+
+    # 3. Update the cc.loop's result types
+    for idx, (ptr_val, ptr_type, elem_type, size) in rewrites.items():
+        if idx < len(loop_op.res):
+            res = loop_op.res[idx]
+            Rewriter.replace_value_with_new_type(res, ptr_type)
+            # Register the loop result in array_map too
+            array_map[res] = (res, elem_type, size)
+
+
+# ===================================================================
+# Call rewriting (uses array_map — no redundant copies)
+# ===================================================================
+
+
+def _rewrite_calls_in_block(block: Block, func_rewrites: dict, array_map: dict) -> None:
+    """Rewrite func.call ops, passing existing CC arrays from array_map."""
+    for op in list(block.ops):
+        if not isinstance(op, func_dialect.CallOp):
+            continue
+        callee = op.callee.string_value()
+        if callee not in func_rewrites:
+            continue
+
+        new_operands = list(op.operands)
+        for arg_idx, old_type, arr_type, _ in func_rewrites[callee]:
+            tensor_val = op.operands[arg_idx]
+            if tensor_val in array_map:
+                new_operands[arg_idx] = array_map[tensor_val][0]
+            else:
+                new_operands[arg_idx] = _materialize_tensor_value(
+                    tensor_val, old_type, arr_type, block, op
+                )
+
+        new_call = func_dialect.CallOp(op.callee, new_operands, list(op.result_types))
+        block.insert_ops_before([new_call], op)
+        for old_res, new_res in zip(op.results, new_call.results):
+            old_res.replace_by(new_res)
+        Rewriter.erase_op(op, safe_erase=False)
+
+
+# ===================================================================
+# Helpers
+# ===================================================================
+
+
+def _is_ranked_1_tensor(t) -> bool:
+    return isinstance(t, TensorType) and len(t.get_shape()) == 1
+
+
+def _cast_index_to_i64(val: SSAValue, block: Block, insert_before) -> SSAValue:
+    if isinstance(val.type, IndexType):
+        cast = arith.IndexCastOp(val, i64)
+        block.insert_ops_before([cast], insert_before)
+        return cast.result
+    return val
+
+
+def _emit_load_from_array(arr_ptr, index, elem_type, block, insert_before):
+    """Emit cc.compute_ptr + cc.load."""
+    if isinstance(index, SSAValue):
+        index = _cast_index_to_i64(index, block, insert_before)
+    ptr = CcComputePtrOp(arr_ptr, index, elem_type)
+    load = CcLoadOp(ptr.result)
+    block.insert_ops_before([ptr, load], insert_before)
+    return load.result
+
+
+def _make_scalar_const(value, elem_type):
+    if isinstance(elem_type, (Float64Type, Float32Type, Float16Type)):
+        return arith.ConstantOp(FloatAttr(float(value), elem_type))
+    return arith.ConstantOp(IntegerAttr(int(value), elem_type))
+
+
+# ===================================================================
+# Array materialization
+# ===================================================================
+
+
+def _materialize_array(const_op, block: Block, array_map: dict) -> None:
+    """Replace a ranked tensor constant with cc.alloca + stores."""
+    values = _get_dense_values(const_op)
+    if values is None:
+        return
+
+    result_type = const_op.result.type
+    size = result_type.get_shape()[0]
+    elem_type = result_type.element_type
+    arr_type = CcArrayType(elem_type, size)
+
+    alloca = CcAllocaOp(arr_type)
+    block.insert_ops_before([alloca], const_op)
+
+    for i, val in enumerate(values):
+        scalar_const = _make_scalar_const(val, elem_type)
+        block.insert_ops_before([scalar_const], const_op)
+        if i == 0:
+            cast = CcCastOp(alloca.result, CcPtrType(elem_type))
+            block.insert_ops_before([cast], const_op)
+            store = CcStoreOp(scalar_const.result, cast.result)
+        else:
+            ptr = CcComputePtrOp(alloca.result, i, elem_type)
+            block.insert_ops_before([ptr], const_op)
+            store = CcStoreOp(scalar_const.result, ptr.result)
+        block.insert_ops_before([store], const_op)
+
+    array_map[const_op.result] = (alloca.result, elem_type, size)
+
+
+def _materialize_tensor_value(
+    tensor_val: SSAValue,
+    tensor_type: TensorType,
+    arr_type: CcArrayType,
+    block: Block,
+    insert_before,
+) -> SSAValue:
+    """Materialize a non-constant tensor into a CC array (fallback)."""
+    size = tensor_type.get_shape()[0]
+    elem_type = tensor_type.element_type
+
+    alloca = CcAllocaOp(arr_type)
+    block.insert_ops_before([alloca], insert_before)
+
+    for i in range(size):
+        idx = arith.ConstantOp(IntegerAttr(i, i64))
+        extract = tensor.ExtractOp(tensor_val, [idx.result], elem_type)
+        block.insert_ops_before([idx, extract], insert_before)
+        if i == 0:
+            cast = CcCastOp(alloca.result, CcPtrType(elem_type))
+            block.insert_ops_before([cast], insert_before)
+            store = CcStoreOp(extract.result, cast.result)
+        else:
+            ptr = CcComputePtrOp(alloca.result, i, elem_type)
+            block.insert_ops_before([ptr], insert_before)
+            store = CcStoreOp(extract.result, ptr.result)
+        block.insert_ops_before([store], insert_before)
+
+    return alloca.result
+
+
+def _get_dense_values(const_op):
+    if not isinstance(const_op.value, DenseIntOrFPElementsAttr):
+        return None
+    try:
+        return list(const_op.value.iter_values())
+    except (AttributeError, TypeError):
+        return None
+
+
+# ===================================================================
+# Access pattern rewriting
+# ===================================================================
+
+
+def _rewrite_tensor_extract(extract_op, block: Block, array_map: dict) -> None:
+    """Rewrite ranked tensor.extract → cc.compute_ptr + cc.load."""
+    source = extract_op.tensor
+    indices = list(extract_op.indices)
+    if not indices or source not in array_map:
+        return
+    arr_ptr, elem_type, _ = array_map[source]
+    loaded = _emit_load_from_array(arr_ptr, indices[0], elem_type, block, extract_op)
+    extract_op.result.replace_by(loaded)
+    Rewriter.erase_op(extract_op, safe_erase=False)
+
+
+def _rewrite_extract_slice_chain(slice_op, block: Block, array_map: dict) -> None:
+    source = slice_op.operands[0]
+    if source not in array_map:
+        return
+    arr_ptr, elem_type, _ = array_map[source]
+
+    offset = _get_static_offset(slice_op)
+    
+    # Find collapse_shape users (in practice always exactly one)
+    collapse_ops = _find_all_users(slice_op.results[0], "tensor.collapse_shape")
+    if not collapse_ops:
+        return
+
+    for collapse_op in collapse_ops:
+        # Find ALL tensor.extract users of this collapse_shape result
+        extract_ops = _find_all_users(collapse_op.results[0], "tensor.extract")
+        if not extract_ops:
+            continue
+
+        for extract_op in extract_ops:
+            if offset is not None:
+                loaded = _emit_load_from_array(arr_ptr, offset, elem_type, block, extract_op)
+            else:
+                dynamic_offsets = list(slice_op.offsets)
+                if not dynamic_offsets:
+                    continue
+                loaded = _emit_load_from_array(arr_ptr, dynamic_offsets[0], elem_type, block, extract_op)
+
+            extract_op.result.replace_by(loaded)
+            Rewriter.erase_op(extract_op, safe_erase=False)
+
+        if not any(collapse_op.results[0].uses):
+            Rewriter.erase_op(collapse_op, safe_erase=False)
+
+    if not any(slice_op.results[0].uses):
+        Rewriter.erase_op(slice_op, safe_erase=False)
+
+
+def _find_all_users(value: SSAValue, op_name: str) -> list:
+    """Find all users of a value with the given operation name.
+
+    Returns a list of operations (may be empty).
+    """
+    results = []
+    for use in value.uses:
+        if use.operation.name == op_name:
+            if use.operation not in results:
+                results.append(use.operation)
+    return results
+
+
+def _get_static_offset(slice_op) -> int | None:
+    """Extract the static offset from a tensor.extract_slice op.
+
+    Returns None if the offset is dynamic (sentinel value i64::MIN).
+    """
+    values = list(slice_op.static_offsets.get_values())
+    if values and values[0] != _MLIR_DYNAMIC:
+        return int(values[0])
+    return None

--- a/tests/jax_tests/test_composite_gate_interpreter.py
+++ b/tests/jax_tests/test_composite_gate_interpreter.py
@@ -175,3 +175,44 @@ def test_decompose_nested_jaspr():
     # The jaspr must still be executable
     result = decomposed()
     assert result is not None
+
+
+def test_call_graph_compression_preserved():
+    """When the same @qache function is called twice, both jit equations in the
+    original jaspr share the exact same ClosedJaxpr object (call-graph compression).
+    After decompose_composite_gates, the two jit equations in the decomposed jaspr
+    must still reference the same ClosedJaxpr object — not two distinct copies."""
+
+    @qache
+    def test(qv):
+        prepare(qv, np.array([0.2, 0.4, 0.7, 0.5]))
+
+    def main():
+        qv = QuantumFloat(2)
+        test(qv)
+        test(qv)
+        return measure(qv)
+
+    jaspr = make_jaspr(main)()
+
+    # Collect the ClosedJaxpr objects from all top-level jit equations
+    def _jit_jaxprs(jaxpr):
+        return [
+            eqn.params["jaxpr"]
+            for eqn in jaxpr.eqns
+            if eqn.primitive.name == "jit"
+        ]
+
+    orig_jaxprs = _jit_jaxprs(jaspr)
+    assert len(orig_jaxprs) >= 2
+    # Verify that the original already shares the same object
+    assert orig_jaxprs[0] is orig_jaxprs[1]
+
+    decomposed = decompose_composite_gates(jaspr)
+
+    decomp_jaxprs = _jit_jaxprs(decomposed)
+    assert len(decomp_jaxprs) >= 2
+    assert decomp_jaxprs[0] is decomp_jaxprs[1]
+
+    # Correctness: decomposed jaspr must still produce the same distribution
+    assert_same_distribution(jaspr, decomposed)

--- a/tests/jax_tests/test_composite_gate_interpreter.py
+++ b/tests/jax_tests/test_composite_gate_interpreter.py
@@ -17,6 +17,8 @@
 """
 
 import numpy as np
+import jax.numpy as jnp
+import jax.lax as lax
 from qrisp import *
 from qrisp.jasp import make_jaspr
 from qrisp.jasp.interpreter_tools import decompose_composite_gates
@@ -54,6 +56,11 @@ def _collect_gates_from_jaxpr(jaxpr):
             for branch in eqn.params["branches"]:
                 inner = branch.jaxpr if isinstance(branch, ClosedJaxpr) else branch
                 yield from _collect_gates_from_jaxpr(inner)
+
+        elif eqn.primitive.name == "scan":
+            sub = eqn.params["jaxpr"]
+            inner = sub.jaxpr if isinstance(sub, ClosedJaxpr) else sub
+            yield from _collect_gates_from_jaxpr(inner)
 
 
 def assert_no_composite_gates(jaspr):
@@ -216,3 +223,44 @@ def test_call_graph_compression_preserved():
 
     # Correctness: decomposed jaspr must still produce the same distribution
     assert_same_distribution(jaspr, decomposed)
+
+
+def test_decompose_scan_body():
+    """Qrisp code called inside a jax.lax.scan body must also be decomposed.
+    A @quantum_kernel using prepare() introduces a composite gate inside the
+    scan body jaxpr.  decompose_composite_gates must recurse into it."""
+
+    @quantum_kernel
+    def random_number():
+        qv = QuantumFloat(2)
+        prepare(qv, np.array([0.3, 0.7, 0.2, 0.8]))
+        return measure(qv)
+
+    def main():
+        def scan_body(carry, x):
+            rnd = random_number()
+            return carry + x + rnd, carry + x + rnd
+
+        xs = jnp.array([1, 2, 3, 4, 5])
+        final_carry, cumulative_sums = lax.scan(scan_body, 0, xs)
+        return final_carry, cumulative_sums
+
+    jaspr = make_jaspr(main)()
+
+    # Confirm a scan equation is present at the top level
+    scan_eqns = [e for e in jaspr.eqns if e.primitive.name == "scan"]
+    assert len(scan_eqns) >= 1
+
+    # Confirm the scan body contains composite gates before decomposition
+    all_gates = list(_collect_gates_from_jaxpr(jaspr))
+    assert any(g.definition is not None for g in all_gates)
+
+    decomposed = decompose_composite_gates(jaspr)
+
+    # After decomposition no composite gates must remain anywhere, including
+    # inside the scan body
+    assert_no_composite_gates(decomposed)
+
+    # The decomposed jaspr must still be executable and return sensible values
+    result = decomposed()
+    assert result is not None

--- a/tests/jax_tests/test_composite_gate_interpreter.py
+++ b/tests/jax_tests/test_composite_gate_interpreter.py
@@ -1,0 +1,177 @@
+"""
+********************************************************************************
+* Copyright (c) 2026 the Qrisp authors
+*
+* This program and the accompanying materials are made available under the
+* terms of the Eclipse Public License 2.0 which is available at
+* http://www.eclipse.org/legal/epl-2.0.
+*
+* This Source Code may also be made available under the following Secondary
+* Licenses when the conditions for such availability set forth in the Eclipse
+* Public License, v. 2.0 are satisfied: GNU General Public License, version 2
+* with the GNU Classpath Exception which is
+* available at https://www.gnu.org/software/classpath/license.html.
+*
+* SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+********************************************************************************
+"""
+
+import numpy as np
+from qrisp import *
+from qrisp.jasp import make_jaspr
+from qrisp.jasp.interpreter_tools import decompose_composite_gates
+from qrisp.jasp.primitives import quantum_gate_p
+
+
+# ---------------------------------------------------------------------------
+# Helper: walk all equations in a jaspr (top-level only; sub-jaxprs in jit/
+# while/cond are inspected recursively) and collect gate objects.
+# ---------------------------------------------------------------------------
+
+def _collect_gates_from_jaxpr(jaxpr):
+    """Yield every gate object found in quantum_gate_p equations, recursing
+    into jit/while/cond sub-jaxprs."""
+    from jax.extend.core import ClosedJaxpr
+    from qrisp.jasp import Jaspr
+
+    for eqn in jaxpr.eqns:
+        if eqn.primitive == quantum_gate_p:
+            yield eqn.params["gate"]
+
+        # Recurse into sub-jaxprs carried by control-flow primitives
+        if eqn.primitive.name == "jit":
+            sub = eqn.params["jaxpr"]
+            inner = sub.jaxpr if isinstance(sub, ClosedJaxpr) else sub
+            yield from _collect_gates_from_jaxpr(inner)
+
+        elif eqn.primitive.name == "while":
+            for key in ("body_jaxpr", "cond_jaxpr"):
+                sub = eqn.params[key]
+                inner = sub.jaxpr if isinstance(sub, ClosedJaxpr) else sub
+                yield from _collect_gates_from_jaxpr(inner)
+
+        elif eqn.primitive.name == "cond":
+            for branch in eqn.params["branches"]:
+                inner = branch.jaxpr if isinstance(branch, ClosedJaxpr) else branch
+                yield from _collect_gates_from_jaxpr(inner)
+
+
+def assert_no_composite_gates(jaspr):
+    """Assert that all gates in the jaspr are primitive (definition is None)."""
+    for gate in _collect_gates_from_jaxpr(jaspr):
+        assert gate.definition is None, (
+            f"Gate '{gate.name}' still has a composite definition after decomposition."
+        )
+
+
+def assert_same_distribution(jaspr_a, jaspr_b):
+    """Assert that two jasprs produce identical exact probability distributions
+    via to_qc().run() (no shots), compared with np.allclose."""
+    _, qc_a = jaspr_a.to_qc()
+    _, qc_b = jaspr_b.to_qc()
+    probs_a = qc_a.run()
+    probs_b = qc_b.run()
+    assert set(probs_a.keys()) == set(probs_b.keys()), (
+        f"Outcome sets differ: {set(probs_a.keys())} vs {set(probs_b.keys())}"
+    )
+    keys = sorted(probs_a.keys())
+    assert np.allclose(
+        [probs_a[k] for k in keys],
+        [probs_b[k] for k in keys],
+    ), f"Probability distributions differ:\n  original:   {probs_a}\n  decomposed: {probs_b}"
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+def test_decompose_state_preparation():
+    """prepare() inserts a state_init composite gate.  After decomposition,
+    no composite gates should remain and the output distribution should be
+    unchanged."""
+
+    def main():
+        qv = QuantumFloat(2)
+        prepare(qv, np.array([0.2, 0.4, 0.7, 0.5]))
+        return measure(qv)
+
+    jaspr = make_jaspr(main)()
+
+    # Verify that the original jaspr contains at least one composite gate
+    all_gates = list(_collect_gates_from_jaxpr(jaspr))
+    assert any(g.definition is not None for g in all_gates), (
+        "Expected at least one composite gate in the original jaspr."
+    )
+
+    decomposed = decompose_composite_gates(jaspr)
+
+    assert_no_composite_gates(decomposed)
+    assert_same_distribution(jaspr, decomposed)
+
+
+def test_decompose_mcx():
+    """mcx with control_amount > 1 produces a composite gate.  After
+    decomposition the circuit must contain only primitive gates and give
+    the correct deterministic measurement outcome."""
+
+    def main():
+        qv = QuantumFloat(4)
+        x(qv[0])
+        x(qv[1])
+        x(qv[2])
+        mcx([qv[0], qv[1], qv[2]], qv[3])
+        return measure(qv)
+
+    jaspr = make_jaspr(main)()
+
+    # Sanity-check: original has composite gates
+    all_gates = list(_collect_gates_from_jaxpr(jaspr))
+    assert any(g.definition is not None for g in all_gates)
+
+    decomposed = decompose_composite_gates(jaspr)
+
+    assert_no_composite_gates(decomposed)
+    assert_same_distribution(jaspr, decomposed)
+
+
+def test_decompose_cx_is_noop():
+    """cx is already a primitive gate (definition is None).  The decomposition
+    pass must leave it untouched and the circuit must still be correct."""
+
+    def main():
+        qv = QuantumVariable(2)
+        h(qv[0])
+        cx(qv[0], qv[1])
+        return measure(qv)
+
+    jaspr = make_jaspr(main)()
+
+    decomposed = decompose_composite_gates(jaspr)
+
+    assert_no_composite_gates(decomposed)
+    assert_same_distribution(jaspr, decomposed)
+
+
+def test_decompose_nested_jaspr():
+    """BlockEncoding introduces deeply nested sub-jasprs containing composite
+    gates.  The decomposition must recurse into jit/while/cond sub-jaxprs."""
+
+    from qrisp.operators import X, Y, Z
+    from qrisp.block_encodings import BlockEncoding
+
+    H_op = X(0) * X(1) + Y(0) * Y(1) + Z(0) * Z(1)
+    BE = BlockEncoding.from_operator(H_op)
+
+    def main():
+        qv = QuantumFloat(2)
+        ancs = BE.apply(qv)
+        return measure(qv)
+
+    jaspr = make_jaspr(main)()
+    decomposed = decompose_composite_gates(jaspr)
+
+    assert_no_composite_gates(decomposed)
+
+    # The jaspr must still be executable
+    result = decomposed()
+    assert result is not None


### PR DESCRIPTION
## Description

Introduces a new Jasp interpreter pass `decompose_composite_gates` that recursively inlines all composite (non-primitive) quantum gates in a `Jaspr` into their primitive constituents. A composite gate is any `Operation` whose `.definition` attribute holds a sub-circuit. The pass traverses not only top-level equations but also sub-jaxprs nested inside `jit`, `while`, `cond`, and `scan` control-flow primitives, making it applicable to complex programs.

Call-graph compression is preserved: if multiple `jit` equations in the original jaspr reference the same `ClosedJaxpr` object (as produced by `@qache`), the decomposed jaspr ensures they still reference the same transformed object — not independent copies — by caching results via `@lru_cache`.

## Related Issues

Closes #550
Related to #

## Type of Change

- [x] Feature (new functionality)
- [ ] Change Request (modification of existing functionality)
- [ ] Bug Fix
- [ ] Refactoring (no behavior change)
- [ ] Performance improvement
- [ ] Documentation
- [ ] CI / Build

## Breaking Change?
- [ ] Yes
- [x] No

## What was changed?

- Added `composite_gate_interpreter.py` — new interpreter module containing:
  - `_apply_op(op, qubit_tracers, abs_qst)`: recursively inlines a gate by walking its `.definition` circuit and rebinding each sub-instruction via `quantum_gate_p`
  - `decompose_eqn_evaluator(eqn, context_dic)`: `reinterpret`-compatible evaluator that decomposes composite `quantum_gate_p` equations and recursively applies the transformation to `jit`/`while`/`cond`/`scan` sub-jaxprs
  - `_decompose_sub_jaxpr(jaxpr)`: cached helper (`@lru_cache`) to apply the pass to both `Jaspr` and `ClosedJaxpr` sub-expressions; caching ensures shared sub-jaxpr objects remain shared after transformation
  - `decompose_composite_gates(jaspr)`: public API (`@lru_cache`) — returns a new `Jaspr` with all composite gates inlined
- Updated `__init__.py` to export the new module
- Added test_composite_gate_interpreter.py with a full test suite

## How was it tested?

| Test-ID | Description | Status |
|---------|-------------|--------|
| T-001 | `test_decompose_state_preparation` — `prepare()` introduces a `state_init` composite gate; verifies it is absent after decomposition and that exact output probabilities match the original via `to_qc().run()` + `np.allclose` | ✅ |
| T-002 | `test_decompose_mcx` — multi-controlled X is a composite gate; verifies decomposition and identical deterministic output distribution | ✅ |
| T-003 | `test_decompose_cx_is_noop` — `cx` is already primitive; verifies the pass is a no-op and the Bell-state distribution is preserved | ✅ |
| T-004 | `test_decompose_nested_jaspr` — `BlockEncoding` with deeply nested `jit`/`while`/`cond` sub-jaxprs; verifies full recursive decomposition and that the resulting jaspr remains executable | ✅ |
| T-005 | `test_call_graph_compression_preserved` — two calls to the same `@qache` function share one `ClosedJaxpr` object in the original; verifies the decomposed jaspr maintains that identity (`is` check), confirming call-graph compression is not destroyed | ✅ |
| T-006 | `test_decompose_scan_body` — a `@quantum_kernel` using `prepare()` is called inside a `jax.lax.scan` body; verifies the composite gate inside the scan body jaxpr is decomposed and the result remains executable | ✅ |

## Checklist
- [x] My code follows the project's coding standards
- [x] I have performed a self-review
- [x] I have added/updated tests (referencing issue Test-IDs)
- [x] All tests pass locally and in CI
- [ ] I have updated the documentation
- [ ] I have added a changelog entry
- [ ] Breaking changes are documented with migration path

## Reviewer Notes

The key design decision is that `decompose_eqn_evaluator` explicitly handles `jit`, `while`, `cond`, and `scan` by patching their embedded sub-jaxprs before re-executing — following the same pattern used in `environment_flattening.py`. Without this, composite gates inside control-flow bodies would be silently left undecomposed.

Call-graph compression is preserved via `@lru_cache` on both `_decompose_sub_jaxpr` and `decompose_composite_gates`, keyed by object identity — matching the pattern used in `get_traced_fun` in catalyst_interpreter.py. Without caching, two `jit` equations referencing the same `ClosedJaxpr` would each receive a distinct copy after transformation, defeating the structural sharing that downstream passes (e.g. XLA's `flatten-call-graph`) rely on to avoid compilation explosion.