### PR TITLE
Decompose composite gates for mlir emission

### DIFF
--- a/src/qrisp/jasp/mlir/mlir_emission.py
+++ b/src/qrisp/jasp/mlir/mlir_emission.py
@@ -20,13 +20,15 @@
 Utilities to lower a JAXPR produced by Qrisp to MLIR using the JASP dialect
 and convert it into an xDSL module for downstream transformations.
 
-Two key steps happen here:
-1) Lower JAX primitives to our custom JASP dialect (via ``jaxpr_to_xdsl`` and ``jasp_lowering_rules``).
-2) Run xDSL-based rewrites (e.g., control-flow fixes for quantum types).
+Three key steps happen here:
+1) Decompose composite gates in the Jaspr into their constituent gates (via ``decompose_composite_gates``).
+2) Lower JAX primitives to our custom JASP dialect (via ``jaxpr_to_xdsl`` and ``jasp_lowering_rules``).
+3) Run xDSL-based rewrites (e.g., control-flow fixes for quantum types).
 """
 
 from xdsl.dialects import builtin
 
+from qrisp.jasp.interpreter_tools.interpreters.composite_gate_interpreter import decompose_composite_gates
 from qrisp.jasp.mlir.jaxpr_lowering import jaxpr_to_xdsl
 from qrisp.jasp.mlir.jasp_lowering_rules import jasp_lowering_rules
 from qrisp.jasp.mlir.quantum_control_flow import fix_quantum_control_flow
@@ -36,7 +38,8 @@ from qrisp.jasp.jasp_expression import Jaspr
 
 def jaspr_to_mlir(jaspr: Jaspr) -> builtin.ModuleOp:
 
-    xdsl_module = jaxpr_to_xdsl(jaspr, lowering_rules=jasp_lowering_rules)
+    jaspr_no_composite_gates = decompose_composite_gates(jaspr)
+    xdsl_module = jaxpr_to_xdsl(jaspr_no_composite_gates, lowering_rules=jasp_lowering_rules)
     fix_quantum_control_flow(xdsl_module)
 
     return xdsl_module


### PR DESCRIPTION
## Description

Before lowering a `Jaspr` to MLIR, composite gates must be expanded into their constituent primitive gates. Without this step, composite gates (custom multi-gate operations wrapped as a single `jit`-traced primitive) pass through to the MLIR emitter un-decomposed, causing incorrect or incomplete MLIR output.

This PR adds a `decompose_composite_gates` pass as the first step in `jaspr_to_mlir`, ensuring all composite gates are recursively expanded before JAXPR-to-xDSL lowering takes place.

## Related Issues

<!-- Link related issues. Use closing keywords to auto-close them on merge. -->
Closes #
Related to #

## Type of Change

<!-- Check all that apply -->
- [ ] Feature (new functionality)
- [x] Bug Fix
- [ ] Change Request (modification of existing functionality)
- [ ] Refactoring (no behavior change)
- [ ] Performance improvement
- [ ] Documentation
- [ ] CI / Build

## Breaking Change?
- [ ] Yes
- [x] No

If yes, describe the impact and migration path:


## What was changed?

- `src/qrisp/jasp/mlir/mlir_emission.py`: Added a `decompose_composite_gates` pass before `jaxpr_to_xdsl` in `jaspr_to_mlir`. The function now decomposes composite gates from the input `Jaspr` into a flat representation before MLIR lowering, and updated the module docstring to reflect the new three-step pipeline.

## How was it tested?

The existing `tests/jax_tests/test_composite_gate_interpreter.py` test suite covers `decompose_composite_gates` across multiple scenarios (basic decomposition, nested composites, control flow, scan bodies). The existing `tests/jax_tests/test_mlir.py` (`test_mlir_generation`) exercises the full `jaspr_to_mlir` pipeline end-to-end, which now implicitly validates the decomposition step on realistic circuits.

| Test-ID | Status |
|---------|--------|
| `test_composite_gate_interpreter.py` | ✅ |
| `test_mlir.py::test_mlir_generation` | ✅ |

## Screenshots / Output (if applicable)

<!-- Add additional information if it helps -->

## Checklist
- [x] My code follows the project's coding standards
- [x] I have performed a self-review
- [ ] I have added/updated tests (referencing issue Test-IDs)
- [x] All tests pass locally and in CI
- [x] I have updated the documentation
- [ ] I have added a changelog entry
- [x] Breaking changes are documented with migration path

## Reviewer Notes

The only changed file is `mlir_emission.py`. The `decompose_composite_gates` function already existed and is well-tested independently; this PR merely wires it into the MLIR emission pipeline at the right point.