### PR TITLE
Enhanced reflection

### DIFF
--- a/src/qrisp/alg_primitives/reflection.py
+++ b/src/qrisp/alg_primitives/reflection.py
@@ -17,8 +17,8 @@
 """
 
 from collections.abc import Callable, Sequence
-import numpy as np
 from typing import Any
+import numpy as np
 
 from qrisp import (
     QuantumArray,
@@ -64,7 +64,7 @@ def reflection(
     state_function : Callable, optional
         A Python function ``state_function(*qargs, *args, **kwargs)`` preparing the state $\ket{\psi}$ in variables ``qargs`` around which to reflect.
         By default, the reflection is performed around the $\ket{0}$ state.
-    args : Sequence, optional
+    args : Sequence[Any], optional
         Additional arguments for the state function.
     kwargs : dict, optional
         Keyword arguments for the state function.
@@ -191,7 +191,8 @@ def reflection(
     if reflection_indices is None:
         reflection_indices = range(len(flattened_qargs))
 
-    qubits = sum([flattened_qargs[i].reg for i in reflection_indices], [])
+    indices = reflection_indices if reflection_indices is not None else range(len(flattened_qargs))
+    qubits = [q for i in indices for q in flattened_qargs[i].reg]
 
     # Reflection around |0> state
     def inner_reflection(qubits, phase):

--- a/src/qrisp/alg_primitives/reflection.py
+++ b/src/qrisp/alg_primitives/reflection.py
@@ -188,9 +188,6 @@ def reflection(
         else:
             raise TypeError("Arguments must be of type QuantumVariable or QuantumArray")
 
-    if reflection_indices is None:
-        reflection_indices = range(len(flattened_qargs))
-
     indices = reflection_indices if reflection_indices is not None else range(len(flattened_qargs))
     qubits = [q for i in indices for q in flattened_qargs[i].reg]
 

--- a/src/qrisp/alg_primitives/reflection.py
+++ b/src/qrisp/alg_primitives/reflection.py
@@ -189,7 +189,7 @@ def reflection(
             raise TypeError("Arguments must be of type QuantumVariable or QuantumArray")
 
     indices = reflection_indices if reflection_indices is not None else range(len(flattened_qargs))
-    qubits = [q for i in indices for q in flattened_qargs[i].reg]
+    qubits = sum([flattened_qargs[i].reg for i in indices], [])
 
     # Reflection around |0> state
     def inner_reflection(qubits, phase):

--- a/src/qrisp/alg_primitives/reflection.py
+++ b/src/qrisp/alg_primitives/reflection.py
@@ -16,7 +16,10 @@
 ********************************************************************************
 """
 
+from collections.abc import Callable, Sequence
 import numpy as np
+from typing import Any
+
 from qrisp import (
     QuantumArray,
     QuantumVariable,
@@ -31,13 +34,18 @@ from qrisp import (
     invert,
     control,
 )
-from qrisp.jasp import jlen, qache
+from qrisp.jasp import jlen
+from qrisp.typing import FloatLike
 
 
-# @qache
 @gate_wrap(permeability=[], is_qfree=False)
 def reflection(
-    qargs, state_function=None, args=(), kwargs={}, phase=np.pi, reflection_indices=None
+    qargs: QuantumVariable | QuantumArray | Sequence[QuantumVariable | QuantumArray],
+    state_function: Callable | None = None,
+    args: Sequence[Any] | None = None,
+    kwargs: dict[str, Any] | None = None,
+    phase: FloatLike = np.pi,
+    reflection_indices: list[int] | None = None,
 ):
     r"""
     Applies a reflection around a state $\ket{\psi}$ of (multiple) QuantumVariables, i.e., applies the operator
@@ -51,18 +59,18 @@ def reflection(
 
     Parameters
     ----------
-    qargs : QuantumVariable | QuantumArray | list[QuantumVariable | QuantumArray]
-        The (list of) QuantumVariables representing the state to apply the reflection on.
-    state_function : function, optional
+    qargs : QuantumVariable | QuantumArray | Sequence[QuantumVariable | QuantumArray]
+        The quantum variable, array, or collection thereof on which the reflection is performed.
+    state_function : Callable, optional
         A Python function ``state_function(*qargs, *args, **kwargs)`` preparing the state $\ket{\psi}$ in variables ``qargs`` around which to reflect.
         By default, the reflection is performed around the $\ket{0}$ state.
-    args : tuple, optional
+    args : Sequence, optional
         Additional arguments for the state function.
     kwargs : dict, optional
         Keyword arguments for the state function.
-    phase : float or sympy.Symbol, optional
+    phase : FloatLike, optional
         Specifies the phase shift. The default is $\pi$.
-    refection_indices : list[int], optional
+    reflection_indices : list[int], optional
         A list of indices indicating with respect to which variables the reflection is performed.
         This is used for `oblivious amplitude amplification <https://arxiv.org/pdf/1312.1414>`_.
         Indices correspond to the flattened ``qargs``, e.g., if ``qargs = QuantumArray(QuantumFloat(3), (6,))``,
@@ -98,7 +106,7 @@ def reflection(
         print(qv)
         # {'00000': 1.0}
 
-    The refletion can also be applied to lists of QuantumVariables and QuantumArrays:
+    The reflection can also be applied to lists of QuantumVariables and QuantumArrays:
 
     ::
 
@@ -129,7 +137,7 @@ def reflection(
         print(multi_measurement([qv, qa]))
         # {('00000', OutcomeArray(['000', '000', '000'], dtype=object)): 1.0}
 
-    Addtional arguments can be passed to the state function:
+    Additional arguments can be passed to the state function:
 
     ::
 
@@ -153,6 +161,12 @@ def reflection(
         # {'00000': 0.9900599999999998,'01000': 0.0024799999999999996,'00100': 0.0024799999999999996,'11011': 0.0024799999999999996,'10111': 0.0024799999999999996,'11111': 1.9999999999999998e-05}
 
     """
+
+    if args is None:
+        args = []
+
+    if kwargs is None:
+        kwargs = {}
 
     if isinstance(qargs, (list, tuple)) and not qargs:
         return

--- a/tests/primitives_tests/test_reflection.py
+++ b/tests/primitives_tests/test_reflection.py
@@ -16,17 +16,28 @@
 ********************************************************************************
 """
 
-def test_reflection():
+from qrisp import QuantumVariable, QuantumFloat, QuantumArray, OutcomeArray, h, x, cx, reflection, multi_measurement
+from qrisp.jasp import terminal_sampling, jrange
 
-    from qrisp import QuantumVariable, QuantumFloat, QuantumArray, OutcomeArray, h, x, cx, reflection, multi_measurement
 
-    # Reflection with QuantumVariable as input
-    def ghz(qv):
-        h(qv[0])
+def ghz(*args):
+    """Prepares a GHZ state on the provided quantum variables."""
 
-        for i in range(1, qv.size):
-            cx(qv[0], qv[i])
+    flattened_qargs = []   
+    for arg in args:
+        if isinstance(arg, QuantumVariable):
+            flattened_qargs.append(arg)
+        elif isinstance(arg, QuantumArray):
+            flattened_qargs.extend([qv for qv in arg.flatten()])
 
+    qubits = sum([arg.reg for arg in flattened_qargs], [])
+    h(qubits[0])
+    for i in range(1, len(qubits)):
+        cx(qubits[0], qubits[i])
+
+
+def test_reflection_quantum_variable():
+    """Tests that the reflection primitive correctly applies a reflection around a GHZ state."""
 
     qv = QuantumVariable(5)
     x(qv)
@@ -38,17 +49,71 @@ def test_reflection():
     assert res == {'00000': 1.0}
 
 
-    # Reflection with list[QuantumVariable | QuantumArray] as input
+def test_reflection_quantum_array():
+    """Tests that the reflection primitive correctly applies a reflection around a GHZ state with QuantumArray input."""
+
+    qa = QuantumArray(QuantumFloat(3), shape=(3,))
+    x(qa)
+    res = qa.get_measurement()
+    assert res == {OutcomeArray([7, 7, 7]): 1.0}
+
+    reflection(qa, ghz)
+    res = qa.get_measurement()
+    assert res == {OutcomeArray([0, 0, 0]): 1.0}
+
+
+def test_reflection_quantum_array():
+    """Tests that the reflection primitive correctly applies a reflection around a GHZ state with QuantumArray input."""
+
+    qa = QuantumArray(QuantumFloat(3), shape=(3,))
+    x(qa)
+    res = qa.get_measurement()
+    assert res == {OutcomeArray([7, 7, 7]): 1.0}
+
+    reflection(qa, ghz)
+    res = qa.get_measurement()
+    assert res == {OutcomeArray([0, 0, 0]): 1.0}
+
+
+def test_reflection_list_quantum_variable():
+    """Tests that the reflection primitive correctly applies a reflection around a GHZ state with list of QuantumVariable input."""
+
+    qv_list = [QuantumVariable(3), QuantumVariable(2)]
+    x(qv_list[0])
+    x(qv_list[1])
+    res = multi_measurement(qv_list)
+    assert res == {('111', '11'): 1.0}
+
+    reflection(qv_list, ghz)
+    res = multi_measurement(qv_list)
+    assert res == {('000', '00'): 1.0}
+
+
+def test_reflection_tuple_quantum_variable():
+    """Tests that the reflection primitive correctly applies a reflection around a GHZ state with tuple of QuantumVariable input."""
+
+    qv_tuple = (QuantumVariable(3), QuantumVariable(2))
+    x(qv_tuple[0])
+    x(qv_tuple[1])
+    res = multi_measurement(qv_tuple)
+    assert res == {('111', '11'): 1.0}
+
+    reflection(qv_tuple, ghz)
+    res = multi_measurement(qv_tuple)
+    assert res == {('000', '00'): 1.0}
+
+
+def test_reflection_list_quantum_varaible_quantum_array():
+    """Tests that the reflection primitive correctly applies a reflection around a GHZ state with list of QuantumVariable and QuantumArray input."""
+
     def ghz(qv, qa):
         h(qv[0])
-
         for i in range(1, qv.size):
             cx(qv[0], qv[i])
 
         for var in qa:
             for i in range(var.size):
                 cx(qv[0], var[i])
-
 
     qv = QuantumVariable(5)
     qa = QuantumArray(QuantumFloat(3), shape=(3,))
@@ -63,17 +128,12 @@ def test_reflection():
 
 
 def test_jasp_reflection():
+    """Tests that the reflection primitive correctly applies a reflection around a GHZ state in Jasp."""
 
-    from qrisp import QuantumVariable, QuantumArray, h, x, cx, reflection
-    from qrisp.jasp import terminal_sampling, jrange
-
-    # Reflection with QuantumVariable as input
     def ghz(qv):
         h(qv[0])
-
         for i in jrange(1, qv.size):
             cx(qv[0], qv[i])
-
 
     @terminal_sampling
     def main():


### PR DESCRIPTION

**Description:**
This PR refines the reflection operator primitive in `qrisp`. It updates the function signature with more precise type hinting and enhances its documentation for better clarity on how it operates across different quantum variable types (single variables, arrays, lists, tuples).

**Changes:**
*   **reflection.py**:
    *   Updated parameter type hints in the `reflection` function to support modern Python typing and handle various input structures (`QuantumVariable`, `QuantumArray`, `Sequence`).
    *   Improved docstrings for better readability and corrected a typo ("refection" -> "reflection").

**Tests:**
The following new tests have been added to test_reflection.py to ensure the reflection primitive works correctly across different input types:
*   `test_reflection_quantum_variable`: Validates reflection with a single `QuantumVariable`.
*   `test_reflection_quantum_array`: Validates reflection when the input is a `QuantumArray`.
*   `test_reflection_list_quantum_variable`: Tests reflection using a list of `QuantumVariables`.
*   `test_reflection_tuple_quantum_variable`: Tests reflection using a tuple of `QuantumVariables`.
*   `test_reflection_list_quantum_varaible_quantum_array`: Validates mixed input types (list containing both `QuantumVariable` and `QuantumArray`).
*   `test_jasp_reflection`: Verifies the primitive's functionality within the JASP environment.