### PR TITLE
Controlled jaspr const fix

### DIFF
--- a/src/qrisp/jasp/interpreter_tools/interpreters/qc_extraction_interpreter.py
+++ b/src/qrisp/jasp/interpreter_tools/interpreters/qc_extraction_interpreter.py
@@ -711,7 +711,7 @@ def make_qc_extraction_eqn_evaluator(qc):
             definition_jaxpr = eqn.params["jaxpr"]
             res = eval_jaxpr(
                 definition_jaxpr.jaxpr, eqn_evaluator=qc_extraction_eqn_evaluator
-            )(*(invalues + definition_jaxpr.consts))
+            )(*(definition_jaxpr.consts + invalues))
 
             if len(definition_jaxpr.jaxpr.outvars) == 1:
                 res = [res]

--- a/src/qrisp/jasp/jasp_expression/control_transform.py
+++ b/src/qrisp/jasp/jasp_expression/control_transform.py
@@ -317,7 +317,7 @@ def multi_control_jaspr(jaspr, num_ctrl, ctrl_state):
     ctrl_avals = [x.aval for x in ctrl_vars]
 
     return make_jaspr(exec_multi_controlled_jaspr(jaspr, num_ctrl, ctrl_state))(
-        *(ctrl_avals + [var.aval for var in jaspr.invars[:-1] + jaspr.constvars])
+        *(ctrl_avals + [var.aval for var in jaspr.invars[:-1]])
     )
 
 

--- a/tests/jax_tests/test_control_compilation.py
+++ b/tests/jax_tests/test_control_compilation.py
@@ -98,3 +98,26 @@ def test_control_compilation():
         return qv
             
     assert main(np.pi, 5) == {15.0: 0.5, 31.0: 0.5}
+
+    # Closed-over array. This should become a JASPR constvar in the qached body.
+    angles = jnp.array([jnp.pi], dtype=jnp.float64)
+
+    @qache
+    def apply_const_angle(qv):
+        rz(angles[0], qv[0]) # angles array is closed over by the apply_const_angle
+
+    def main():
+        ctrl = QuantumBool()
+        qv = QuantumVariable(1)
+
+        h(ctrl[0])
+        h(qv[0])
+
+        with control(ctrl[0]):
+            apply_const_angle(qv)
+
+        return measure(qv)
+
+    jaspr = make_jaspr(main)()
+    jaspr.to_qc()
+    assert jaspify(main)()

--- a/tests/jax_tests/test_control_compilation.py
+++ b/tests/jax_tests/test_control_compilation.py
@@ -99,6 +99,13 @@ def test_control_compilation():
             
     assert main(np.pi, 5) == {15.0: 0.5, 31.0: 0.5}
 
+
+def test_control_qached_fun_closed_over_const():
+    """
+    Test that a qached function which closes over a constant JAX array can be
+    called inside a control block. The closed-over array must become a JASPR constvar in the qached body.
+    """
+
     # Closed-over array. This should become a JASPR constvar in the qached body.
     angles = jnp.array([jnp.pi], dtype=jnp.float64)
 
@@ -120,4 +127,4 @@ def test_control_compilation():
 
     jaspr = make_jaspr(main)()
     jaspr.to_qc()
-    assert jaspify(main)()
+    assert int(jaspify(main)()) in {0, 1}


### PR DESCRIPTION

## Description

Fix a bug where a `@qache`d quantum function that closes over a constant JAX array (e.g. `jnp.array([jnp.pi])`) raised an error when called inside a `control` block. The closed-over array must be lifted as a JASPR `constvar` in the qached body, and this constant must be correctly propagated through the control transformation so that both `jaspr.to_qc()` and `jaspify` execution succeed.

## Related Issues

Closes #
Related to #

## Type of Change

- [ ] Feature (new functionality)
- [ ] Change Request (modification of existing functionality)
- [x] Bug Fix
- [ ] Refactoring (no behavior change)
- [ ] Performance improvement
- [ ] Documentation
- [ ] CI / Build

## Breaking Change?
- [ ] Yes
- [x] No

## What was changed?

- Fixed propagation of `consts`/`constvars` through the control transformation in control_transform.py so that a `@qache`d function's closed-over constant arrays are correctly preserved when `control_jaspr` / `ControlledJaspr` constructs the controlled version.
- Added test `test_control_qached_fun_closed_over_const` to test_control_compilation.py covering the bug scenario: a `@qache`d function closing over a `jnp.array` constant called inside a `with control(...)` block.

## How was it tested?

| Test-ID | Status |
|---------|--------|
| `test_control_qached_fun_closed_over_const` | ✅ |
| `test_control_compilation` (full suite) | ✅ |

The new test constructs a `@qache`d function `apply_const_angle` that closes over a `jnp.float64` array and applies `rz` with it, then calls that function inside `with control(ctrl[0])`. It asserts both `jaspr.to_qc()` succeeds and that `int(jaspify(main)()) in {0, 1}`.

## Checklist
- [x] My code follows the project's coding standards
- [x] I have performed a self-review
- [x] I have added/updated tests (referencing issue Test-IDs)
- [x] All tests pass locally and in CI
- [ ] I have updated the documentation
- [ ] I have added a changelog entry
- [ ] Breaking changes are documented with migration path

## Reviewer Notes
