### PR TITLE
Fix minor typo in `q_fori_loop` example

### DIFF
--- a/src/qrisp/jasp/program_control/prefix_control.py
+++ b/src/qrisp/jasp/program_control/prefix_control.py
@@ -212,7 +212,7 @@ def q_fori_loop(lower, upper, body_fun, init_val):
 
             return acc, measure(qf)
 
-        print(main(k))
+        print(main(5))
         # Yields:
         # (Array(5, dtype=int64), Array(31., dtype=float64))
 


### PR DESCRIPTION
## Description

<!-- What does this PR do? Keep it concise. -->

The example available in the [docs](https://qrisp.eu/reference/Jasp/Control%20Flow/Prefix%20Control.html#qrisp.jasp.q_fori_loop) fails with `NameError: name `k` is not defined`. 

## Related Issues

<!-- Link related issues. Use closing keywords to auto-close them on merge. -->
Closes #
Related to #

## Type of Change

<!-- Check all that apply -->
- [ ] Feature (new functionality)
- [ ] Change Request (modification of existing functionality)
- [x] Bug Fix
- [ ] Refactoring (no behavior change)
- [ ] Performance improvement
- [x] Documentation
- [ ] CI / Build

## Breaking Change?
- [ ] Yes
- [x] No

If yes, describe the impact and migration path:


## What was changed?

<!-- Bullet list of concrete changes -->
-
-

## How was it tested?

<!-- Optional - Reference Test-IDs from the linked issue(s) and describe any additional testing. -->

| Test-ID | Status |
|---------|--------|
| T-001   | ✅ / ❌ |
| T-002   | ✅ / ❌ |
| T-003   | ✅ / ❌ |
| T-004   | ✅ / ❌ |

## Screenshots / Output (if applicable)

<!-- Add additional information if it helps -->

## Checklist
- [ ] My code follows the project's coding standards
- [ ] I have performed a self-review
- [ ] I have added/updated tests (referencing issue Test-IDs)
- [ ] All tests pass locally and in CI
- [ ] I have updated the documentation
- [ ] I have added a changelog entry
- [ ] Breaking changes are documented with migration path

## Reviewer Notes

<!-- Anything specific the reviewer should focus on? -->