### PR TITLE
fix: Qiskit example on landing page uses deprecated Aer API

### DIFF
--- a/src/qrisp/examples/quantum_arithmetic_example.py
+++ b/src/qrisp/examples/quantum_arithmetic_example.py
@@ -15,7 +15,8 @@ from numpy.linalg import norm
 import time
 from qrisp import QuantumFloat, transpile
 from qrisp.simulator import statevector_sim
-from qiskit import Aer, execute
+from qiskit_aer import AerSimulator
+from qiskit import execute
 
 
 n = 6
@@ -48,8 +49,7 @@ qc.qubits.reverse()
 qiskit_qc = qc.to_qiskit()
 
 start_time = time.time()
-# simulator = Aer.get_backend('qasm_simulator')
-simulator = Aer.get_backend("statevector_simulator")
+simulator = AerSimulator()
 result = execute(qiskit_qc, simulator).result()
 qiskit_res = result.get_statevector(qiskit_qc).data
 print("Qiskit simulator time: ", time.time() - start_time)


### PR DESCRIPTION
Closes #635

## Description
Updates the Qiskit Aer backend initialization in the landing page example to use the current API.

## Type of Change
- [ ] Feature (new functionality)
- [ ] Change Request (modification of existing functionality)
- [x] Bug Fix
- [ ] Refactoring (no behavior change)
- [ ] Performance improvement
- [ ] Documentation
- [ ] CI / Build

## Breaking Change?
- [ ] Yes
- [x] No

If yes, describe the impact and migration path:

## What was changed?
- Replaced deprecated `Aer.get_backend('qasm_simulator')` with `AerSimulator()` in `src/qrisp/examples/quantum_arithmetic_example.py`.
- Updated the corresponding import statement to `from qiskit_aer import AerSimulator`.

## Checklist
- [x] My code follows the project's coding standards
- [ ] I have performed a self-review
- [ ] I have added/updated tests (referencing issue Test-IDs)
- [x] All tests pass locally and in CI
- [x] I have updated the documentation
- [ ] I