### PR TITLE
Fix qiskit warning

### DIFF
--- a/src/qrisp/interface/converter/qiskit_converter.py
+++ b/src/qrisp/interface/converter/qiskit_converter.py
@@ -323,7 +323,7 @@ def convert_from_qiskit(qiskit_qc):
     from sympy import sympify
 
     for i in range(len(qiskit_qc.data)):
-        qiskit_op = qiskit_qc.data[i][0]
+        qiskit_op = qiskit_qc.data[i].operation
 
         if hasattr(qiskit_op, "condition_bits"):
             condition_bits = [cb_dic[cb] for cb in qiskit_op.condition_bits]
@@ -388,7 +388,7 @@ def convert_from_qiskit(qiskit_qc):
                     )
 
         if controlled_gate:
-            qiskit_op = qiskit_qc.data[i][0]
+            qiskit_op = qiskit_qc.data[i].operation
             op = ControlledOperation(
                 base_operation=op,
                 num_ctrl_qubits=qiskit_op.num_ctrl_qubits,
@@ -400,8 +400,8 @@ def convert_from_qiskit(qiskit_qc):
         if op.name == "barrier":
             op = Barrier(qiskit_op.num_qubits)
 
-        qubits = [qb_dic[qb] for qb in qiskit_qc.data[i][1]]
-        clbits = [cb_dic[cb] for cb in qiskit_qc.data[i][2]]
+        qubits = [qb_dic[qb] for qb in qiskit_qc.data[i].qubits]
+        clbits = [cb_dic[cb] for cb in qiskit_qc.data[i].clbits]
 
         if condition_bits:
             clbits += condition_bits


### PR DESCRIPTION

## Description

Fixes a `DeprecationWarning` in the Qiskit circuit converter introduced in Qiskit 1.2, which will become an error in Qiskit 3.0. The `CircuitInstruction` class no longer supports tuple-style index access; the named attributes `.operation`, `.qubits`, and `.clbits` must be used instead.

## Related Issues

Closes https://github.com/eclipse-qrisp/Qrisp/issues/349
Related to #

## Type of Change

- [ ] Feature (new functionality)
- [ ] Change Request (modification of existing functionality)
- [x] Bug Fix
- [ ] Refactoring (no behavior change)
- [ ] Performance improvement
- [ ] Documentation
- [ ] CI / Build

## Breaking Change?
- [ ] Yes
- [x] No

## What was changed?

- In qiskit_converter.py, replaced deprecated index-based access on `CircuitInstruction` objects (`data[i][0]`, `data[i][1]`, `data[i][2]`) with the named attributes `.operation`, `.qubits`, and `.clbits` at all four call sites inside `convert_from_qiskit`.

## How was it tested?

Ran the circuit tests locally (no deprecation warnings emitted, all tests pass):

```
pytest -n 4  # from tests/circuit_tests/
```

## Reviewer Notes

Only qiskit_converter.py is touched. The change is a pure API compatibility fix with no behavioral difference.