### PR TITLE
fix: add __iter__ to QuantumArrayIterator to satisfy iterator protocol

### DIFF
--- a/src/qrisp/core/quantum_array.py
+++ b/src/qrisp/core/quantum_array.py
@@ -2280,6 +2280,9 @@ class QuantumArrayIterator:
         self.qa = qa
         self.counter = -1
 
+    def __iter__(self):
+        return self
+
     def __next__(self):
         self.counter += 1
         if self.counter >= self.qa.size:


### PR DESCRIPTION
hey, spotted issue #638 while browsing the repo and figured it was a small fix.

the root cause is that `QuantumArrayIterator` defines `__next__` but not `__iter__`, so python doesn't recognise it as a proper iterator. calling `list()` on it (or using it anywhere that expects an iterable) raises the `'QuantumArrayIterator' object is not iterable` error you see in the bug report.

the fix is just adding `__iter__` returning `self`, which is the standard pattern for iterator classes in python.

reproduced the original traceback with the snippet from the issue before and confirmed it passes after the fix. let me know if anything else needs adjusting!