### PR TITLE
Remove terms with zero coefficients in QubitOperator

### DIFF
--- a/src/qrisp/operators/qubit/qubit_operator.py
+++ b/src/qrisp/operators/qubit/qubit_operator.py
@@ -34,7 +34,6 @@ from qrisp.misc.exceptions import QrispDeprecationWarning
 
 from qrisp.jasp import check_for_tracing_mode, jrange, qache
 
-
 threshold = 1e-9
 
 #
@@ -385,7 +384,7 @@ class QubitOperator(Hamiltonian):
                 res_terms_dict[curr_term] = (
                     res_terms_dict.get(curr_term, 0) + curr_coeff * coeff1 * coeff2
                 )
-        
+
         res_terms_dict = {
             term: coeff
             for term, coeff in res_terms_dict.items()
@@ -482,7 +481,7 @@ class QubitOperator(Hamiltonian):
                 res_terms_dict[curr_term] = (
                     res_terms_dict.get(curr_term, 0) + curr_coeff * coeff1 * coeff2
                 )
-    
+
         res_terms_dict = {
             term: coeff
             for term, coeff in res_terms_dict.items()

--- a/src/qrisp/operators/qubit/qubit_operator.py
+++ b/src/qrisp/operators/qubit/qubit_operator.py
@@ -385,7 +385,12 @@ class QubitOperator(Hamiltonian):
                 res_terms_dict[curr_term] = (
                     res_terms_dict.get(curr_term, 0) + curr_coeff * coeff1 * coeff2
                 )
-
+        
+        res_terms_dict = {
+            term: coeff
+            for term, coeff in res_terms_dict.items()
+            if abs(coeff) >= threshold
+        }
         result = QubitOperator(res_terms_dict)
         return result
 
@@ -457,6 +462,13 @@ class QubitOperator(Hamiltonian):
             # other = QubitOperator({QubitTerm():other})
             for term in self.terms_dict:
                 self.terms_dict[term] *= other
+
+            res_terms_dict = {
+                term: coeff
+                for term, coeff in self.terms_dict.items()
+                if abs(coeff) >= threshold
+            }
+            self.terms_dict = res_terms_dict
             return self
 
         if not isinstance(other, QubitOperator):
@@ -470,7 +482,12 @@ class QubitOperator(Hamiltonian):
                 res_terms_dict[curr_term] = (
                     res_terms_dict.get(curr_term, 0) + curr_coeff * coeff1 * coeff2
                 )
-
+    
+        res_terms_dict = {
+            term: coeff
+            for term, coeff in res_terms_dict.items()
+            if abs(coeff) >= threshold
+        }
         self.terms_dict = res_terms_dict
         return self
 

--- a/tests/operators_tests/test_qubit_operator.py
+++ b/tests/operators_tests/test_qubit_operator.py
@@ -16,14 +16,20 @@
 ********************************************************************************
 """
 
-from qrisp.operators.qubit import QubitOperator, QubitTerm, X ,Y, Z
+from qrisp.operators.qubit import X
 
 def test_qubit_operator_mul_by_zero():
     """Test that multiplying a QubitOperator by zero results in an operator with an empty terms dict, 
     rather than a dict with a single term with zero coefficient."""
     op = X(1) * 0
     assert op.terms_dict == {}
+    assert not op.find_minimal_qubit_amount()
+
+    op = 0 * X(1)
+    assert op.terms_dict == {}
+    assert not op.find_minimal_qubit_amount()
 
     op = X(1)
     op *= 0
     assert op.terms_dict == {}
+    assert not op.find_minimal_qubit_amount()

--- a/tests/operators_tests/test_qubit_operator.py
+++ b/tests/operators_tests/test_qubit_operator.py
@@ -1,0 +1,29 @@
+"""
+********************************************************************************
+* Copyright (c) 2026 the Qrisp authors
+*
+* This program and the accompanying materials are made available under the
+* terms of the Eclipse Public License 2.0 which is available at
+* http://www.eclipse.org/legal/epl-2.0.
+*
+* This Source Code may also be made available under the following Secondary
+* Licenses when the conditions for such availability set forth in the Eclipse
+* Public License, v. 2.0 are satisfied: GNU General Public License, version 2
+* with the GNU Classpath Exception which is
+* available at https://www.gnu.org/software/classpath/license.html.
+*
+* SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+********************************************************************************
+"""
+
+from qrisp.operators.qubit import QubitOperator, QubitTerm, X ,Y, Z
+
+def test_qubit_operator_mul_by_zero():
+    """Test that multiplying a QubitOperator by zero results in an operator with an empty terms dict, 
+    rather than a dict with a single term with zero coefficient."""
+    op = X(1) * 0
+    assert op.terms_dict == {}
+
+    op = X(1)
+    op *= 0
+    assert op.terms_dict == {}


### PR DESCRIPTION
## Description

Remove terms with coefficients below the `threshold` in`mul`, `imul` operation of `QubitOperator`.

## Related Issues

<!-- Link related issues. Use closing keywords to auto-close them on merge. -->
Closes #
Related to #611

## Type of Change

<!-- Check all that apply -->
- [ ] Feature (new functionality)
- [ ] Change Request (modification of existing functionality)
- [x] Bug Fix
- [ ] Refactoring (no behavior change)
- [ ] Performance improvement
- [ ] Documentation
- [ ] CI / Build

## Breaking Change?
- [ ] Yes
- [ ] No

If yes, describe the impact and migration path:


## What was changed?

<!-- Bullet list of concrete changes -->
-
-

## How was it tested?

<!-- Optional - Reference Test-IDs from the linked issue(s) and describe any additional testing. -->

| Test-ID | Status |
|---------|--------|
| test_qubit_operator_mul_by_zero  | ✅ |


## Screenshots / Output (if applicable)

<!-- Add additional information if it helps -->

## Checklist
- [x] My code follows the project's coding standards
- [x] I have performed a self-review
- [x] I have added/updated tests (referencing issue Test-IDs)
- [x] All tests pass locally and in CI
- [ ] I have updated the documentation
- [ ] I have added a changelog entry
- [ ] Breaking changes are documented with migration path

## Reviewer Notes

<!-- Anything specific the reviewer should focus on? -->