### PR TITLE
Fix composite gate interpreter

### DIFF
--- a/src/qrisp/jasp/interpreter_tools/interpreters/composite_gate_interpreter.py
+++ b/src/qrisp/jasp/interpreter_tools/interpreters/composite_gate_interpreter.py
@@ -118,7 +118,7 @@ def _apply_op(op, qubit_tracers, abs_qst, param_dict=None):
             # Evaluate each symbolic parameter expression (e.g. -alpha/2) against
             # the parent gate's symbol->tracer bindings to produce a concrete JAX
             # tracer for each parameter slot.
-            computed_tracers = [_lambdify(sorted_syms, expr)(*sorted_tracers) for expr in op.params]
+            computed_tracers = [_lambdify(sorted_syms, expr, modules="jax")(*sorted_tracers) for expr in op.params]
             # Emit an identity-param version of the gate (params = [alpha, beta, ...])
             # together with the pre-computed tracers.  This is required because
             # append_impl later calls gate.bind_parameters({alpha: val}), which

--- a/src/qrisp/jasp/interpreter_tools/interpreters/composite_gate_interpreter.py
+++ b/src/qrisp/jasp/interpreter_tools/interpreters/composite_gate_interpreter.py
@@ -17,9 +17,8 @@
 """
 
 from functools import lru_cache
-
 from jax.extend.core import JaxprEqn
-
+import jax.numpy as jnp
 from sympy import lambdify as _lambdify
 
 from qrisp.jasp.interpreter_tools import exec_eqn, reinterpret, extract_invalues, insert_outvalues
@@ -39,6 +38,8 @@ _U3_IDENTITY_FACTORIES = {
     "ry":     lambda: _std_ops.RYGate(_greek_letters[0]),
     "rz":     lambda: _std_ops.RZGate(_greek_letters[0]),
     "p":      lambda: _std_ops.PGate(_greek_letters[0]),
+    "u1":     lambda: _std_ops.U1Gate(_greek_letters[0]),
+    "u3":     lambda: _U3Gate(_greek_letters[0], _greek_letters[1], _greek_letters[2]),
 }
 
 
@@ -126,6 +127,18 @@ def _apply_op(op, qubit_tracers, abs_qst, param_dict=None):
             # time: bind_parameters({alpha: val}) would yield -val/2 instead of val.
             identity_op = _make_identity_param_op(op)
             return quantum_gate_p.bind(*qubit_tracers, *computed_tracers, abs_qst, gate=identity_op)
+        elif op.params:
+            # Gate has only constant (non-symbolic) parameters — e.g. rz(-π/2)
+            # emitted as an internal fixed rotation inside a composite gate
+            # definition.  Without this branch the parameter value stays embedded
+            # in the gate object and no param invar is emitted.  The MLIR lowering
+            # expects every parametrised gate to have its angle(s) as explicit
+            # input variables, so we promote each constant to a JAX float64 literal
+            # tracer and emit an identity-param gate, exactly as in the symbolic
+            # branch above.
+            const_tracers = [jnp.float64(float(p)) for p in op.params]
+            identity_op = _make_identity_param_op(op)
+            return quantum_gate_p.bind(*qubit_tracers, *const_tracers, abs_qst, gate=identity_op)
         else:
             return quantum_gate_p.bind(*qubit_tracers, abs_qst, gate=op)
 

--- a/src/qrisp/jasp/interpreter_tools/interpreters/composite_gate_interpreter.py
+++ b/src/qrisp/jasp/interpreter_tools/interpreters/composite_gate_interpreter.py
@@ -106,16 +106,24 @@ def _apply_op(op, qubit_tracers, abs_qst, param_dict=None):
 
     if op.definition is None:
         if op.abstract_params and param_dict:
+            # op.abstract_params is a set, so iteration order is non-deterministic.
+            # lambdify maps positional arguments to symbols in the order given, so
+            # the symbol list passed to lambdify and the tracer list must agree on
+            # the same ordering.  We sort by _greek_letter_order (the canonical
+            # index of each symbol in the greek_letters sequence) to get a stable,
+            # deterministic ordering regardless of Python's set hash randomisation.
+            sorted_syms = sorted(op.abstract_params, key=lambda s: _greek_letter_order[s])
+            sorted_tracers = [param_dict[sym] for sym in sorted_syms]
             # Evaluate each symbolic parameter expression (e.g. -alpha/2) against
             # the parent gate's symbol->tracer bindings to produce a concrete JAX
             # tracer for each parameter slot.
-            sorted_syms = sorted(op.abstract_params, key=lambda s: _greek_letter_order[s])
-            sorted_tracers = [param_dict[sym] for sym in sorted_syms]
             computed_tracers = [_lambdify(sorted_syms, expr)(*sorted_tracers) for expr in op.params]
-            # Create an identity-param version of the gate (params = [alpha, beta, ...]).
-            # This is required so that append_impl's bind_parameters({alpha: val})
-            # call simply passes 'val' through rather than re-applying the original
-            # symbolic expression a second time.
+            # Emit an identity-param version of the gate (params = [alpha, beta, ...])
+            # together with the pre-computed tracers.  This is required because
+            # append_impl later calls gate.bind_parameters({alpha: val}), which
+            # must map val -> val (identity).  Using the original gate (e.g.
+            # gphase(-alpha/2)) would cause the expression to be applied a second
+            # time: bind_parameters({alpha: val}) would yield -val/2 instead of val.
             identity_op = _make_identity_param_op(op)
             return quantum_gate_p.bind(*qubit_tracers, *computed_tracers, abs_qst, gate=identity_op)
         else:

--- a/src/qrisp/jasp/interpreter_tools/interpreters/composite_gate_interpreter.py
+++ b/src/qrisp/jasp/interpreter_tools/interpreters/composite_gate_interpreter.py
@@ -22,6 +22,14 @@ from jax.extend.core import JaxprEqn
 
 from qrisp.jasp.interpreter_tools import exec_eqn, reinterpret, extract_invalues, insert_outvalues
 from qrisp.jasp.primitives import quantum_gate_p
+from qrisp.jasp.primitives.operation_primitive import greek_letters as _greek_letters
+
+# quantum_gate_p.append_impl binds runtime parameter slot i to greek_letters[i].
+# When a decomposed primitive gate uses only a subset of the parent symbols
+# (for example a sub-gate depending only on beta), we must first recover the
+# symbols in canonical greek_letters order and then remap them to a dense
+# prefix alpha, beta, ... before binding the tracers positionally.
+_greek_letter_order = {sym: i for i, sym in enumerate(_greek_letters)}
 
 
 def _copy_eqn(eqn):
@@ -36,21 +44,52 @@ def _copy_eqn(eqn):
     )
 
 
-def _apply_op(op, qubit_tracers, abs_qst):
+def _apply_op(op, qubit_tracers, abs_qst, param_dict=None):
     """Recursively inline a gate.
 
     - Primitive gates (op.definition is None) are bound directly via quantum_gate_p.
     - Composite gates are expanded by iterating their definition circuit and
       recursively calling _apply_op for each sub-instruction.
+
+    param_dict maps the sympy symbols that appear in sub-gate param expressions
+    (i.e. the parent gate's abstract params) to their corresponding JAX tracers.
     """
+    if param_dict is None:
+        param_dict = {}
+
     if op.definition is None:
-        return quantum_gate_p.bind(*qubit_tracers, abs_qst, gate=op)
+        if op.abstract_params and param_dict:
+            # Recover the gate's free symbols in the same canonical order used
+            # when traced operations are constructed: alpha, beta, gamma, ...
+            # The order matters because append_impl later substitutes the
+            # incoming parameter tracers positionally into greek_letters[i].
+            sorted_syms = sorted(
+                op.abstract_params,
+                key=lambda s: _greek_letter_order.get(s, len(_greek_letters)),
+            )
+            # Re-index the gate onto a dense greek-letter prefix. This is the
+            # critical step for sparse subsets such as {beta}: we normalize
+            # beta -> alpha so that passing a single tracer still lands in slot 0.
+            # The symbolic expressions themselves stay intact under this rename,
+            # e.g. rz(beta) becomes rz(alpha) and -beta/2 becomes -alpha/2.
+            remap = {sym: _greek_letters[i] for i, sym in enumerate(sorted_syms)}
+            normalized_op = op.bind_parameters(remap)
+            # Pass one tracer per normalized symbol in the same positional order.
+            # We intentionally forward the raw tracers here; append_impl and
+            # bind_parameters still need to evaluate the gate's sympy expression
+            # (for example -alpha/2) at concrete execution time.
+            param_tracer_list = [param_dict[sym] for sym in sorted_syms]
+            return quantum_gate_p.bind(
+                *qubit_tracers, *param_tracer_list, abs_qst, gate=normalized_op
+            )
+        else:
+            return quantum_gate_p.bind(*qubit_tracers, abs_qst, gate=op)
 
     defn = op.definition.transpile()
     for instr in defn.data:
         qubit_indices = [defn.qubits.index(qb) for qb in instr.qubits]
         sub_qubits = [qubit_tracers[i] for i in qubit_indices]
-        abs_qst = _apply_op(instr.op, sub_qubits, abs_qst)
+        abs_qst = _apply_op(instr.op, sub_qubits, abs_qst, param_dict=param_dict)
 
     return abs_qst
 
@@ -72,8 +111,14 @@ def decompose_eqn_evaluator(eqn, context_dic):
         invalues = extract_invalues(eqn, context_dic)
         qubit_tracers = invalues[: gate.num_qubits]
         abs_qst = invalues[-1]
+        param_tracers = invalues[gate.num_qubits : -1]
 
-        abs_qst = _apply_op(gate, qubit_tracers, abs_qst)
+        # Preserve the parent gate's symbol -> tracer association so primitive
+        # sub-gates can recover the correct tracer even when they reference only
+        # a subset of the parent's parameters.
+        param_dict = {gate.params[i]: param_tracers[i] for i in range(len(param_tracers))}
+
+        abs_qst = _apply_op(gate, qubit_tracers, abs_qst, param_dict=param_dict)
         insert_outvalues(eqn, context_dic, abs_qst)
         return False  # equation handled; skip default exec_eqn
 

--- a/src/qrisp/jasp/interpreter_tools/interpreters/composite_gate_interpreter.py
+++ b/src/qrisp/jasp/interpreter_tools/interpreters/composite_gate_interpreter.py
@@ -61,7 +61,7 @@ def _make_identity_param_op(op):
         params=[alpha, beta, ...] and clearing the lambdify cache is sufficient.
     """
     n = len(op.params)
-    if n == 0:
+    if not n:
         return op
     if isinstance(op, _U3Gate):
         factory = _U3_IDENTITY_FACTORIES.get(op.name)
@@ -127,7 +127,7 @@ def _apply_op(op, qubit_tracers, abs_qst, param_dict=None):
             # time: bind_parameters({alpha: val}) would yield -val/2 instead of val.
             identity_op = _make_identity_param_op(op)
             return quantum_gate_p.bind(*qubit_tracers, *computed_tracers, abs_qst, gate=identity_op)
-        elif op.params:
+        if op.params:
             # Gate has only constant (non-symbolic) parameters — e.g. rz(-π/2)
             # emitted as an internal fixed rotation inside a composite gate
             # definition.  Without this branch the parameter value stays embedded

--- a/src/qrisp/jasp/interpreter_tools/interpreters/composite_gate_interpreter.py
+++ b/src/qrisp/jasp/interpreter_tools/interpreters/composite_gate_interpreter.py
@@ -139,8 +139,8 @@ def _apply_op(op, qubit_tracers, abs_qst, param_dict=None):
             const_tracers = [jnp.float64(float(p)) for p in op.params]
             identity_op = _make_identity_param_op(op)
             return quantum_gate_p.bind(*qubit_tracers, *const_tracers, abs_qst, gate=identity_op)
-        else:
-            return quantum_gate_p.bind(*qubit_tracers, abs_qst, gate=op)
+
+        return quantum_gate_p.bind(*qubit_tracers, abs_qst, gate=op)
 
     defn = op.definition.transpile()
     for instr in defn.data:

--- a/src/qrisp/jasp/interpreter_tools/interpreters/composite_gate_interpreter.py
+++ b/src/qrisp/jasp/interpreter_tools/interpreters/composite_gate_interpreter.py
@@ -20,16 +20,76 @@ from functools import lru_cache
 
 from jax.extend.core import JaxprEqn
 
+from sympy import Add, Mul, Pow, Number, Symbol
+
 from qrisp.jasp.interpreter_tools import exec_eqn, reinterpret, extract_invalues, insert_outvalues
 from qrisp.jasp.primitives import quantum_gate_p
 from qrisp.jasp.primitives.operation_primitive import greek_letters as _greek_letters
+import qrisp.circuit.standard_operations as _std_ops
 
-# quantum_gate_p.append_impl binds runtime parameter slot i to greek_letters[i].
-# When a decomposed primitive gate uses only a subset of the parent symbols
-# (for example a sub-gate depending only on beta), we must first recover the
-# symbols in canonical greek_letters order and then remap them to a dense
-# prefix alpha, beta, ... before binding the tracers positionally.
 _greek_letter_order = {sym: i for i, sym in enumerate(_greek_letters)}
+
+# Gate factories that produce a fresh U3Gate-derived gate whose params are
+# exactly [alpha] (identity), so that append_impl and other consumers can call
+# bind_parameters({alpha: val}) and get back a fully concrete gate with params=[val].
+_U3_IDENTITY_FACTORIES = {
+    "gphase": lambda: _std_ops.GPhaseGate(_greek_letters[0]),
+    "rx":     lambda: _std_ops.RXGate(_greek_letters[0]),
+    "ry":     lambda: _std_ops.RYGate(_greek_letters[0]),
+    "rz":     lambda: _std_ops.RZGate(_greek_letters[0]),
+    "p":      lambda: _std_ops.PGate(_greek_letters[0]),
+}
+
+
+def _eval_param_expr(expr, param_dict):
+    """Recursively evaluate a sympy expression to a JAX tracer using param_dict."""
+    if isinstance(expr, (int, float)):
+        return expr
+    if isinstance(expr, Number):
+        return float(expr)
+    if isinstance(expr, Symbol):
+        return param_dict[expr]
+    if isinstance(expr, Add):
+        result = _eval_param_expr(expr.args[0], param_dict)
+        for arg in expr.args[1:]:
+            result = result + _eval_param_expr(arg, param_dict)
+        return result
+    if isinstance(expr, Mul):
+        result = _eval_param_expr(expr.args[0], param_dict)
+        for arg in expr.args[1:]:
+            result = result * _eval_param_expr(arg, param_dict)
+        return result
+    if isinstance(expr, Pow):
+        base = _eval_param_expr(expr.args[0], param_dict)
+        exp = _eval_param_expr(expr.args[1], param_dict)
+        return base ** exp
+    raise NotImplementedError(f"Cannot evaluate sympy expr of type {type(expr)}: {expr}")
+
+
+def _make_identity_param_op(op):
+    """Return a version of op whose params are [alpha, beta, ...] (identity expressions).
+
+    For standard single-param U3Gate types (gphase, rx, ry, rz, p) a fresh gate
+    is created via the corresponding factory with greek_letters[0] as the argument.
+    This ensures that U3Gate.bind_parameters correctly passes the value through
+    without re-applying the original symbolic expression a second time.
+
+    For all other operations a copy is returned with params and abstract_params
+    patched directly to the dense greek-letter prefix.
+    """
+    n = len(op.params)
+    if n == 0:
+        return op
+    factory = _U3_IDENTITY_FACTORIES.get(op.name)
+    if factory is not None:
+        return factory()
+    # Generic fallback: patch params and abstract_params on a copy.
+    identity = op.copy()
+    identity.params = list(_greek_letters[:n])
+    identity.abstract_params = set(_greek_letters[:n])
+    if hasattr(identity, "lambdified_params"):
+        del identity.lambdified_params
+    return identity
 
 
 def _copy_eqn(eqn):
@@ -59,29 +119,16 @@ def _apply_op(op, qubit_tracers, abs_qst, param_dict=None):
 
     if op.definition is None:
         if op.abstract_params and param_dict:
-            # Recover the gate's free symbols in the same canonical order used
-            # when traced operations are constructed: alpha, beta, gamma, ...
-            # The order matters because append_impl later substitutes the
-            # incoming parameter tracers positionally into greek_letters[i].
-            sorted_syms = sorted(
-                op.abstract_params,
-                key=lambda s: _greek_letter_order.get(s, len(_greek_letters)),
-            )
-            # Re-index the gate onto a dense greek-letter prefix. This is the
-            # critical step for sparse subsets such as {beta}: we normalize
-            # beta -> alpha so that passing a single tracer still lands in slot 0.
-            # The symbolic expressions themselves stay intact under this rename,
-            # e.g. rz(beta) becomes rz(alpha) and -beta/2 becomes -alpha/2.
-            remap = {sym: _greek_letters[i] for i, sym in enumerate(sorted_syms)}
-            normalized_op = op.bind_parameters(remap)
-            # Pass one tracer per normalized symbol in the same positional order.
-            # We intentionally forward the raw tracers here; append_impl and
-            # bind_parameters still need to evaluate the gate's sympy expression
-            # (for example -alpha/2) at concrete execution time.
-            param_tracer_list = [param_dict[sym] for sym in sorted_syms]
-            return quantum_gate_p.bind(
-                *qubit_tracers, *param_tracer_list, abs_qst, gate=normalized_op
-            )
+            # Evaluate each symbolic parameter expression (e.g. -alpha/2) against
+            # the parent gate's symbol->tracer bindings to produce a concrete JAX
+            # tracer for each parameter slot.
+            computed_tracers = [_eval_param_expr(expr, param_dict) for expr in op.params]
+            # Create an identity-param version of the gate (params = [alpha, beta, ...]).
+            # This is required so that append_impl's bind_parameters({alpha: val})
+            # call simply passes 'val' through rather than re-applying the original
+            # symbolic expression a second time.
+            identity_op = _make_identity_param_op(op)
+            return quantum_gate_p.bind(*qubit_tracers, *computed_tracers, abs_qst, gate=identity_op)
         else:
             return quantum_gate_p.bind(*qubit_tracers, abs_qst, gate=op)
 

--- a/src/qrisp/jasp/interpreter_tools/interpreters/composite_gate_interpreter.py
+++ b/src/qrisp/jasp/interpreter_tools/interpreters/composite_gate_interpreter.py
@@ -20,7 +20,7 @@ from functools import lru_cache
 
 from jax.extend.core import JaxprEqn
 
-from sympy import Add, Mul, Pow, Number, Symbol
+from sympy import lambdify as _lambdify
 
 from qrisp.jasp.interpreter_tools import exec_eqn, reinterpret, extract_invalues, insert_outvalues
 from qrisp.jasp.primitives import quantum_gate_p
@@ -39,31 +39,6 @@ _U3_IDENTITY_FACTORIES = {
     "rz":     lambda: _std_ops.RZGate(_greek_letters[0]),
     "p":      lambda: _std_ops.PGate(_greek_letters[0]),
 }
-
-
-def _eval_param_expr(expr, param_dict):
-    """Recursively evaluate a sympy expression to a JAX tracer using param_dict."""
-    if isinstance(expr, (int, float)):
-        return expr
-    if isinstance(expr, Number):
-        return float(expr)
-    if isinstance(expr, Symbol):
-        return param_dict[expr]
-    if isinstance(expr, Add):
-        result = _eval_param_expr(expr.args[0], param_dict)
-        for arg in expr.args[1:]:
-            result = result + _eval_param_expr(arg, param_dict)
-        return result
-    if isinstance(expr, Mul):
-        result = _eval_param_expr(expr.args[0], param_dict)
-        for arg in expr.args[1:]:
-            result = result * _eval_param_expr(arg, param_dict)
-        return result
-    if isinstance(expr, Pow):
-        base = _eval_param_expr(expr.args[0], param_dict)
-        exp = _eval_param_expr(expr.args[1], param_dict)
-        return base ** exp
-    raise NotImplementedError(f"Cannot evaluate sympy expr of type {type(expr)}: {expr}")
 
 
 def _make_identity_param_op(op):
@@ -122,7 +97,9 @@ def _apply_op(op, qubit_tracers, abs_qst, param_dict=None):
             # Evaluate each symbolic parameter expression (e.g. -alpha/2) against
             # the parent gate's symbol->tracer bindings to produce a concrete JAX
             # tracer for each parameter slot.
-            computed_tracers = [_eval_param_expr(expr, param_dict) for expr in op.params]
+            sorted_syms = sorted(op.abstract_params, key=lambda s: _greek_letter_order[s])
+            sorted_tracers = [param_dict[sym] for sym in sorted_syms]
+            computed_tracers = [_lambdify(sorted_syms, expr)(*sorted_tracers) for expr in op.params]
             # Create an identity-param version of the gate (params = [alpha, beta, ...]).
             # This is required so that append_impl's bind_parameters({alpha: val})
             # call simply passes 'val' through rather than re-applying the original

--- a/src/qrisp/jasp/interpreter_tools/interpreters/composite_gate_interpreter.py
+++ b/src/qrisp/jasp/interpreter_tools/interpreters/composite_gate_interpreter.py
@@ -25,6 +25,7 @@ from sympy import lambdify as _lambdify
 from qrisp.jasp.interpreter_tools import exec_eqn, reinterpret, extract_invalues, insert_outvalues
 from qrisp.jasp.primitives import quantum_gate_p
 from qrisp.jasp.primitives.operation_primitive import greek_letters as _greek_letters
+from qrisp.circuit.operation import U3Gate as _U3Gate
 import qrisp.circuit.standard_operations as _std_ops
 
 _greek_letter_order = {sym: i for i, sym in enumerate(_greek_letters)}
@@ -44,21 +45,32 @@ _U3_IDENTITY_FACTORIES = {
 def _make_identity_param_op(op):
     """Return a version of op whose params are [alpha, beta, ...] (identity expressions).
 
-    For standard single-param U3Gate types (gphase, rx, ry, rz, p) a fresh gate
-    is created via the corresponding factory with greek_letters[0] as the argument.
-    This ensures that U3Gate.bind_parameters correctly passes the value through
-    without re-applying the original symbolic expression a second time.
+    Two cases require different treatment:
 
-    For all other operations a copy is returned with params and abstract_params
-    patched directly to the dense greek-letter prefix.
+    U3Gate instances (gphase, rx, ry, rz, p, ...):
+        U3Gate.bind_parameters evaluates its internal fields (theta, phi, lam,
+        global_phase) directly — it does NOT read self.params.  Patching params
+        on a copy therefore has no effect.  Instead, a fresh gate must be
+        constructed via its factory function so that the internal fields carry
+        the identity symbolic structure (e.g. GPhaseGate(alpha) has
+        global_phase=alpha, not -alpha/2).
+
+    Generic Operation instances:
+        Operation.bind_parameters lambdifies over self.params, so patching
+        params=[alpha, beta, ...] and clearing the lambdify cache is sufficient.
     """
     n = len(op.params)
     if n == 0:
         return op
-    factory = _U3_IDENTITY_FACTORIES.get(op.name)
-    if factory is not None:
+    if isinstance(op, _U3Gate):
+        factory = _U3_IDENTITY_FACTORIES.get(op.name)
+        if factory is None:
+            raise NotImplementedError(
+                f"_make_identity_param_op: no identity factory registered for "
+                f"U3Gate '{op.name}'.  Add an entry to _U3_IDENTITY_FACTORIES."
+            )
         return factory()
-    # Generic fallback: patch params and abstract_params on a copy.
+    # Generic Operation fallback: patch params and abstract_params on a copy.
     identity = op.copy()
     identity.params = list(_greek_letters[:n])
     identity.abstract_params = set(_greek_letters[:n])

--- a/tests/jax_tests/test_composite_gate_interpreter.py
+++ b/tests/jax_tests/test_composite_gate_interpreter.py
@@ -87,6 +87,15 @@ def assert_same_distribution(jaspr_a, jaspr_b):
     ), f"Probability distributions differ:\n  original:   {probs_a}\n  decomposed: {probs_b}"
 
 
+def assert_same_unitary(jaspr_a, jaspr_b):
+    """Assert that two jasprs produce identical unitary matrices."""
+    qc_a = jaspr_a.to_qc()[-1]
+    qc_b = jaspr_b.to_qc()[-1]
+    u_a = qc_a.get_unitary()
+    u_b = qc_b.get_unitary()
+    assert np.allclose(u_a, u_b, atol=1e-6), f"Unitary matrices differ:\n  original:   {u_a}\n  decomposed: {u_b}"
+
+
 # ---------------------------------------------------------------------------
 # Tests
 # ---------------------------------------------------------------------------
@@ -274,14 +283,13 @@ def test_decompose_parametrized_rxx():
     After the fix:
     * Every primitive gate that has abstract_params must have exactly
       len(abstract_params) parameter invars in the decomposed jaspr.
-    * Evaluating both jasprs with the same concrete angle must yield the same
-      measurement probability distribution.
+    * Evaluating the decomposed jaspr must yield the same unitary as the original.
     """
 
     def circuit(phi):
         qv = QuantumVariable(2)
         rxx(phi, qv[0], qv[1])
-        return measure(qv)
+        return qv
 
     jaspr = make_jaspr(circuit)(0.5)
     decomposed = decompose_composite_gates(jaspr)
@@ -300,10 +308,50 @@ def test_decompose_parametrized_rxx():
     def circuit_fixed():
         qv = QuantumVariable(2)
         rxx(0.5, qv[0], qv[1])
-        return measure(qv)
+        return qv
 
     jaspr_fixed = make_jaspr(circuit_fixed)()
     decomposed_fixed = decompose_composite_gates(jaspr_fixed)
+    assert_same_unitary(jaspr_fixed, decomposed_fixed)
 
-    assert_same_distribution(jaspr_fixed, decomposed_fixed)
 
+def test_decompose_parametrized_xxyy():
+    """xxyy is a composite gate parameterized by two angles (phi and beta) whose
+    sub-gates carry expressions derived from both parameters.  This test verifies
+    the same two invariants as test_decompose_parametrized_rxx for the two-parameter
+    case:
+
+    * Every primitive gate that has abstract_params must have exactly
+      len(abstract_params) parameter invars in the decomposed jaspr.
+    * Evaluating the decomposed jaspr must yield the same unitary as the original.
+    """
+
+    def circuit(phi):
+        qv = QuantumVariable(2)
+        rxx(phi, qv[0], qv[1])
+        return qv
+
+    jaspr = make_jaspr(circuit)(0.5)
+    decomposed = decompose_composite_gates(jaspr)
+
+    # --- structural check ---
+    assert_no_composite_gates(decomposed)
+
+    for eqn in decomposed.eqns:
+        if eqn.primitive == quantum_gate_p:
+            gate = eqn.params["gate"]
+            if gate.abstract_params:
+                num_param_invars = len(eqn.invars) - gate.num_qubits - 1
+                assert num_param_invars == len(gate.abstract_params)
+
+    # --- numerical check ---
+    def circuit_fixed():
+        qv = QuantumFloat(2)
+        h(qv)
+        xxyy(1.1, 0.4, qv[0], qv[1])
+        h(qv)
+        return qv  
+
+    jaspr_fixed = make_jaspr(circuit_fixed)()
+    decomposed_fixed = decompose_composite_gates(jaspr_fixed)
+    assert_same_unitary(jaspr_fixed, decomposed_fixed)

--- a/tests/jax_tests/test_composite_gate_interpreter.py
+++ b/tests/jax_tests/test_composite_gate_interpreter.py
@@ -328,7 +328,7 @@ def test_decompose_parametrized_xxyy():
 
     def circuit(phi):
         qv = QuantumVariable(2)
-        rxx(phi, qv[0], qv[1])
+        xxyy(phi, qv[0], qv[1])
         return qv
 
     jaspr = make_jaspr(circuit)(0.5)

--- a/tests/jax_tests/test_composite_gate_interpreter.py
+++ b/tests/jax_tests/test_composite_gate_interpreter.py
@@ -20,9 +20,10 @@ import numpy as np
 import jax.numpy as jnp
 import jax.lax as lax
 from jax.extend.core import ClosedJaxpr
+import pytest
 import sympy
 
-from qrisp import QuantumVariable, prepare, measure, x, h, cx, mcx, rxx, xxyy
+from qrisp import QuantumVariable, prepare, measure, x, h, cx, mcx, rxx, rzz, xxyy
 from qrisp.jasp import make_jaspr, qache, quantum_kernel
 from qrisp.jasp.interpreter_tools import decompose_composite_gates
 from qrisp.jasp.primitives import quantum_gate_p
@@ -64,12 +65,31 @@ def _collect_gates_from_jaxpr(jaxpr):
             yield from _collect_gates_from_jaxpr(inner)
 
 
+def assert_composite_gates(jaspr):
+    """Assert that the jaspr contains at least one composite gate (gate.definition is not None)."""
+    all_gates = list(_collect_gates_from_jaxpr(jaspr))
+    assert any(g.definition is not None for g in all_gates), (
+        "Expected at least one composite gate in the original jaspr."
+    )
+
+
 def assert_no_composite_gates(jaspr):
     """Assert that all gates in the jaspr are primitive (definition is None)."""
     for gate in _collect_gates_from_jaxpr(jaspr):
         assert gate.definition is None, (
             f"Gate '{gate.name}' still has a composite definition after decomposition."
         )
+
+
+def assert_primitive_gates_invars_match_abstract_params(jaspr):
+    """Assert that every primitive gate with abstract_params has the correct number
+    of invars corresponding to those abstract_params."""
+    for eqn in jaspr.eqns:
+        if eqn.primitive == quantum_gate_p:
+            gate = eqn.params["gate"]
+            if gate.abstract_params:
+                num_param_invars = len(eqn.invars) - gate.num_qubits - 1
+                assert num_param_invars == len(gate.abstract_params)
 
 
 def assert_same_distribution(jaspr_a, jaspr_b):
@@ -115,10 +135,7 @@ def test_decompose_state_preparation():
     jaspr = make_jaspr(main)()
 
     # Verify that the original jaspr contains at least one composite gate
-    all_gates = list(_collect_gates_from_jaxpr(jaspr))
-    assert any(g.definition is not None for g in all_gates), (
-        "Expected at least one composite gate in the original jaspr."
-    )
+    assert_composite_gates(jaspr)
 
     decomposed = decompose_composite_gates(jaspr)
 
@@ -142,8 +159,7 @@ def test_decompose_mcx():
     jaspr = make_jaspr(main)()
 
     # Sanity-check: original has composite gates
-    all_gates = list(_collect_gates_from_jaxpr(jaspr))
-    assert any(g.definition is not None for g in all_gates)
+    assert_composite_gates(jaspr)
 
     decomposed = decompose_composite_gates(jaspr)
 
@@ -344,8 +360,9 @@ def test_decompose_constant_param_subgates():
     assert_same_unitary(jaspr_fixed, decomposed_fixed)
 
 
-def test_decompose_parametrized_rxx():
-    """rxx is a composite gate whose sub-gates (gphase, p) carry parametrized
+@pytest.mark.parametrize("gate", [rxx, rzz])
+def test_decompose_parametrized_rxx_rzz(gate):
+    """rxx and rzz are composite gates whose sub-gates (gphase, p) carry parametrized
     expressions (-phi/2 and phi respectively).  Before the fix, the param
     tracers were silently dropped during decomposition, leaving those sub-gates
     with no dynamic parameter invars.
@@ -358,26 +375,21 @@ def test_decompose_parametrized_rxx():
 
     def circuit(phi):
         qv = QuantumVariable(2)
-        rxx(phi, qv[0], qv[1])
+        gate(phi, qv[0], qv[1])
         return qv
 
     jaspr = make_jaspr(circuit)(0.5)
     decomposed = decompose_composite_gates(jaspr)
 
     # --- structural check ---
+    assert_composite_gates(jaspr)
     assert_no_composite_gates(decomposed)
-
-    for eqn in decomposed.eqns:
-        if eqn.primitive == quantum_gate_p:
-            gate = eqn.params["gate"]
-            if gate.abstract_params:
-                num_param_invars = len(eqn.invars) - gate.num_qubits - 1
-                assert num_param_invars == len(gate.abstract_params)
+    assert_primitive_gates_invars_match_abstract_params(decomposed)
 
     # --- numerical check ---
     def circuit_fixed():
         qv = QuantumVariable(2)
-        rxx(0.5, qv[0], qv[1])
+        gate(0.5, qv[0], qv[1])
         return qv
 
     jaspr_fixed = make_jaspr(circuit_fixed)()
@@ -405,14 +417,9 @@ def test_decompose_parametrized_xxyy():
     decomposed = decompose_composite_gates(jaspr)
 
     # --- structural check ---
+    assert_composite_gates(jaspr)
     assert_no_composite_gates(decomposed)
-
-    for eqn in decomposed.eqns:
-        if eqn.primitive == quantum_gate_p:
-            gate = eqn.params["gate"]
-            if gate.abstract_params:
-                num_param_invars = len(eqn.invars) - gate.num_qubits - 1
-                assert num_param_invars == len(gate.abstract_params)
+    assert_primitive_gates_invars_match_abstract_params(decomposed)
 
     # --- numerical check ---
     def circuit_fixed():

--- a/tests/jax_tests/test_composite_gate_interpreter.py
+++ b/tests/jax_tests/test_composite_gate_interpreter.py
@@ -19,8 +19,9 @@
 import numpy as np
 import jax.numpy as jnp
 import jax.lax as lax
+from jax.extend.core import ClosedJaxpr
 from qrisp import *
-from qrisp.jasp import make_jaspr
+from qrisp.jasp import make_jaspr, Jaspr
 from qrisp.jasp.interpreter_tools import decompose_composite_gates
 from qrisp.jasp.primitives import quantum_gate_p
 
@@ -33,8 +34,6 @@ from qrisp.jasp.primitives import quantum_gate_p
 def _collect_gates_from_jaxpr(jaxpr):
     """Yield every gate object found in quantum_gate_p equations, recursing
     into jit/while/cond sub-jaxprs."""
-    from jax.extend.core import ClosedJaxpr
-    from qrisp.jasp import Jaspr
 
     for eqn in jaxpr.eqns:
         if eqn.primitive == quantum_gate_p:
@@ -264,3 +263,47 @@ def test_decompose_scan_body():
     # The decomposed jaspr must still be executable and return sensible values
     result = decomposed()
     assert result is not None
+
+
+def test_decompose_parametrized_rxx():
+    """rxx is a composite gate whose sub-gates (gphase, p) carry parametrized
+    expressions (-phi/2 and phi respectively).  Before the fix, the param
+    tracers were silently dropped during decomposition, leaving those sub-gates
+    with no dynamic parameter invars.
+
+    After the fix:
+    * Every primitive gate that has abstract_params must have exactly
+      len(abstract_params) parameter invars in the decomposed jaspr.
+    * Evaluating both jasprs with the same concrete angle must yield the same
+      measurement probability distribution.
+    """
+
+    def circuit(phi):
+        qv = QuantumVariable(2)
+        rxx(phi, qv[0], qv[1])
+        return measure(qv)
+
+    jaspr = make_jaspr(circuit)(0.5)
+    decomposed = decompose_composite_gates(jaspr)
+
+    # --- structural check ---
+    assert_no_composite_gates(decomposed)
+
+    for eqn in decomposed.eqns:
+        if eqn.primitive == quantum_gate_p:
+            gate = eqn.params["gate"]
+            if gate.abstract_params:
+                num_param_invars = len(eqn.invars) - gate.num_qubits - 1
+                assert num_param_invars == len(gate.abstract_params)
+
+    # --- numerical check ---
+    def circuit_fixed():
+        qv = QuantumVariable(2)
+        rxx(0.5, qv[0], qv[1])
+        return measure(qv)
+
+    jaspr_fixed = make_jaspr(circuit_fixed)()
+    decomposed_fixed = decompose_composite_gates(jaspr_fixed)
+
+    assert_same_distribution(jaspr_fixed, decomposed_fixed)
+

--- a/tests/jax_tests/test_composite_gate_interpreter.py
+++ b/tests/jax_tests/test_composite_gate_interpreter.py
@@ -326,12 +326,12 @@ def test_decompose_parametrized_xxyy():
     * Evaluating the decomposed jaspr must yield the same unitary as the original.
     """
 
-    def circuit(phi):
+    def circuit(phi, beta):
         qv = QuantumVariable(2)
-        xxyy(phi, qv[0], qv[1])
+        xxyy(phi, beta, qv[0], qv[1])
         return qv
 
-    jaspr = make_jaspr(circuit)(0.5)
+    jaspr = make_jaspr(circuit)(0.5, 0.4)
     decomposed = decompose_composite_gates(jaspr)
 
     # --- structural check ---

--- a/tests/jax_tests/test_composite_gate_interpreter.py
+++ b/tests/jax_tests/test_composite_gate_interpreter.py
@@ -20,8 +20,10 @@ import numpy as np
 import jax.numpy as jnp
 import jax.lax as lax
 from jax.extend.core import ClosedJaxpr
-from qrisp import *
-from qrisp.jasp import make_jaspr, Jaspr
+import sympy
+
+from qrisp import QuantumVariable, prepare, measure, x, h, cx, mcx, rxx, xxyy
+from qrisp.jasp import make_jaspr, qache, quantum_kernel
 from qrisp.jasp.interpreter_tools import decompose_composite_gates
 from qrisp.jasp.primitives import quantum_gate_p
 
@@ -106,7 +108,7 @@ def test_decompose_state_preparation():
     unchanged."""
 
     def main():
-        qv = QuantumFloat(2)
+        qv = QuantumVariable(2)
         prepare(qv, np.array([0.2, 0.4, 0.7, 0.5]))
         return measure(qv)
 
@@ -130,7 +132,7 @@ def test_decompose_mcx():
     the correct deterministic measurement outcome."""
 
     def main():
-        qv = QuantumFloat(4)
+        qv = QuantumVariable(4)
         x(qv[0])
         x(qv[1])
         x(qv[2])
@@ -178,7 +180,7 @@ def test_decompose_nested_jaspr():
     BE = BlockEncoding.from_operator(H_op)
 
     def main():
-        qv = QuantumFloat(2)
+        qv = QuantumVariable(2)
         ancs = BE.apply(qv)
         return measure(qv)
 
@@ -203,7 +205,7 @@ def test_call_graph_compression_preserved():
         prepare(qv, np.array([0.2, 0.4, 0.7, 0.5]))
 
     def main():
-        qv = QuantumFloat(2)
+        qv = QuantumVariable(2)
         test(qv)
         test(qv)
         return measure(qv)
@@ -240,7 +242,7 @@ def test_decompose_scan_body():
 
     @quantum_kernel
     def random_number():
-        qv = QuantumFloat(2)
+        qv = QuantumVariable(2)
         prepare(qv, np.array([0.3, 0.7, 0.2, 0.8]))
         return measure(qv)
 
@@ -272,6 +274,74 @@ def test_decompose_scan_body():
     # The decomposed jaspr must still be executable and return sensible values
     result = decomposed()
     assert result is not None
+
+
+def test_decompose_constant_param_subgates():
+    """Composite gates whose internal sub-gates carry plain numeric constants
+    as params (empty abstract_params, non-empty params) must have those
+    constants promoted to explicit JAX literal invars after decomposition.
+
+    xxyy(phi, beta) is the canonical example: its definition includes sub-gates
+    such as rz(-π/2) whose angle is a fixed Python float — not derived from phi
+    or beta.  Before the fix those values were embedded in the gate object and
+    not passed as invars, so the MLIR lowering received a gate without its
+    expected angle input variable.
+
+    Invariant checked here (distinct from test_decompose_parametrized_xxyy):
+    after decomposition every gate's params list must contain only sympy
+    expressions (symbols or symbolic expressions), never raw Python numerics.
+    A raw float/int in gate.params means the angle is still embedded rather
+    than lifted to an invar.
+    """
+
+    def circuit(phi, beta):
+        qv = QuantumVariable(2)
+        xxyy(phi, beta, qv[0], qv[1])
+        return qv
+
+    jaspr = make_jaspr(circuit)(0.5, 0.4)
+
+    # Sanity-check: at least one sub-gate with constant (non-symbolic) params
+    # exists in the original composite definition so the test is meaningful.
+    found_const_param_gate = False
+    for gate in _collect_gates_from_jaxpr(jaspr):
+        if gate.definition is not None:
+            for instr in gate.definition.data:
+                sub = instr.op
+                if sub.params and not sub.abstract_params:
+                    found_const_param_gate = True
+                    break
+    assert found_const_param_gate, (
+        "Expected at least one sub-gate with constant params inside the "
+        "composite gate definition; the test may need updating."
+    )
+
+    decomposed = decompose_composite_gates(jaspr)
+    assert_no_composite_gates(decomposed)
+
+    # Core assertion: no gate may retain a raw Python numeric in its params
+    # list.  All parameter values must be sympy expressions so that the MLIR
+    # lowering can find them as explicit input variables.
+    for eqn in decomposed.eqns:
+        if eqn.primitive == quantum_gate_p:
+            gate = eqn.params["gate"]
+            for param in gate.params:
+                assert isinstance(param, sympy.Basic), (
+                    f"Gate '{gate.name}' has a raw numeric param {param!r} "
+                    f"({type(param).__name__}) embedded in the gate object "
+                    f"after decomposition.  It must be a sympy expression so "
+                    f"that every angle is an explicit invar for MLIR lowering."
+                )
+
+    # Unitary check: use hardcoded params so to_qc() needs no arguments.
+    def circuit_fixed():
+        qv = QuantumVariable(2)
+        xxyy(0.5, 0.4, qv[0], qv[1])
+        return qv
+
+    jaspr_fixed = make_jaspr(circuit_fixed)()
+    decomposed_fixed = decompose_composite_gates(jaspr_fixed)
+    assert_same_unitary(jaspr_fixed, decomposed_fixed)
 
 
 def test_decompose_parametrized_rxx():
@@ -346,7 +416,7 @@ def test_decompose_parametrized_xxyy():
 
     # --- numerical check ---
     def circuit_fixed():
-        qv = QuantumFloat(2)
+        qv = QuantumVariable(2)
         h(qv)
         xxyy(1.1, 0.4, qv[0], qv[1])
         h(qv)


### PR DESCRIPTION

## Description

`decompose_composite_gates` had two related bugs in `_apply_op`, both in the branch that handles primitive sub-gates (i.e. gates with `definition is None`):

**Bug 1 — symbolic params dropped (original fix)**  
When a parametrized composite gate (e.g. `rxx(phi)`) was decomposed, the symbolic expressions in its primitive sub-gates (e.g. `gphase(-phi/2)`) were silently dropped. The decomposed JASPR contained those sub-gates with no dynamic parameter invars, so execution with any backend — simulator or MLIR — would produce wrong results.

The root cause was that `_apply_op` passed primitive sub-gates straight through to `quantum_gate_p.bind` without (a) evaluating their symbolic parameter expressions against the parent gate's symbol→tracer bindings, or (b) normalising the gate to identity params so downstream consumers do not re-apply the expression a second time.

**Bug 2 — constant params embedded in gate object instead of becoming invars (new fix)**  
Primitive sub-gates with *concrete* (non-symbolic) constant params — such as `rz(-π/2)` inside the `xxyy` decomposition — also fell through to the bare `quantum_gate_p.bind` call with no param invars. The constant angle was embedded in the gate object rather than passed as an explicit invar. This caused the MLIR lowering to emit a gate call with the angle input variable missing entirely, producing malformed output.

## Related Issues

Closes #  
Related to #

## Type of Change

- [ ] Feature (new functionality)
- [ ] Change Request (modification of existing functionality)
- [x] Bug Fix
- [ ] Refactoring (no behavior change)
- [ ] Performance improvement
- [ ] Documentation
- [ ] CI / Build

## Breaking Change?
- [ ] Yes
- [x] No

## What was changed?

**`composite_gate_interpreter.py`**

- Added `_U3_IDENTITY_FACTORIES` and `_make_identity_param_op(op)` — returns a version of a gate whose `params` are exactly `[alpha, beta, ...]` (the dense greek-letter prefix). For standard single-param `U3Gate` types (`gphase`, `rx`, `ry`, `rz`, `p`, `u1`) and the three-param `u3` gate, a fresh gate is created via the existing factory function. This is necessary because `U3Gate.bind_parameters` evaluates the gate's internal `theta/phi/lam/global_phase` fields, not `params` directly — so setting `params` alone is insufficient. For generic `Operation` types the copy's `params` and `abstract_params` are patched directly.

- Fixed `_apply_op` for sub-gates with **symbolic** params: when a primitive sub-gate has `abstract_params`, it now (1) evaluates each `op.params` expression via `lambdify` against the parent gate's symbol→tracer bindings, and (2) calls `_make_identity_param_op` to obtain a gate that downstream consumers can bind correctly. The result is a self-consistent JASPR equation: identity params in the gate object, pre-computed value as the dynamic invar.

- Fixed `_apply_op` for sub-gates with **constant** params: added an `elif op.params:` branch (guarded by `not op.abstract_params`) that promotes each concrete constant to a `jnp.float64` JAX literal tracer and calls `_make_identity_param_op` in the same way as the symbolic path. This ensures every parametrised gate in the decomposed JASPR has its angle(s) as explicit input variables, as required by the MLIR lowering.

**test_composite_gate_interpreter.py**

- Added `test_decompose_parametrized_rxx` — structural check (every primitive gate with `abstract_params` in the decomposed jaspr has exactly `len(abstract_params)` parameter invars) and numerical check (same unitary as the non-decomposed reference).

- Added `test_decompose_parametrized_xxyy` — same two invariants for the two-parameter case.

- Added `test_decompose_constant_param_subgates` — specifically targets Bug 2: verifies that after decomposition every gate's `params` list contains only `sympy.Basic` expressions (never raw Python floats/ints). A raw float in `gate.params` is the observable signature of the constant-param bug. Includes a unitary check on a fixed-param version of the circuit.

## How was it tested?

| Test-ID | Status |
|---------|--------|
| `test_decompose_state_preparation` | ✅ |
| `test_decompose_mcx` | ✅ |
| `test_decompose_cx_is_noop` | ✅ |
| `test_decompose_nested_jaspr` | ✅ |
| `test_call_graph_compression_preserved` | ✅ |
| `test_decompose_scan_body` | ✅ |
| `test_decompose_constant_param_subgates` (new) | ✅ |
| `test_decompose_parametrized_rxx` (new) | ✅ |
| `test_decompose_parametrized_xxyy` (new) | ✅ |

## Reviewer Notes

The key invariant this PR establishes: after `decompose_composite_gates`, every `quantum_gate_p` equation in the resulting JASPR is self-consistent — the gate object has identity params (`params[j] == greek_letters[j]`) and its dynamic invars carry the fully evaluated concrete values, whether those values were computed from symbolic expressions or were plain constants in the original composite definition. No backend needs to interpret the gate's original symbolic expression or read embedded numeric values from the gate object.

The fix deliberately does not touch `jasp_lowering_rules.py`. Making the JASPR semantically correct at the IR level is preferable to compensating for a broken IR inside a single backend lowering rule, because it also fixes correctness for the simulator path (`append_impl`) and the inversion transform (`inv_transform.py`).

The `_U3_IDENTITY_FACTORIES` dictionary must be extended whenever a new named `U3Gate` variant is introduced that has non-zero params. Currently registered: `gphase`, `rx`, `ry`, `rz`, `p`, `u1`, `u3`.