### PR TITLE
Fix composite gate interpreter and MLIR lowering

### DIFF
--- a/src/qrisp/jasp/interpreter_tools/interpreters/composite_gate_interpreter.py
+++ b/src/qrisp/jasp/interpreter_tools/interpreters/composite_gate_interpreter.py
@@ -22,6 +22,14 @@ from jax.extend.core import JaxprEqn
 
 from qrisp.jasp.interpreter_tools import exec_eqn, reinterpret, extract_invalues, insert_outvalues
 from qrisp.jasp.primitives import quantum_gate_p
+from qrisp.jasp.primitives.operation_primitive import greek_letters as _greek_letters
+
+# quantum_gate_p.append_impl binds runtime parameter slot i to greek_letters[i].
+# When a decomposed primitive gate uses only a subset of the parent symbols
+# (for example a sub-gate depending only on beta), we must first recover the
+# symbols in canonical greek_letters order and then remap them to a dense
+# prefix alpha, beta, ... before binding the tracers positionally.
+_greek_letter_order = {sym: i for i, sym in enumerate(_greek_letters)}
 
 
 def _copy_eqn(eqn):
@@ -36,21 +44,52 @@ def _copy_eqn(eqn):
     )
 
 
-def _apply_op(op, qubit_tracers, abs_qst):
+def _apply_op(op, qubit_tracers, abs_qst, param_dict=None):
     """Recursively inline a gate.
 
     - Primitive gates (op.definition is None) are bound directly via quantum_gate_p.
     - Composite gates are expanded by iterating their definition circuit and
       recursively calling _apply_op for each sub-instruction.
+
+    param_dict maps the sympy symbols that appear in sub-gate param expressions
+    (i.e. the parent gate's abstract params) to their corresponding JAX tracers.
     """
+    if param_dict is None:
+        param_dict = {}
+
     if op.definition is None:
-        return quantum_gate_p.bind(*qubit_tracers, abs_qst, gate=op)
+        if op.abstract_params and param_dict:
+            # Recover the gate's free symbols in the same canonical order used
+            # when traced operations are constructed: alpha, beta, gamma, ...
+            # The order matters because append_impl later substitutes the
+            # incoming parameter tracers positionally into greek_letters[i].
+            sorted_syms = sorted(
+                op.abstract_params,
+                key=lambda s: _greek_letter_order.get(s, len(_greek_letters)),
+            )
+            # Re-index the gate onto a dense greek-letter prefix. This is the
+            # critical step for sparse subsets such as {beta}: we normalize
+            # beta -> alpha so that passing a single tracer still lands in slot 0.
+            # The symbolic expressions themselves stay intact under this rename,
+            # e.g. rz(beta) becomes rz(alpha) and -beta/2 becomes -alpha/2.
+            remap = {sym: _greek_letters[i] for i, sym in enumerate(sorted_syms)}
+            normalized_op = op.bind_parameters(remap)
+            # Pass one tracer per normalized symbol in the same positional order.
+            # We intentionally forward the raw tracers here; append_impl and
+            # bind_parameters still need to evaluate the gate's sympy expression
+            # (for example -alpha/2) at concrete execution time.
+            param_tracer_list = [param_dict[sym] for sym in sorted_syms]
+            return quantum_gate_p.bind(
+                *qubit_tracers, *param_tracer_list, abs_qst, gate=normalized_op
+            )
+        else:
+            return quantum_gate_p.bind(*qubit_tracers, abs_qst, gate=op)
 
     defn = op.definition.transpile()
     for instr in defn.data:
         qubit_indices = [defn.qubits.index(qb) for qb in instr.qubits]
         sub_qubits = [qubit_tracers[i] for i in qubit_indices]
-        abs_qst = _apply_op(instr.op, sub_qubits, abs_qst)
+        abs_qst = _apply_op(instr.op, sub_qubits, abs_qst, param_dict=param_dict)
 
     return abs_qst
 
@@ -72,8 +111,14 @@ def decompose_eqn_evaluator(eqn, context_dic):
         invalues = extract_invalues(eqn, context_dic)
         qubit_tracers = invalues[: gate.num_qubits]
         abs_qst = invalues[-1]
+        param_tracers = invalues[gate.num_qubits : -1]
 
-        abs_qst = _apply_op(gate, qubit_tracers, abs_qst)
+        # Preserve the parent gate's symbol -> tracer association so primitive
+        # sub-gates can recover the correct tracer even when they reference only
+        # a subset of the parent's parameters.
+        param_dict = {gate.params[i]: param_tracers[i] for i in range(len(param_tracers))}
+
+        abs_qst = _apply_op(gate, qubit_tracers, abs_qst, param_dict=param_dict)
         insert_outvalues(eqn, context_dic, abs_qst)
         return False  # equation handled; skip default exec_eqn
 

--- a/src/qrisp/jasp/mlir/jasp_lowering_rules.py
+++ b/src/qrisp/jasp/mlir/jasp_lowering_rules.py
@@ -16,6 +16,9 @@
 ********************************************************************************
 """
 
+import numpy as np
+from sympy import Add, Expr, Mul, Pow
+
 from qrisp.jasp.primitives import (
     create_qubits_p,
     get_qubit_p,
@@ -33,12 +36,15 @@ from qrisp.jasp.primitives import (
     AbstractQubitArray,
     AbstractQubit,
 )
+from qrisp.jasp.primitives.operation_primitive import greek_letters as _greek_letters
 
 
 import qrisp.jasp.mlir.dialect_implementation._jasp_ops_gen as jasp_dialect
 
+from jax.interpreters import mlir as jax_mlir
 from jax.interpreters.mlir import ir_type_handlers
 from jaxlib.mlir import ir
+from jaxlib.mlir.dialects import stablehlo
 
 ##########################
 # Register type lowering #
@@ -91,6 +97,104 @@ def _aqb_lowering(aval):
 ir_type_handlers[AbstractQuantumState] = _aqc_lowering
 ir_type_handlers[AbstractQubitArray] = _aqa_lowering
 ir_type_handlers[AbstractQubit] = _aqb_lowering
+
+
+_greek_letter_order = {sym: i for i, sym in enumerate(_greek_letters)}
+
+
+def _as_ir_value(value):
+    if isinstance(value, (tuple, list)):
+        if len(value) != 1:
+            raise ValueError(f"Expected a single MLIR value, got {len(value)} values")
+        return value[0]
+    return value
+
+
+def _sorted_param_symbols(param_exprs):
+    symbols = set()
+    for expr in param_exprs:
+        if isinstance(expr, Expr):
+            symbols.update(expr.free_symbols)
+    return sorted(symbols, key=lambda sym: _greek_letter_order.get(sym, len(_greek_letters)))
+
+
+def _lower_f64_constant(ctx, value):
+    return _as_ir_value(
+        jax_mlir.ir_constant(
+            np.asarray(float(value), dtype=np.float64),
+            const_lowering=ctx.const_lowering,
+        )
+    )
+
+
+def _lower_gate_param_expr(ctx, expr, symbol_bindings):
+    """Lower a sympy gate-parameter expression to a tensor<f64> SSA value.
+
+    quantum_gate_p stores gate parameters symbolically in ``gate.params`` while the
+    runtime tracer operands are provided positionally. MLIR lowering must rebuild
+    the symbolic expression explicitly; otherwise a gate such as ``gphase(-alpha/2)``
+    is emitted as if its parameter were just ``alpha``.
+    """
+    if isinstance(expr, np.number):
+        expr = expr.item()
+
+    if isinstance(expr, (int, float)):
+        return _lower_f64_constant(ctx, expr)
+
+    if isinstance(expr, Expr):
+        if expr.is_Symbol:
+            try:
+                return symbol_bindings[expr]
+            except KeyError as exc:
+                raise KeyError(f"Missing MLIR operand for symbolic gate parameter {expr}") from exc
+
+        if not expr.free_symbols:
+            return _lower_f64_constant(ctx, expr)
+
+        if isinstance(expr, Add):
+            values = [_lower_gate_param_expr(ctx, arg, symbol_bindings) for arg in expr.args]
+            acc = values[0]
+            for value in values[1:]:
+                acc = stablehlo.AddOp(acc, value).result
+            return acc
+
+        if isinstance(expr, Mul):
+            values = [_lower_gate_param_expr(ctx, arg, symbol_bindings) for arg in expr.args]
+            acc = values[0]
+            for value in values[1:]:
+                acc = stablehlo.MulOp(acc, value).result
+            return acc
+
+        if isinstance(expr, Pow):
+            base_expr, exponent_expr = expr.args
+
+            if isinstance(exponent_expr, Expr) and exponent_expr.free_symbols:
+                raise NotImplementedError(
+                    f"Dynamic exponent in gate parameter expression is not supported: {expr}"
+                )
+
+            exponent_value = float(exponent_expr)
+            if not exponent_value.is_integer():
+                raise NotImplementedError(
+                    f"Non-integer powers in gate parameter expressions are not supported: {expr}"
+                )
+
+            exponent = int(exponent_value)
+            if exponent == 0:
+                return _lower_f64_constant(ctx, 1.0)
+
+            base_value = _lower_gate_param_expr(ctx, base_expr, symbol_bindings)
+            power_value = base_value
+            for _ in range(abs(exponent) - 1):
+                power_value = stablehlo.MulOp(power_value, base_value).result
+
+            if exponent < 0:
+                return stablehlo.DivOp(_lower_f64_constant(ctx, 1.0), power_value).result
+            return power_value
+
+    raise NotImplementedError(
+        f"Unsupported gate parameter expression for MLIR lowering: {expr!r}"
+    )
 
 
 ###############################
@@ -262,10 +366,27 @@ def quantum_gate_lowering(ctx, *args, **params):
     # Convert gate_type string to MLIR string attribute
     gate_type_attr = ir.StringAttr.get(op.name)
 
-    # args contains: [gate_operands..., quantum_state]
-    # Separate gate operands from the quantum state (last argument)
-    gate_operands = args[:-1]  # All arguments except the last
-    quantum_state = args[-1]  # Last argument is the quantum state
+    # args contains: [qubits..., raw_param_operands..., quantum_state]. Rebuild
+    # the gate's symbolic parameter expressions from gate.params so expressions
+    # like -0.5 * alpha survive into MLIR as StableHLO arithmetic.
+    qubit_operands = list(args[: op.num_qubits])
+    raw_param_operands = list(args[op.num_qubits:-1])
+    quantum_state = args[-1]
+
+    sorted_symbols = _sorted_param_symbols(op.params)
+    if len(raw_param_operands) != len(sorted_symbols):
+        raise ValueError(
+            f"Gate '{op.name}' expected {len(sorted_symbols)} raw parameter operand(s) "
+            f"for symbols {sorted_symbols}, got {len(raw_param_operands)}"
+        )
+
+    symbol_bindings = {
+        sym: raw_param_operands[i] for i, sym in enumerate(sorted_symbols)
+    }
+    lowered_param_operands = [
+        _lower_gate_param_expr(ctx, expr, symbol_bindings) for expr in op.params
+    ]
+    gate_operands = qubit_operands + lowered_param_operands
 
     # Create our quantum_gate operation using the generated class
     quantum_gate_op = jasp_dialect.QuantumGateOp(

--- a/tests/jax_tests/test_composite_gate_interpreter.py
+++ b/tests/jax_tests/test_composite_gate_interpreter.py
@@ -19,8 +19,9 @@
 import numpy as np
 import jax.numpy as jnp
 import jax.lax as lax
+from jax.extend.core import ClosedJaxpr
 from qrisp import *
-from qrisp.jasp import make_jaspr
+from qrisp.jasp import make_jaspr, Jaspr
 from qrisp.jasp.interpreter_tools import decompose_composite_gates
 from qrisp.jasp.primitives import quantum_gate_p
 
@@ -33,8 +34,6 @@ from qrisp.jasp.primitives import quantum_gate_p
 def _collect_gates_from_jaxpr(jaxpr):
     """Yield every gate object found in quantum_gate_p equations, recursing
     into jit/while/cond sub-jaxprs."""
-    from jax.extend.core import ClosedJaxpr
-    from qrisp.jasp import Jaspr
 
     for eqn in jaxpr.eqns:
         if eqn.primitive == quantum_gate_p:
@@ -264,3 +263,47 @@ def test_decompose_scan_body():
     # The decomposed jaspr must still be executable and return sensible values
     result = decomposed()
     assert result is not None
+
+
+def test_decompose_parametrized_rxx():
+    """rxx is a composite gate whose sub-gates (gphase, p) carry parametrized
+    expressions (-phi/2 and phi respectively).  Before the fix, the param
+    tracers were silently dropped during decomposition, leaving those sub-gates
+    with no dynamic parameter invars.
+
+    After the fix:
+    * Every primitive gate that has abstract_params must have exactly
+      len(abstract_params) parameter invars in the decomposed jaspr.
+    * Evaluating both jasprs with the same concrete angle must yield the same
+      measurement probability distribution.
+    """
+
+    def circuit(phi):
+        qv = QuantumVariable(2)
+        rxx(phi, qv[0], qv[1])
+        return measure(qv)
+
+    jaspr = make_jaspr(circuit)(0.5)
+    decomposed = decompose_composite_gates(jaspr)
+
+    # --- structural check ---
+    assert_no_composite_gates(decomposed)
+
+    for eqn in decomposed.eqns:
+        if eqn.primitive == quantum_gate_p:
+            gate = eqn.params["gate"]
+            if gate.abstract_params:
+                num_param_invars = len(eqn.invars) - gate.num_qubits - 1
+                assert num_param_invars == len(gate.abstract_params)
+
+    # --- numerical check ---
+    def circuit_fixed():
+        qv = QuantumVariable(2)
+        rxx(0.5, qv[0], qv[1])
+        return measure(qv)
+
+    jaspr_fixed = make_jaspr(circuit_fixed)()
+    decomposed_fixed = decompose_composite_gates(jaspr_fixed)
+
+    assert_same_distribution(jaspr_fixed, decomposed_fixed)
+

--- a/tests/jax_tests/test_mlir.py
+++ b/tests/jax_tests/test_mlir.py
@@ -120,6 +120,25 @@ def test_mlir_basic_dialect_operations():
     assert "jasp.measure" in mlir_str, "measure operation not found in MLIR"
     assert "jasp.quantum_gate" in mlir_str or "jasp.gate" in mlir_str, "gate operations not found in MLIR"
 
+def test_mlir_symbolic_gate_parameter_expression_lowering():
+    """Composite-gate decomposition may produce primitive gates whose parameter
+    is a symbolic expression of a runtime tracer, e.g. gphase(-alpha/2) inside
+    rxx(alpha). MLIR lowering must materialize that expression instead of
+    forwarding the raw tracer unchanged.
+    """
+
+    def circuit(phi):
+        qv = QuantumVariable(2)
+        rxx(phi, qv[0], qv[1])
+        return measure(qv[0])
+
+    jaspr = make_jaspr(circuit)(1.57)
+    mlir_str = str(jaspr.to_mlir())
+
+    assert 'jasp.quantum_gate "gphase"' in mlir_str, "Expected decomposed gphase gate in MLIR"
+    assert "stablehlo.multiply" in mlir_str, "Expected MLIR arithmetic for gphase(-alpha/2)"
+    assert "dense<-5.000000e-01>" in mlir_str, "Expected -0.5 constant factor for gphase(-alpha/2)"
+
 def test_mlir_quantum_control_flow_rewriting():
     """
     Test that StableHLO control flow is properly rewritten to SCF for quantum types.


### PR DESCRIPTION
## Description

Composite gates with parametrized expressions (e.g. `rxx(phi)`, which decomposes into `gphase(-phi/2)` and `p(phi)`) were silently broken in two related places.

1. **composite_gate_interpreter.py** — when inlining a composite gate, the sub-gate parameter tracers were not forwarded to the primitive `quantum_gate_p` bind call. Sub-gates whose symbolic expressions referenced a subset of the parent symbols (e.g. only `beta` out of `alpha, beta`) had their tracers dropped entirely, leaving them with zero dynamic parameter invars.

2. **jasp_lowering_rules.py** — the `quantum_gate_p` MLIR lowering rule forwarded raw parameter operands unchanged, ignoring the gate's symbolic `params` expressions entirely. A gate like `gphase(-alpha/2)` was emitted to MLIR as `gphase(alpha)`, losing the `-1/2` factor.

Both bugs are fixed on this branch.

## Related Issues

Closes #
Related to #

## Type of Change

- [ ] Feature (new functionality)
- [ ] Change Request (modification of existing functionality)
- [x] Bug Fix
- [ ] Refactoring (no behavior change)
- [ ] Performance improvement
- [ ] Documentation
- [ ] CI / Build

## Breaking Change?
- [ ] Yes
- [x] No

## What was changed?

- **composite_gate_interpreter.py**
  - Added `_greek_letter_order` lookup to sort a gate's free symbols in canonical `greek_letters` order before binding parameter tracers.
  - Added `_apply_op` helper that recursively inlines composite gates while correctly threading the parent gate's `param_dict` (symbol → tracer) into all primitive sub-gates.
  - `decompose_eqn_evaluator` now builds `param_dict` from the parent gate's `params` list and passes it through `_apply_op` so sparse sub-gate symbol subsets (e.g. only `beta`) are normalized and bound correctly.
  - Added `_decompose_sub_jaxpr` to propagate decomposition into `jit`, `while`, `cond`, and `scan` sub-jaxprs.

- **jasp_lowering_rules.py**
  - Added `_lower_gate_param_expr` — a recursive Sympy-to-StableHLO scalar lowerer handling `Add`, `Mul`, `Pow`, constants, and symbol lookups.
  - Added `_sorted_param_symbols` and `_lower_f64_constant` helpers.
  - `quantum_gate_lowering` now reconstructs each gate parameter operand from `gate.params` symbolic expressions via `_lower_gate_param_expr`, emitting the required StableHLO arithmetic (e.g. `stablehlo.constant dense<-5.0e-01>` + `stablehlo.multiply`) before constructing `jasp.quantum_gate`.

- **test_composite_gate_interpreter.py**
  - Added `test_decompose_parametrized_rxx`: structural check that every parametrized primitive gate in the decomposed jaspr has the correct number of parameter invars; numerical check that the decomposed jaspr yields the same measurement distribution as the non-decomposed one.

- **test_mlir.py**
  - Added `test_mlir_symbolic_gate_parameter_expression_lowering`: asserts that lowering a dynamic `rxx(phi)` circuit to MLIR produces a `gphase` gate with a materialized `-0.5 * phi` expression (`stablehlo.multiply` with `dense<-5.000000e-01>`).

## How was it tested?

| Test-ID | Description | Status |
|---------|-------------|--------|
| T-001 | `test_decompose_parametrized_rxx` — structural + numerical check on `decompose_composite_gates` for `rxx(phi)` | ✅ |
| T-002 | `test_mlir_symbolic_gate_parameter_expression_lowering` — MLIR contains `stablehlo.multiply` with `-0.5` for `gphase(-phi/2)` | ✅ |
| T-003 | `test_mlir_basic_dialect_operations` — existing MLIR lowering of non-parametrized gates unaffected | ✅ |

## Reviewer Notes

The two bugs are logically independent but always co-occur for composite parametrized gates: the interpreter bug loses the tracer, and the MLIR lowering bug loses the expression. Both need to be fixed together for `rxx`, `rzz`, `xxyy`, and any other composite gate that uses abstract parameters in its decomposition.