### PR TITLE
Remove `Job.submit()` from the public interface

### DIFF
--- a/documentation/source/reference/Backend Interface/Abstract Backend Interface/Job.rst
+++ b/documentation/source/reference/Backend Interface/Abstract Backend Interface/Job.rst
@@ -23,7 +23,6 @@ Abstract Methods
 .. autosummary::
    :toctree: generated/
 
-   Job.submit
    Job.result
    Job.cancel
    Job.status

--- a/documentation/source/reference/Backend Interface/Abstract Backend Interface/generated/qrisp.interface.Job.submit.rst
+++ b/documentation/source/reference/Backend Interface/Abstract Backend Interface/generated/qrisp.interface.Job.submit.rst
@@ -1,6 +1,0 @@
-﻿qrisp.interface.Job.submit
-==========================
-
-.. currentmodule:: qrisp.interface
-
-.. automethod:: Job.submit

--- a/documentation/source/reference/Backend Interface/Hardware Backends/AQTBackend.rst
+++ b/documentation/source/reference/Backend Interface/Hardware Backends/AQTBackend.rst
@@ -8,3 +8,5 @@ AQTBackend
 .. autoclass:: AQTBackend
    :members:
 
+.. automethod:: AQTBackend.run_async
+

--- a/documentation/source/reference/Backend Interface/Hardware Backends/QiskitBackend.rst
+++ b/documentation/source/reference/Backend Interface/Hardware Backends/QiskitBackend.rst
@@ -5,3 +5,5 @@ QiskitBackend
 
 .. currentmodule:: qrisp.interface
 .. autoclass:: QiskitBackend
+
+.. automethod:: QiskitBackend.run_async

--- a/documentation/source/reference/Backend Interface/index.rst
+++ b/documentation/source/reference/Backend Interface/index.rst
@@ -380,7 +380,7 @@ the execution is synchronous or asynchronous.
 This follows the *Future* (or *Promise*) pattern: execution happens independently of the
 caller, and the caller decides when to block for the result.
 
-The base ``Job`` class defines *only the observable contract*: four abstract methods that
+The base ``Job`` class defines *only the observable contract*: three abstract methods that
 every concrete implementation must provide.
 It deliberately prescribes no internal synchronisation mechanism.
 A synchronous simulator may resolve the job inline; an asynchronous hardware backend
@@ -400,9 +400,8 @@ From the caller's perspective, both are used identically:
    # Attempt cancellation (best-effort, may return False if already done).
    accepted = job.cancel()
 
-Concrete subclasses must implement the four abstract methods:
+Concrete subclasses must implement three abstract methods:
 
-- :meth:`~qrisp.interface.Job.submit`: trigger the actual execution.
 - :meth:`~qrisp.interface.Job.result`: block until the result is available and return it.
 - :meth:`~qrisp.interface.Job.cancel`: attempt to cancel the job.
 - :meth:`~qrisp.interface.Job.status`: return the current :ref:`JobStatus` without blocking.
@@ -431,7 +430,7 @@ during its lifecycle.
 
 The six states are:
 
-- ``INITIALIZING``: the job has been created but not yet submitted to the backend.
+- ``INITIALIZING``: the job has been created and execution has not yet been handed off to the backend.
 - ``QUEUED``: the job has been submitted and is waiting for execution resources.
 - ``RUNNING``: the job is currently being executed.
 - ``DONE``: the job completed successfully. Results are available via :meth:`~qrisp.interface.Job.result`.

--- a/documentation/source/reference/Backend Interface/index.rst
+++ b/documentation/source/reference/Backend Interface/index.rst
@@ -406,6 +406,20 @@ Concrete subclasses must implement three abstract methods:
 - :meth:`~qrisp.interface.Job.cancel`: attempt to cancel the job.
 - :meth:`~qrisp.interface.Job.status`: return the current :ref:`JobStatus` without blocking.
 
+.. note::
+
+   *Submission responsibility:* ``Job`` does not mandate how or when a job transitions
+   out of :attr:`~qrisp.interface.JobStatus.INITIALIZING`. That responsibility belongs
+   entirely to the concrete backend author. 
+   
+   The only hard contract is that the job returned by
+   :meth:`~qrisp.interface.Backend.run_async` must not still be in
+   :attr:`~qrisp.interface.JobStatus.INITIALIZING` state.
+
+   For real-world examples, see
+   :meth:`QiskitBackend.run_async <qrisp.interface.QiskitBackend.run_async>` and
+   :meth:`AQTBackend.run_async <qrisp.interface.AQTBackend.run_async>`.
+
 Several non-blocking convenience helpers are provided by the base class
 and derived from :meth:`~qrisp.interface.Job.status`:
 
@@ -430,7 +444,10 @@ during its lifecycle.
 
 The six states are:
 
-- ``INITIALIZING``: the job has been created and execution has not yet been handed off to the backend.
+- ``INITIALIZING``: the job object has been created but execution has not yet been
+  handed off to the backend. This is a transient state: a correctly implemented backend
+  must ensure that every job exits ``INITIALIZING`` before :meth:`~qrisp.interface.Backend.run_async`
+  returns.
 - ``QUEUED``: the job has been submitted and is waiting for execution resources.
 - ``RUNNING``: the job is currently being executed.
 - ``DONE``: the job completed successfully. Results are available via :meth:`~qrisp.interface.Job.result`.

--- a/src/qrisp/interface/backend.py
+++ b/src/qrisp/interface/backend.py
@@ -221,19 +221,17 @@ class Backend(ABC):
         """
         Submit one or more circuits for execution and return a :class:`Job`.
 
-        Before returning, every concrete implementation should call
-        :meth:`job.submit() <qrisp.interface.Job.submit>` on the newly created
-        job. :meth:`~qrisp.interface.Job.submit` is the hook that moves the job out of
-        :attr:`~qrisp.interface.JobStatus.INITIALIZING`, signalling that execution
-        has been handed off to the backend. The exact state the job enters depends
-        on the backend type:
+        The returned job must not be in
+        :attr:`~qrisp.interface.JobStatus.INITIALIZING` state: by the time
+        ``run_async`` returns, execution must have been handed off to the
+        backend. The exact state the job enters depends on the backend type:
 
         * :attr:`~qrisp.interface.JobStatus.QUEUED`: for asynchronous or remote
           backends where the job waits in a queue before execution begins.
 
-        * :attr:`~qrisp.interface.JobStatus.RUNNING`: for synchronous simulators
-          that start execution immediately inside
-          :meth:`~qrisp.interface.Job.submit`.
+        * :attr:`~qrisp.interface.JobStatus.RUNNING` or
+          :attr:`~qrisp.interface.JobStatus.DONE`: for synchronous simulators
+          that begin (or complete) execution before returning.
 
         Parameters
         ----------

--- a/src/qrisp/interface/backend.py
+++ b/src/qrisp/interface/backend.py
@@ -56,11 +56,21 @@ class BackendLike(Protocol):
         """Human-readable name of the backend."""
         ...
 
+    @overload
+    def run(
+        self, circuits: QuantumCircuit, shots: int | None = None
+    ) -> MeasurementResult: ...
+
+    @overload
+    def run(
+        self, circuits: Sequence[QuantumCircuit], shots: int | None = None
+    ) -> list[MeasurementResult]: ...
+
     def run(
         self,
         circuits: QuantumCircuit | Sequence[QuantumCircuit],
         shots: int | None = None,
-    ):
+    ) -> MeasurementResult | list[MeasurementResult]:
         """Submit circuits and return measurement result(s)."""
         ...
 

--- a/src/qrisp/interface/job.py
+++ b/src/qrisp/interface/job.py
@@ -39,7 +39,10 @@ class JobStatus(StrEnum):
     ----------
 
     INITIALIZING :
-        The job has been created and execution has not yet been handed off to the backend.
+        The job object has been created but execution has not yet been handed off to the
+        backend. This is a transient state: a correctly implemented backend must ensure
+        that every job exits ``INITIALIZING`` before :meth:`~qrisp.interface.Backend.run_async`
+        returns.
     QUEUED :
         The job has been submitted and is waiting for execution resources.
     RUNNING :

--- a/src/qrisp/interface/job.py
+++ b/src/qrisp/interface/job.py
@@ -39,7 +39,7 @@ class JobStatus(StrEnum):
     ----------
 
     INITIALIZING :
-        The job has been created but not yet submitted to the backend.
+        The job has been created and execution has not yet been handed off to the backend.
     QUEUED :
         The job has been submitted and is waiting for execution resources.
     RUNNING :
@@ -219,7 +219,7 @@ class Job(ABC):
 
     .. rubric:: Design contract
 
-    The ``Job`` base class defines *only the observable contract*. That is, the four
+    The ``Job`` base class defines *only the observable contract*. That is, the three
     abstract methods that every concrete job must implement. It deliberately
     prescribes no internal synchronisation mechanism (no threading, no
     asyncio, no polling loop). Each concrete subclass chooses whatever
@@ -281,8 +281,6 @@ class Job(ABC):
         updated at the following points:
 
         * :meth:`status`: every live query updates the cache as a side effect.
-        * :meth:`submit`: transitions to ``QUEUED`` (or ``RUNNING`` for
-          synchronous backends) once execution has been handed off.
         * :meth:`result`: transitions to ``DONE``, ``CANCELLED``, or
           ``ERROR`` when the job reaches a terminal state.
         * :meth:`refresh`: explicitly fetches the live status and caches it
@@ -294,35 +292,6 @@ class Job(ABC):
     # ------------------------------------------------------------------
     # Abstract methods
     # ------------------------------------------------------------------
-
-    @abstractmethod
-    def submit(self) -> None:
-        """
-        Move the job out of ``INITIALIZING``.
-
-        This method is called by :meth:`~qrisp.interface.Backend.run_async`
-        immediately after the job object has been constructed. Its
-        responsibility is to signal that execution has been handed off to the
-        backend by transitioning the job out of ``INITIALIZING``.
-
-        The target state depends on the backend type:
-
-        * ``QUEUED``: the job has been registered with a remote or local queue
-          and is waiting for execution resources.
-
-        * ``RUNNING``: for synchronous backends that begin execution
-          immediately inside this method.
-
-        For backends where submission to the vendor SDK already happened
-        inside :meth:`~qrisp.interface.Backend.run_async` before this method
-        is called (e.g. because the vendor SDK returns a job handle
-        immediately), no additional network call is needed. However,
-        the vendor is responsible for ensuring that the job's status is
-        updated appropriately via :attr:`last_known_status` to reflect
-        that the job is no longer ``INITIALIZING`` (at minimum ``QUEUED``).
-        """
-
-        raise NotImplementedError
 
     @abstractmethod
     def result(self, timeout: float | None = None) -> JobResult:

--- a/tests/interface_tests/conftest.py
+++ b/tests/interface_tests/conftest.py
@@ -47,11 +47,8 @@ class MinimalJob(Job):
         self._error = None
         self._done_event = threading.Event()
 
-    # ── Abstract interface ────────────────────────────────────────────
-
     def submit(self) -> None:
-        # Honour the INITIALIZING → QUEUED transition so the lifecycle
-        # contract is visible even in this minimal helper.
+        """Transition from INITIALIZING to QUEUED."""
         self._last_known_status = JobStatus.QUEUED
 
     def result(self, timeout=None) -> JobResult | None:
@@ -110,8 +107,8 @@ class MinimalBackend(Backend):
             circuits = list(circuits)
         n_shots = shots if shots is not None else self.options.get("shots", 1024)
         job = MinimalJob(backend=self)
-        job.submit()  # INITIALIZING → QUEUED
-        job._set_status(JobStatus.RUNNING)  # QUEUED → RUNNING
+        job.submit()
+        job._set_status(JobStatus.RUNNING)
         counts = [{"0": n_shots} for _ in circuits]
         job._resolve(JobResult(counts))  # RUNNING → DONE
         return job

--- a/tests/interface_tests/test_backend.py
+++ b/tests/interface_tests/test_backend.py
@@ -1217,7 +1217,7 @@ class JobTestLifecycle:
 
     The only hard guarantee is that a job must exit INITIALIZING before
     run_async() returns. The exact state after that depends on the backend:
-    asynchronous backends transition to QUEUED; synchronous simulators may
+    asynchronous backends transition to QUEUED. Synchronous simulators may
     go directly to RUNNING or DONE.
     """
 

--- a/tests/interface_tests/test_backend.py
+++ b/tests/interface_tests/test_backend.py
@@ -224,8 +224,6 @@ class BackendTest(Backend):
         n_shots = shots if shots is not None else self._options["shots"]
         job = JobTest(circuits=circuits, shots=n_shots, backend=self)
 
-        # Honour the lifecycle contract: every run_async implementation
-        # must call submit() so the job transitions out of INITIALIZING.
         job.submit()  # INITIALIZING → QUEUED
 
         if self.mode == ExecutionMode.SYNC:
@@ -1218,13 +1216,13 @@ class JobTestLifecycle:
     """Tests that the job lifecycle contract is honoured.
 
     The only hard guarantee is that a job must exit INITIALIZING before
-    run_async() returns. The exact post-submit state depends on the backend:
-    asynchronous backends transition to QUEUED. Synchronous simulators may
-    go directly to RUNNING or DONE inside submit().
+    run_async() returns. The exact state after that depends on the backend:
+    asynchronous backends transition to QUEUED; synchronous simulators may
+    go directly to RUNNING or DONE.
     """
 
     def test_job_starts_in_initializing_state(self):
-        """A newly constructed job must start in INITIALIZING before submit() is called."""
+        """A newly constructed job must start in INITIALIZING state."""
         backend = MinimalBackend()
         job = MinimalJob(backend=backend)
         assert job.status() == JobStatus.INITIALIZING
@@ -1247,10 +1245,7 @@ class JobTestLifecycle:
         assert job.status() == JobStatus.QUEUED
 
     def test_run_async_does_not_leave_job_in_initializing(self):
-        """After run_async() returns, the job must no longer be in INITIALIZING state.
-
-        This guards against backends that forget to call submit() before returning.
-        """
+        """After run_async() returns, the job must no longer be in INITIALIZING state."""
         backend = MinimalBackend()
         job = backend.run_async("c")
         assert job.status() != JobStatus.INITIALIZING

--- a/tests/interface_tests/test_job.py
+++ b/tests/interface_tests/test_job.py
@@ -211,10 +211,6 @@ class TestJobAbstractInterface:
         with pytest.raises(TypeError):
             Job(backend=None)
 
-    def test_submit_is_abstract(self):
-        """Test that submit() is declared as an abstract method."""
-        assert getattr(Job.submit, "__isabstractmethod__", False)
-
     def test_result_is_abstract(self):
         """Test that result() is declared as an abstract method."""
         assert getattr(Job.result, "__isabstractmethod__", False)


### PR DESCRIPTION
## Description

This PR removes `Job.submit()` from the abstract interface of the `Job` base class. 

This enables more freedom for the vendor(s) implementing their own `Backend` subclasses.
Concrete subclasses may still define their own `submit()` as an internal implementation detail, and existing backends are left unchanged.

## Related Issues

None.

## Type of Change

<!-- Check all that apply -->
- [ ] Feature (new functionality)
- [x] Change Request (modification of existing functionality)
- [ ] Bug Fix
- [x] Refactoring (no behavior change)
- [ ] Performance improvement
- [x] Documentation
- [ ] CI / Build

## Breaking Change?
- [ ] Yes
- [x] No

If yes, describe the impact and migration path:

> Existing `Job` subclasses that implement `submit()` continue to work without modification. The only scenario that would break is calling `super().submit()` from a subclass (which previously raised `NotImplementedError` anyway).

## What was changed?

- Removed `@abstractmethod submit()` from `Job`. We updated class docstring as well.

- The rest is a consequence of this (see changed files).

## How was it tested?

| Test-ID | Status |
|---------|--------|
| `TestJobAbstractInterface::test_job_cannot_be_instantiated_directly` | ✅ |
| `TestJobAbstractInterface::test_result_is_abstract` | ✅ |
| `TestJobAbstractInterface::test_cancel_is_abstract` | ✅ |
| `TestJobAbstractInterface::test_status_is_abstract` | ✅ |
| `JobTestLifecycle::test_job_starts_in_initializing_state` | ✅ |
| `JobTestLifecycle::test_run_async_does_not_leave_job_in_initializing` | ✅ |
| `JobTestLifecycle::test_full_lifecycle_order_via_set_status` | ✅ |
| Full interface test suite (170 tests) | ✅ |

## Checklist
- [x] My code follows the project's coding standards
- [x] I have performed a self-review
- [x] I have added/updated tests (referencing issue Test-IDs)
- [x] All tests pass locally and in CI
- [x] I have updated the documentation
- [x] Breaking changes are documented with migration path

## Reviewer Notes