### PR TITLE
Replacing `Param` with `FloatLike`

### DIFF
--- a/src/qrisp/circuit/operation.py
+++ b/src/qrisp/circuit/operation.py
@@ -28,7 +28,7 @@ from sympy import lambdify
 from sympy.core.expr import Expr
 
 if TYPE_CHECKING:
-    from qrisp.typing import Param
+    from qrisp.typing import FloatLike
 
 
 def adaptive_substitution(expr, subs_dic, precision=10):
@@ -116,7 +116,7 @@ class Operation:
         self.num_clbits = num_clbits
 
         # List of parameters (also available behind the interface)
-        self.params: list[Param] = []
+        self.params: list[FloatLike] = []
 
         # If a definition circuit is given, this means we are supposed to create a
         # non-elementary operation
@@ -461,11 +461,11 @@ class Operation:
 class U3Gate(Operation):
     def __init__(
         self,
-        theta: Param,
-        phi: Param,
-        lam: Param,
+        theta: FloatLike,
+        phi: FloatLike,
+        lam: FloatLike,
         name: str = "u3",
-        global_phase: Param = 0,
+        global_phase: FloatLike = 0,
     ):
 
         # Initialize Operation instance

--- a/src/qrisp/circuit/quantum_circuit.py
+++ b/src/qrisp/circuit/quantum_circuit.py
@@ -48,7 +48,7 @@ if TYPE_CHECKING:
     from qrisp.jasp.interpreter_tools.interpreters.qc_extraction_interpreter import (
         ParityHandle,
     )
-    from qrisp.typing import ClbitLike, Param, QubitLike
+    from qrisp.typing import ClbitLike, FloatLike, QubitLike
 
 
 TO_GATE_COUNTER = np.zeros(1)
@@ -2563,13 +2563,13 @@ class QuantumCircuit:
         """
         self.append(ops.ZGate(), [qubits])
 
-    def rx(self, phi: Param, qubits: QubitLike):
+    def rx(self, phi: FloatLike, qubits: QubitLike):
         """
         Instruct a parametrized RX-gate.
 
         Parameters
         ----------
-        phi : Param
+        phi : FloatLike
             The angle parameter.
 
         qubits : QubitLike
@@ -2579,13 +2579,13 @@ class QuantumCircuit:
             return
         self.append(ops.RXGate(phi), [qubits])
 
-    def ry(self, phi: Param, qubits: QubitLike):
+    def ry(self, phi: FloatLike, qubits: QubitLike):
         """
         Instruct a parametrized RY-gate.
 
         Parameters
         ----------
-        phi : Param
+        phi : FloatLike
             The angle parameter.
 
         qubits : QubitLike
@@ -2596,13 +2596,13 @@ class QuantumCircuit:
             return
         self.append(ops.RYGate(phi), [qubits])
 
-    def rz(self, phi: Param, qubits: QubitLike):
+    def rz(self, phi: FloatLike, qubits: QubitLike):
         """
         Instruct a parametrized RZ-gate.
 
         Parameters
         ----------
-        phi : Param
+        phi : FloatLike
             The angle parameter.
 
         qubits : QubitLike
@@ -2612,13 +2612,13 @@ class QuantumCircuit:
             return
         self.append(ops.RZGate(phi), [qubits])
 
-    def cp(self, phi: Param, qubits_0: QubitLike, qubits_1: QubitLike):
+    def cp(self, phi: FloatLike, qubits_0: QubitLike, qubits_1: QubitLike):
         """
         Instruct a controlled phase-gate.
 
         Parameters
         ----------
-        phi : Param
+        phi : FloatLike
             The angle parameter.
 
         qubits_0 : QubitLike
@@ -2631,13 +2631,13 @@ class QuantumCircuit:
             return
         self.append(ops.CPGate(phi), [qubits_0, qubits_1])
 
-    def p(self, phi: Param, qubits: QubitLike):
+    def p(self, phi: FloatLike, qubits: QubitLike):
         """
         Instruct a phase-gate.
 
         Parameters
         ----------
-        phi : Param
+        phi : FloatLike
             The angle parameter.
 
         qubits : QubitLike
@@ -2647,13 +2647,13 @@ class QuantumCircuit:
             return
         self.append(ops.PGate(phi), [qubits])
 
-    def rxx(self, phi: Param, qubits_0: QubitLike, qubits_1: QubitLike):
+    def rxx(self, phi: FloatLike, qubits_0: QubitLike, qubits_1: QubitLike):
         """
         Instruct an RXX-gate.
 
         Parameters
         ----------
-        phi : Param
+        phi : FloatLike
             The angle parameter.
 
         qubits_0 : QubitLike
@@ -2667,13 +2667,13 @@ class QuantumCircuit:
             return
         self.append(ops.RXXGate(phi), [qubits_0, qubits_1])
 
-    def rzz(self, phi: Param, qubits_0: QubitLike, qubits_1: QubitLike):
+    def rzz(self, phi: FloatLike, qubits_0: QubitLike, qubits_1: QubitLike):
         """
         Instruct an RZZ-gate.
 
         Parameters
         ----------
-        phi : Param
+        phi : FloatLike
             The angle parameter.
 
         qubits_0 : QubitLike
@@ -2687,15 +2687,17 @@ class QuantumCircuit:
             return
         self.append(ops.RZZGate(phi), [qubits_0, qubits_1])
 
-    def xxyy(self, phi: Param, beta: Param, qubits_0: QubitLike, qubits_1: QubitLike):
+    def xxyy(
+        self, phi: FloatLike, beta: FloatLike, qubits_0: QubitLike, qubits_1: QubitLike
+    ):
         """
         Instruct an XXYY-gate.
 
         Parameters
         ----------
-        phi : Param
+        phi : FloatLike
             The angle parameter.
-        beta : Param
+        beta : FloatLike
             The other angle parameter
         qubits_0 : QubitLike
             The Qubit to apply the gate on.
@@ -2774,13 +2776,13 @@ class QuantumCircuit:
 
         self.mcx([ctrl_qubit_0, ctrl_qubit_1], target_qubit, method=method)
 
-    def crx(self, phi: Param, qubits_0: QubitLike, qubits_1: QubitLike):
+    def crx(self, phi: FloatLike, qubits_0: QubitLike, qubits_1: QubitLike):
         """
         Instruct a controlled rx-gate.
 
         Parameters
         ----------
-        phi : Param
+        phi : FloatLike
             The angle parameter.
 
         qubits_0 : QubitLike
@@ -2890,7 +2892,7 @@ class QuantumCircuit:
 
         self.append(ops.Reset(), [qubits])
 
-    def u3(self, theta: Param, phi: Param, lam: Param, qubits: QubitLike):
+    def u3(self, theta: FloatLike, phi: FloatLike, lam: FloatLike, qubits: QubitLike):
         r"""
         Instruct a U3-gate from given Euler angles.
 
@@ -2905,11 +2907,11 @@ class QuantumCircuit:
 
         Parameters
         ----------
-        theta : Param
+        theta : FloatLike
             The theta parameter.
-        phi : Param
+        phi : FloatLike
             The phi parameter.
-        lam : Param
+        lam : FloatLike
             The lambda parameter.
         qubits : QubitLike
             The Qubit to apply the u3 gate on.
@@ -2917,7 +2919,7 @@ class QuantumCircuit:
         """
         self.append(ops.u3Gate(theta, phi, lam), [qubits])
 
-    def r(self, phi: Param, theta: Param, qubits: QubitLike):
+    def r(self, phi: FloatLike, theta: FloatLike, qubits: QubitLike):
         self.append(ops.RGate(phi, theta), [qubits])
 
     def unitary(self, unitary_array, qubits: QubitLike):
@@ -2959,7 +2961,7 @@ class QuantumCircuit:
         self.append(U3Gate(theta, phi, lam, global_phase=gphase), qubits)
         # self.u3(theta, phi, lam, [qubits], global_phase = gphase)
 
-    def gphase(self, phi: Param, qubits: QubitLike):
+    def gphase(self, phi: FloatLike, qubits: QubitLike):
         """
         Instruct a global phase. Global phases do not directly influence the
         QuantumCircuits outcome however they can become physical if used as a base gate
@@ -2967,7 +2969,7 @@ class QuantumCircuit:
 
         Parameters
         ----------
-        phi : Param
+        phi : FloatLike
             The angle parameter.
         qubits : QubitLike
             The Qubit to apply the gate on.

--- a/src/qrisp/circuit/standard_operations.py
+++ b/src/qrisp/circuit/standard_operations.py
@@ -27,7 +27,7 @@ from qrisp.circuit import PauliGate, U3Gate
 from qrisp.circuit.operation import Operation
 
 if TYPE_CHECKING:
-    from qrisp.typing import Param
+    from qrisp.typing import FloatLike
 
 # TODO: properly treat all gates
 # from Aer.get_backend('qasm_simulator').configuration().basis_gates
@@ -67,12 +67,12 @@ def MCXGate(control_amount=1, ctrl_state=-1, method="gray"):
     return XGate().control(control_amount, method=method, ctrl_state=ctrl_state)
 
 
-def PGate(phi: Param = 0):
+def PGate(phi: FloatLike = 0):
     res = U3Gate(0, 0, phi, name="p")
     return res
 
 
-def CPGate(phi: Param = 0):
+def CPGate(phi: FloatLike = 0):
     if isinstance(phi, (int, float)):
         phi = phi % (2 * np.pi)
         if np.abs(phi - np.pi) < 1e-8:
@@ -96,33 +96,33 @@ def HGate():
     return res
 
 
-def RXGate(phi: Param = 0):
+def RXGate(phi: FloatLike = 0):
     res = U3Gate(phi, -np.pi / 2, np.pi / 2, name="rx")
     return res
 
 
-def RYGate(phi: Param = 0):
+def RYGate(phi: FloatLike = 0):
     res = U3Gate(phi, 0, 0, name="ry")
     return res
 
 
-def RZGate(phi: Param = 0):
+def RZGate(phi: FloatLike = 0):
     res = U3Gate(0, phi, 0, name="rz", global_phase=-phi / 2)
     return res
 
 
-def RGate(theta: Param = 0, phi: Param = 0):
+def RGate(theta: FloatLike = 0, phi: FloatLike = 0):
     res = U3Gate(-theta, phi, -phi, name="r", global_phase=0)
     res.params = [theta, phi]
     return res
 
 
-def GPhaseGate(phi: Param = 0):
+def GPhaseGate(phi: FloatLike = 0):
     res = U3Gate(0, 0, 0, name="gphase", global_phase=phi)
     return res
 
 
-def MCRXGate(phi: Param = 0, control_amount: int = 0):
+def MCRXGate(phi: FloatLike = 0, control_amount: int = 0):
     res = RXGate(phi).control(control_amount)
     res.name = "mcrx"
     return res
@@ -147,7 +147,7 @@ def IDGate():
     return res
 
 
-def RXXGate(phi: Param = 0):
+def RXXGate(phi: FloatLike = 0):
     from qrisp.circuit.quantum_circuit import QuantumCircuit
 
     qc = QuantumCircuit(2)
@@ -168,7 +168,7 @@ def RXXGate(phi: Param = 0):
     return res
 
 
-def RZZGate(phi: Param = 0):
+def RZZGate(phi: FloatLike = 0):
     from qrisp.circuit.quantum_circuit import QuantumCircuit
 
     qc = QuantumCircuit(2)
@@ -185,7 +185,7 @@ def RZZGate(phi: Param = 0):
     return res
 
 
-def XXYYGate(phi: Param = 0, beta: Param = 0):
+def XXYYGate(phi: FloatLike = 0, beta: FloatLike = 0):
     from qrisp.circuit.quantum_circuit import QuantumCircuit
 
     qc = QuantumCircuit(2)
@@ -219,11 +219,11 @@ def Barrier(num_qubits=1):
     return res
 
 
-def u3Gate(theta: Param = 0, phi: Param = 0, lam: Param = 0):
+def u3Gate(theta: FloatLike = 0, phi: FloatLike = 0, lam: FloatLike = 0):
     return U3Gate(theta, phi, lam)
 
 
-def U1Gate(phi: Param = 0):
+def U1Gate(phi: FloatLike = 0):
     res = RZGate(phi)
     res.name = "u1"
     res.params = [phi]

--- a/src/qrisp/typing.py
+++ b/src/qrisp/typing.py
@@ -28,7 +28,14 @@ from sympy import Expr
 from qrisp.circuit.clbit import Clbit
 from qrisp.circuit.qubit import Qubit
 
-__all__ = ["QubitLike", "ClbitLike", "ScalarLike", "NDArrayLike", "ArrayLike", "Param"]
+__all__ = [
+    "QubitLike",
+    "ClbitLike",
+    "ScalarLike",
+    "NDArrayLike",
+    "ArrayLike",
+    "FloatLike",
+]
 
 QubitLike: TypeAlias = Qubit | int | Sequence[Qubit | int]
 """Accepted as a qubit specifier in circuit methods and gate functions.
@@ -95,25 +102,24 @@ True
 True
 """
 
-Param: TypeAlias = (
-    float | int | complex | np.number | Expr | jax.Array | jax.core.Tracer
+FloatLike: TypeAlias = (
+    float | int | np.floating | np.integer | Expr | jax.Array | jax.core.Tracer
 )
 """A gate parameter value.
 
 Covers all types accepted as gate parameters throughout Qrisp: Python numeric
-scalars (``float``, ``int``, ``complex``), NumPy numeric scalars
-(``np.float64``, ``np.int32``, etc. via ``np.number``), symbolic expressions
+scalars (``float``, ``int``), NumPy floating-point and integer scalars
+(``np.float64``, ``np.int32``, etc.), symbolic expressions
 (``sympy.Symbol``, ``sympy.Expr``, and any SymPy expression), concrete JAX
-arrays (``jax.Array``, including 0-d arrays), and JAX tracers
-(``jax.core.Tracer``, produced during ``jax.jit``, ``jax.grad``, etc.).
+arrays (``jax.Array``, including 0-d arrays), and JAX tracers.
 
 Examples
 --------
 
->>> from qrisp.typing import Param
+>>> from qrisp.typing import FloatLike
 >>> import sympy
->>> isinstance(1.5, Param)
+>>> isinstance(1.5, FloatLike)
 True
->>> isinstance(sympy.Symbol("phi"), Param)
+>>> isinstance(sympy.Symbol("phi"), FloatLike)
 True
 """

--- a/tests/test_typing.py
+++ b/tests/test_typing.py
@@ -26,7 +26,14 @@ from sympy import Symbol
 
 from qrisp.circuit.clbit import Clbit
 from qrisp.circuit.qubit import Qubit
-from qrisp.typing import ArrayLike, ClbitLike, NDArrayLike, Param, QubitLike, ScalarLike
+from qrisp.typing import (
+    ArrayLike,
+    ClbitLike,
+    FloatLike,
+    NDArrayLike,
+    QubitLike,
+    ScalarLike,
+)
 
 
 class TestQubitLike:
@@ -181,40 +188,35 @@ class TestArrayLike:
         assert not isinstance(value, ArrayLike)
 
 
-class TestParam:
-    """Tests for the Param type alias."""
+class TestFloatLike:
+    """Tests for the FloatLike type alias."""
 
     @pytest.mark.parametrize("value", [1.5, 0.0, -3.14])
     def test_python_float(self, value):
         """Python floats are valid gate parameters."""
-        assert isinstance(value, Param)
+        assert isinstance(value, FloatLike)
 
     @pytest.mark.parametrize("value", [0, 1, -5])
     def test_python_int(self, value):
         """Python ints are valid gate parameters."""
-        assert isinstance(value, Param)
-
-    @pytest.mark.parametrize("value", [1 + 2j, 0j, complex(0, -1)])
-    def test_python_complex(self, value):
-        """Python complex numbers are valid gate parameters."""
-        assert isinstance(value, Param)
+        assert isinstance(value, FloatLike)
 
     @pytest.mark.parametrize(
         "value",
-        [np.float64(1.0), np.float32(0.5), np.int32(3), np.complex128(1 + 2j)],
+        [np.float64(1.0), np.float32(0.5), np.int32(3)],
     )
     def test_numpy_numeric_scalars(self, value):
-        """NumPy numeric scalars (np.number subclasses) are valid gate parameters."""
-        assert isinstance(value, Param)
+        """NumPy floating-point and integer scalars are valid gate parameters."""
+        assert isinstance(value, FloatLike)
 
     def test_sympy_symbol(self):
         """A sympy.Symbol is a valid gate parameter."""
-        assert isinstance(Symbol("phi"), Param)
+        assert isinstance(Symbol("phi"), FloatLike)
 
     def test_sympy_expression(self):
         """An arbitrary sympy expression is a valid gate parameter."""
         phi = Symbol("phi")
-        assert isinstance(sympy.Integer(2) * phi + sympy.pi, Param)
+        assert isinstance(sympy.Integer(2) * phi + sympy.pi, FloatLike)
 
     def test_jax_tracer(self):
         """JAX tracers encountered during tracing are valid gate parameters."""
@@ -222,16 +224,18 @@ class TestParam:
 
         def f(x):
             results.append(isinstance(x, Tracer))
-            results.append(isinstance(x, Param))
+            results.append(isinstance(x, FloatLike))
             return x
 
         jax.make_jaxpr(f)(1.0)
         assert results[
             0
         ], "make_jaxpr did not produce a Tracer (test precondition failed)"
-        assert results[1], "Tracer is not an instance of Param"
+        assert results[1], "Tracer is not an instance of FloatLike"
 
-    @pytest.mark.parametrize("value", ["phi", [1.0], None, np.array([1.0])])
-    def test_non_param_types_are_rejected(self, value):
-        """Strings, lists, None, and NumPy arrays are not valid gate parameters."""
-        assert not isinstance(value, Param)
+    @pytest.mark.parametrize(
+        "value", ["phi", [1.0], None, np.array([1.0]), 1 + 2j, np.complex128(1 + 2j)]
+    )
+    def test_non_floatlike_types_are_rejected(self, value):
+        """Strings, lists, None, NumPy arrays, and complex numbers are not valid gate parameters."""
+        assert not isinstance(value, FloatLike)


### PR DESCRIPTION
## Description

Renames the `Param` type alias to `FloatLike`.  Furthermore, `complex` is removed and the broad `np.number` is replaced with the explicit `np.floating | np.integer` to exclude complex NumPy scalar types. 
All call sites, imports, and tests are updated accordingly.

## Related Issues

<!-- Link related issues. Use closing keywords to auto-close them on merge. -->

Related to #587

## Type of Change

<!-- Check all that apply -->
- [ ] Feature (new functionality)
- [x] Change Request (modification of existing functionality)
- [ ] Bug Fix
- [x] Refactoring (no behavior change)
- [ ] Performance improvement
- [ ] Documentation
- [ ] CI / Build

## Breaking Change?
- [ ] Yes
- [x] No

## What was changed?

- Renamed `Param` → `FloatLike` in `src/qrisp/typing.py`, including `__all__` and docstring examples
- Replaced `np.number` with `np.floating | np.integer` in `FloatLike` to explicitly exclude complex NumPy scalar types
- Removed `complex` from `FloatLike` (gate parameters are real-valued rotation angles)
- Updated the import and all type annotations in `src/qrisp/circuit/operation.py`, `src/qrisp/circuit/standard_operations.py`, and `src/qrisp/circuit/quantum_circuit.py`
- Updated `tests/test_typing.py`: renamed `TestParam` → `TestFloatLike`, removed the `test_python_complex` test, dropped `np.complex128` from the accepted-scalars parametrize list, and added `complex` and `np.complex128` to the rejected-types parametrize list

## How was it tested?

| Test-ID | Status |
|---------|--------|
| `tests/test_typing.py::TestFloatLike` (all 18 cases) | ✅ |


## Checklist
- [x] My code follows the project's coding standards
- [x] I have performed a self-review
- [x] I have added/updated tests (referencing issue Test-IDs)
- [x] All tests pass locally and in CI
- [ ] I have updated the documentation
- [ ] I have added a changelog entry
- [x] Breaking changes are documented with migration path