### PR TITLE
Enhanced from_lcu constructor

### DIFF
--- a/src/qrisp/block_encodings/constructors/from_eye.py
+++ b/src/qrisp/block_encodings/constructors/from_eye.py
@@ -36,7 +36,7 @@ def build_from_eye(
     Returns
     -------
     BlockEncoding
-        A new BlockEncoding instance representing an array where all elements are equal to zero,
+        A BlockEncoding representing an array where all elements are equal to zero,
         except for the $k$-th diagonal, whose values are equal to one.
 
     Examples

--- a/src/qrisp/block_encodings/constructors/from_lcu.py
+++ b/src/qrisp/block_encodings/constructors/from_lcu.py
@@ -144,11 +144,17 @@ def build_from_lcu(
     if m == 1:
         if np.abs(complex_coeffs[0].imag) < _TOLERANCE:
             return cls(
-                complex_coeffs[0].real, [], unitaries[0], num_ops=num_ops, is_hermitian=is_hermitian
+                complex_coeffs[0].real,
+                [],
+                unitaries[0],
+                num_ops=num_ops,
+                is_hermitian=is_hermitian,
             )
-        
-        raise ValueError("For a single unitary, the coefficient must be real (up to numerical precision).")
-    
+
+        raise ValueError(
+            "For a single unitary, the coefficient must be real (up to numerical precision)."
+        )
+
     # Block encoding of a linear combination of unitaries via the LCU protocol
     # If all coefficients are real and non-negative: LCU = PREP SEL PREP_dg
     if _is_real_non_negative_array(complex_coeffs):
@@ -166,8 +172,8 @@ def build_from_lcu(
             num_ops=num_ops,
             is_hermitian=is_hermitian,
         )
-    
-     # If coefficients are complex or negative, we use a state preparation pair (PREP_R, PREP_L): LCU = PREP_R SEL PREP_L_dg
+
+    # If coefficients are complex or negative, we use a state preparation pair (PREP_R, PREP_L): LCU = PREP_R SEL PREP_L_dg
     complex_coeffs_r = np.sqrt(complex_coeffs / alpha)
     complex_coeffs_l = np.sqrt(complex_coeffs / alpha).conjugate()
 
@@ -188,13 +194,15 @@ def build_from_lcu(
     )
 
 
-def _is_real_non_negative_array(arr: npt.NDArray[np.number], tol: float=_TOLERANCE) -> bool:
+def _is_real_non_negative_array(
+    arr: npt.NDArray[np.number], tol: float = _TOLERANCE
+) -> bool:
     """Checks if all entries in an array are non-negative and have negligible imaginary parts."""
     # 1. Check if the array is a complex type
     if np.issubdtype(arr.dtype, np.complexfloating):
         abs_imag_part = np.abs(arr.imag)
         real_part = arr.real
-        
+
         # Check if imaginary parts are within tolerance AND real parts are non-negative
         return (abs_imag_part < tol).all() and (real_part >= 0).all()
 

--- a/src/qrisp/block_encodings/constructors/from_lcu.py
+++ b/src/qrisp/block_encodings/constructors/from_lcu.py
@@ -16,13 +16,16 @@
 ********************************************************************************
 """
 
+from collections.abc import Callable
+from typing import Any
+
 import numpy as np
 import numpy.typing as npt
-from typing import Any, Callable
 
+from qrisp.alg_primitives.state_preparation import prepare
 from qrisp.block_encodings.block_encoding_base import BlockEncoding
-from qrisp.environments import conjugate
-from qrisp.jasp import qache
+from qrisp.environments import conjugate, invert
+from qrisp.jasp import qache, q_switch
 from qrisp.qtypes import QuantumFloat
 
 
@@ -42,10 +45,11 @@ def build_from_lcu(
 
         O = \sum_{i=0}^{M-1} \alpha_i U_i
 
-    where $\alpha_i$ are real non-negative coefficients such that $\sum_i \alpha_i = \alpha$,
+    where $\alpha_i$ are complex coefficients, $\alpha = \sum_i |\alpha_i|$,
     and $U_i$ are unitaries acting on the same operand quantum variables.
 
-    The block encoding unitary is constructed via the LCU protocol:
+    The block encoding unitary is constructed via the LCU protocol.
+    If all coefficients are real and non-negative, the block encoding unitary can be expressed as
 
     .. math::
 
@@ -53,46 +57,54 @@ def build_from_lcu(
 
     where:
 
-    * **SEL** (Select, in Qrisp: :ref:`q_switch <qswitch>`) applies each unitary $U_i$ conditioned on the auxiliary variable state $\ket{i}_a$:
+    * $SEL$ (Select, in Qrisp: :ref:`q_switch <qswitch>`) applies each unitary $U_i$ conditioned on the auxiliary variable state $\ket{i}_a$:
 
     .. math::
 
         \text{SEL} = \sum_{i=0}^{M-1} \ket{i}\bra{i} \otimes U_i
 
-    * **PREP** (Prepare) prepares the state representing the coefficients:
+    * $PREP$ (Prepare) prepares the state representing the coefficients:
 
     .. math::
 
         \text{PREP} \ket{0}_a = \sum_{i=0}^{M-1} \sqrt{\frac{\alpha_i}{\alpha}} \ket{i}_a
 
+    If the coefficients are complex or negative, a state preparation pair $(PREP_R, PREP_L)$ is used:
+
+    .. math::
+
+        U = \text{PREP}_R \cdot \text{SEL} \cdot \text{PREP}_L^{\dagger}
+
+    * $PREP_R$ and $PREP_L$ prepare the states representing the coefficients and their complex conjugates, respectively:
+
+    .. math::
+
+        \text{PREP}_R \ket{0}_a = \sum_{i=0}^{M-1} \sqrt{\frac{\alpha_i}{\alpha}} \ket{i}_a, \qquad
+        \text{PREP}_L \ket{0}_a = \sum_{i=0}^{M-1} \sqrt{\frac{\alpha_i}{\alpha}}^* \ket{i}_a
+
     Parameters
     ----------
-    coeffs : ArrayLike
-        1-D array of non-negative coefficients $\alpha_i$.
+    coeffs : np.ndarray
+        1-D array containing the complex coefficients $\alpha_i$.
     unitaries : list[Callable]
-        List of functions, where each ``U(*operands)`` applies a unitary
+        List of functions, where each ``unitary(*operands)`` applies a unitary
         transformation in-place to the provided quantum variables.
         All functions must accept the same signature and operate on the
         same set of operands.
-    num_ops : int
-        The number of operand quantum variables. The default is 1.
-    is_hermitian : bool
-        Indicates whether the block-encoding unitary is Hermitian. The default is False.
-        Set to True, if all provided unitaries are Hermitian.
+    num_ops : int, optional
+        The number of operand quantum variables. The defaults to 1.
+    is_hermitian : bool, optional
+        Indicates whether the block-encoding unitary is Hermitian. The defaults to `False`.
+        Set to `True`, if all provided unitaries are Hermitian.
 
     Returns
     -------
     BlockEncoding
-        A BlockEncoding using LCU.
-
-    Raises
-    ------
-    ValueError
-        If any entry in ``coeffs`` is negative, as the LCU protocol only supports positive coefficients.
+        A BlockEncoding representing the operator defined as the linear combination of unitaries.
 
     Notes
     -----
-    - **Normalization**: The block-encoding normalization factor is $\alpha = \sum_i \alpha_i$.
+    - **Normalization**: The block-encoding normalization factor is $\alpha = \sum_i |\alpha_i|$.
 
     Examples
     --------
@@ -113,30 +125,49 @@ def build_from_lcu(
         # {1.0: 0.5, 3.0: 0.5}
 
     """
-    from qrisp.alg_primitives.state_preparation import prepare
-    from qrisp.jasp import q_switch
 
     m = len(coeffs)
     n = (m - 1).bit_length()  # Number of qubits for index variable
     # Ensure coeffs has size 2 ** n by zero padding
     coeffs = np.pad(coeffs, (0, (1 << n) - m))
-    alpha = np.sum(coeffs)
+    alpha = np.sum(np.abs(coeffs))
 
-    if np.any(coeffs < 0):
-        raise ValueError(
-            f"Negative coefficients detected: {coeffs}. Only positive values are supported."
-        )
-
+    # Block encoding of a single unitary (up to normalization)
     if m == 1:
         return cls(
-            alpha, [], unitaries[0], num_ops=num_ops, is_hermitian=is_hermitian
+            coeffs[0], [], unitaries[0], num_ops=num_ops, is_hermitian=is_hermitian
         )
+    
+    # Block encoding of a linear combination of unitaries via the LCU protocol
+    # If all coefficients are real and non-negative: LCU = PREP SEL PREP_dg
+    if _is_real_non_negative_array(coeffs):
+
+        @qache
+        def unitary(*args):
+            # LCU = PREP SEL PREP_dg
+            with conjugate(prepare)(args[0], np.sqrt(coeffs / alpha)):
+                q_switch(args[0], unitaries, *args[1:])
+
+        return cls(
+            alpha,
+            [QuantumFloat(n).template()],
+            unitary,
+            num_ops=num_ops,
+            is_hermitian=is_hermitian,
+        )
+    
+     # If coefficients are complex or negative, we use a state preparation pair (PREP_R, PREP_L): LCU = PREP_R SEL PREP_L_dg
+    complex_coeffs = coeffs.astype(complex)
+    complex_coeffs_r = np.sqrt(complex_coeffs / alpha)
+    complex_coeffs_l = np.sqrt(complex_coeffs / alpha).conjugate()
 
     @qache
     def unitary(*args):
-        # LCU = PREP SEL PREP_dg
-        with conjugate(prepare)(args[0], np.sqrt(coeffs / alpha)):
-            q_switch(args[0], unitaries, *args[1:])
+        # LCU = PREP_R SEL PREP_L_dg
+        prepare(args[0], complex_coeffs_r)
+        q_switch(args[0], unitaries, *args[1:])
+        with invert():
+            prepare(args[0], complex_coeffs_l)
 
     return cls(
         alpha,
@@ -145,3 +176,18 @@ def build_from_lcu(
         num_ops=num_ops,
         is_hermitian=is_hermitian,
     )
+
+
+def _is_real_non_negative_array(arr: npt.NDArray[np.number], tol: float=1e-12):
+    """Checks if all entries in an array are non-negative and have negligible imaginary parts."""
+    # 1. Check if the array is a complex type
+    if np.issubdtype(arr.dtype, np.complexfloating):
+        abs_imag_part = np.abs(arr.imag)
+        real_part = arr.real
+        
+        # Check if imaginary parts are within tolerance AND real parts are non-negative
+        return (abs_imag_part < tol).all() and (real_part >= 0).all()
+
+    else:
+        return np.all(arr >= 0)
+

--- a/src/qrisp/block_encodings/constructors/from_lcu.py
+++ b/src/qrisp/block_encodings/constructors/from_lcu.py
@@ -28,6 +28,8 @@ from qrisp.environments import conjugate, invert
 from qrisp.jasp import qache, q_switch
 from qrisp.qtypes import QuantumFloat
 
+_TOLERANCE = 1e-12
+
 
 def build_from_lcu(
     cls: BlockEncoding,
@@ -102,6 +104,11 @@ def build_from_lcu(
     BlockEncoding
         A BlockEncoding representing the operator defined as the linear combination of unitaries.
 
+    Raises
+    ------
+    ValueError
+        If a single unitary is provided with a complex coefficient (up to numerical precision).
+
     Notes
     -----
     - **Normalization**: The block-encoding normalization factor is $\alpha = \sum_i |\alpha_i|$.
@@ -126,26 +133,30 @@ def build_from_lcu(
 
     """
 
-    m = len(coeffs)
+    complex_coeffs = np.array(coeffs, dtype=complex)
+    m = len(complex_coeffs)
     n = (m - 1).bit_length()  # Number of qubits for index variable
     # Ensure coeffs has size 2 ** n by zero padding
-    coeffs = np.pad(coeffs, (0, (1 << n) - m))
-    alpha = np.sum(np.abs(coeffs))
+    complex_coeffs = np.pad(complex_coeffs, (0, (1 << n) - m))
+    alpha = np.sum(np.abs(complex_coeffs))
 
     # Block encoding of a single unitary (up to normalization)
     if m == 1:
-        return cls(
-            coeffs[0], [], unitaries[0], num_ops=num_ops, is_hermitian=is_hermitian
-        )
+        if np.abs(complex_coeffs[0].imag) < _TOLERANCE:
+            return cls(
+                complex_coeffs[0].real, [], unitaries[0], num_ops=num_ops, is_hermitian=is_hermitian
+            )
+        
+        raise ValueError("For a single unitary, the coefficient must be real (up to numerical precision).")
     
     # Block encoding of a linear combination of unitaries via the LCU protocol
     # If all coefficients are real and non-negative: LCU = PREP SEL PREP_dg
-    if _is_real_non_negative_array(coeffs):
+    if _is_real_non_negative_array(complex_coeffs):
 
         @qache
         def unitary(*args):
             # LCU = PREP SEL PREP_dg
-            with conjugate(prepare)(args[0], np.sqrt(coeffs / alpha)):
+            with conjugate(prepare)(args[0], np.sqrt(complex_coeffs / alpha)):
                 q_switch(args[0], unitaries, *args[1:])
 
         return cls(
@@ -157,7 +168,6 @@ def build_from_lcu(
         )
     
      # If coefficients are complex or negative, we use a state preparation pair (PREP_R, PREP_L): LCU = PREP_R SEL PREP_L_dg
-    complex_coeffs = coeffs.astype(complex)
     complex_coeffs_r = np.sqrt(complex_coeffs / alpha)
     complex_coeffs_l = np.sqrt(complex_coeffs / alpha).conjugate()
 
@@ -178,7 +188,7 @@ def build_from_lcu(
     )
 
 
-def _is_real_non_negative_array(arr: npt.NDArray[np.number], tol: float=1e-12):
+def _is_real_non_negative_array(arr: npt.NDArray[np.number], tol: float=_TOLERANCE) -> bool:
     """Checks if all entries in an array are non-negative and have negligible imaginary parts."""
     # 1. Check if the array is a complex type
     if np.issubdtype(arr.dtype, np.complexfloating):
@@ -190,4 +200,3 @@ def _is_real_non_negative_array(arr: npt.NDArray[np.number], tol: float=1e-12):
 
     else:
         return np.all(arr >= 0)
-

--- a/src/qrisp/block_encodings/constructors/from_lcu.py
+++ b/src/qrisp/block_encodings/constructors/from_lcu.py
@@ -87,7 +87,10 @@ def build_from_lcu(
     Parameters
     ----------
     coeffs : np.ndarray
-        1-D array containing the complex coefficients $\alpha_i$.
+        1-D array containing the real non-negative or complex coefficients.
+            - If all coefficients are real and non-negative, the block encoding unitary is constructed as $U = PREP \cdot SEL \cdot PREP^{\dagger}$.
+            - If coefficients are complex or negative, the block encoding unitary is constructed as $U = PREP_R \cdot SEL \cdot PREP_L^{\dagger}$, 
+              where $PREP_R$ and $PREP_L$ prepare the states representing the coefficients and their complex conjugates, respectively.
     unitaries : list[Callable]
         List of functions, where each ``unitary(*operands)`` applies a unitary
         transformation in-place to the provided quantum variables.
@@ -112,6 +115,10 @@ def build_from_lcu(
     Notes
     -----
     - **Normalization**: The block-encoding normalization factor is $\alpha = \sum_i |\alpha_i|$.
+    - **Performance**: Complex or negative coefficients require a state preparation pair, 
+      which increases the number of gates in the controlled block-encoding unitary compared to the case of real non-negative coefficients.
+      If all coefficients are real and non-negative, the block encoding unitary is constructed as $U = PREP \cdot SEL \cdot PREP^{\dagger}$.
+      In this case, the controlled block-encoding unitary requires only to control the $SEL$ operation. 
 
     Examples
     --------

--- a/src/qrisp/block_encodings/constructors/from_projector.py
+++ b/src/qrisp/block_encodings/constructors/from_projector.py
@@ -44,8 +44,8 @@ def build_from_projector(
         or a function ``right(*operands)`` preparing a state $\ket{\psi}$ from $\ket{0}$.
         Defaults to ``left``.
     kernel : bool
-        If True, the kernel projector $\mathbb I - \ket{\phi}\bra{\phi}$ is block-encoded.
-        If False the projector $\ket{\phi}\bra{\psi}$ is block-encoded. Defauts to False.
+        If `True`, the kernel projector $\mathbb I - \ket{\phi}\bra{\phi}$ is block-encoded.
+        If `False`, the projector $\ket{\phi}\bra{\psi}$ is block-encoded. Defaults to `False`.
     num_ops : int
         The number of operand quantum variables.
         Automatically inferred when ``left`` or ``right`` is an integer or tuple of integers.
@@ -54,7 +54,8 @@ def build_from_projector(
     Returns
     -------
     BlockEncoding
-        A new BlockEncoding instance representing the projector $\ket{\phi}\bra{\psi}$.
+        A BlockEncoding representing either the projector $\ket{\phi}\bra{\psi}$
+        or the kernel projector $\mathbb I - \ket{\phi}\bra{\phi}$, depending on the value of ``kernel``.
 
     Examples
     --------

--- a/tests/block_encodings_tests/test_block_encoding_from_lcu.py
+++ b/tests/block_encodings_tests/test_block_encoding_from_lcu.py
@@ -1,0 +1,94 @@
+"""
+********************************************************************************
+* Copyright (c) 2026 the Qrisp authors
+*
+* This program and the accompanying materials are made available under the
+* terms of the Eclipse Public License 2.0 which is available at
+* http://www.eclipse.org/legal/epl-2.0.
+*
+* This Source Code may also be made available under the following Secondary
+* Licenses when the conditions for such availability set forth in the Eclipse
+* Public License, v. 2.0 are satisfied: GNU General Public License, version 2
+* with the GNU Classpath Exception which is
+* available at https://www.gnu.org/software/classpath/license.html.
+*
+* SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+********************************************************************************
+"""
+
+import numpy as np
+import pytest
+
+from qrisp import QuantumBool, QuantumFloat, control, h, prepare, swap, terminal_sampling
+from qrisp.block_encodings import BlockEncoding
+
+
+def create_matrix(coeffs, N):
+    """Creates a banded matrix with specified coefficients on superdiagonal, subdiagonal, and their wrap-around elements."""
+
+    A = np.zeros((N, N), dtype=complex)
+    
+    A += np.eye(N, k=1) * coeffs[0]  # Superdiagonal
+    A += np.eye(N, k=-1) * coeffs[1]  # Subdiagonal
+    A[0, N-1] = coeffs[1]  # Wrap-around for subdiagonal
+    A[N-1, 0] = coeffs[0]  # Wrap-around for superdiagonal
+
+    A += np.eye(N, k=2) * coeffs[2]  # Super-superdiagonal
+    A += np.eye(N, k=-2) * coeffs[3]  # Sub-subdiagonal
+    A[0, N-2] = coeffs[3]  # Wrap-around for sub-subdiagonal
+    A[1, N-1] = coeffs[3]  # Wrap-around for sub-subdiagonal
+    A[N-2, 0] = coeffs[2]  # Wrap-around for super-superdiagonal
+    A[N-1, 1] = coeffs[2]  # Wrap-around for super-superdiagonal
+    return A
+
+
+def create_block_encoding(coeffs):
+    """Creates a BlockEncoding of a banded matrix with specified coefficients on superdiagonal, subdiagonal,
+    and their wrap-around elements using the LCU constructor."""
+
+    def f0(qv): qv -= 1
+    def f1(qv): qv += 1
+    def f2(qv): qv -= 2
+    def f3(qv): qv += 2
+    return BlockEncoding.from_lcu(coeffs, [f0, f1, f2, f3])
+
+
+@pytest.mark.parametrize("coeffs", [
+    np.array([1.4, 1.1, 0.5, 0.3]),
+    np.array([0.8, -0.6, 0.2, 0.1j]),
+    np.array([1.0+0.5j, 0.9j, 0.4, 0.2]),
+    np.array([-0.6j, 0.9j, 0.4, 0.7+0.2j]),
+    np.array([0.3j, 0.9j, -0.4, 0.2]),
+])
+def test_block_encoding_from_lcu(coeffs):
+    """Test the construction of a BlockEncoding from a linear combination of unitaries (LCU) with various types of coefficients."""
+
+    A = create_matrix(coeffs, N=8)
+    b = np.array([0, 1, 1, 0, 1, 0, 0, 1])
+    c = A @ b / np.linalg.norm(A @ b)
+
+    BA = create_block_encoding(coeffs)
+
+    def operand_prep():
+        operand = QuantumFloat(3)
+        prepare(operand, b)
+        return operand
+    
+    # Use swap test to check if the block encoding correctly implements the desired operation on the operand state.
+    @terminal_sampling
+    def main():
+        operand = BA.apply_rus(operand_prep)()
+
+        psi = QuantumFloat(3)
+        prepare(psi, c)
+
+        qb = QuantumBool()
+        h(qb)
+        with control(qb):
+            swap(operand, psi)
+        h(qb)
+
+        return qb
+
+    res_dict = main()
+    assert np.isclose(res_dict.get(False, 0), 1.0, atol=1e-6)

--- a/tests/block_encodings_tests/test_block_encoding_from_lcu.py
+++ b/tests/block_encodings_tests/test_block_encoding_from_lcu.py
@@ -92,3 +92,11 @@ def test_block_encoding_from_lcu(coeffs):
 
     res_dict = main()
     assert np.isclose(res_dict.get(False, 0), 1.0, atol=1e-6)
+
+
+def test_block_encoding_from_lcu_single_unitary_raises_value_error():
+    """Test that a ValueError is raised when a single unitary is provided with a complex coefficient."""
+    coeffs = np.array([1.0 + 0.5j])
+    def f0(qv): qv -= 1
+    with pytest.raises(ValueError):
+        BlockEncoding.from_lcu(coeffs, [f0])


### PR DESCRIPTION


## Description

Extends `BlockEncoding.from_lcu` to support **complex and negative coefficients**. Previously, the LCU constructor rejected any non-positive coefficient with a `ValueError`. It now handles the general complex case via an asymmetric PREP_R–SEL–PREP_L† circuit, while preserving the original symmetric PREP–SEL–PREP† fast path for real non-negative coefficients. The normalization factor is updated to $\alpha = \sum_i |\alpha_i|$.

## Related Issues

Closes #
Related to #

## Type of Change

- [ ] Feature (new functionality)
- [x] Change Request (modification of existing functionality)
- [ ] Bug Fix
- [ ] Refactoring (no behavior change)
- [ ] Performance improvement
- [x] Documentation
- [ ] CI / Build

## Breaking Change?
- [ ] Yes
- [x] No

## What was changed?

- **`constructors/from_lcu.py`**:
  - Removed `ValueError` for negative coefficients; `from_lcu` now accepts any complex array.
  - Normalization updated from $\alpha = \sum_i \alpha_i$ to $\alpha = \sum_i |\alpha_i|$.
  - All inputs are internally cast to `complex` (`complex_coeffs = np.array(coeffs, dtype=complex)`).
  - Module-level constant `_TOLERANCE = 1e-12` introduced.
  - Added **fast path** for real non-negative coefficients: unchanged symmetric `PREP–SEL–PREP†` circuit.
  - Added **general path** for complex/negative coefficients: asymmetric `PREP_R–SEL–PREP_L†` circuit, where `PREP_R` prepares $\sqrt{\alpha_i/\alpha}$ and `PREP_L` prepares $\sqrt{\alpha_i/\alpha}^*$.
  - Single-unitary short-circuit (`m == 1`) now extracts the real part of the coefficient if its imaginary part is within tolerance, and raises `ValueError` for genuinely complex single coefficients.
  - Added internal helper `_is_real_non_negative_array` to select between the two circuit paths.
  - Moved `prepare` and `q_switch` imports from inside the function body to module level.
  - Updated docstring: coefficient type updated to complex, `Raises` section updated, normalization note updated, math extended to include the asymmetric PREP_R/PREP_L variant.
- **`constructors/from_projector.py`**: minor docstring fixes (`Defauts` → `Defaults`, clarified `Returns` to cover both `kernel=True` and `kernel=False`).
- **`constructors/from_eye.py`**: minor docstring wording fix.

## How was it tested?

New test file test_block_encoding_from_lcu.py. The main test uses a **swap test** to verify the block-encoded output matches the classical $Ab/\|Ab\|$ for a banded circulant matrix, parametrized over 5 coefficient types:

| Test-ID | Coefficient type | Status |
|---------|-----------------|--------|
| `test_block_encoding_from_lcu[coeffs0]` | Real non-negative `[1.4, 1.1, 0.5, 0.3]` | ✅ |
| `test_block_encoding_from_lcu[coeffs1]` | Mixed real with negative `[0.8, -0.6, 0.2, 0.1j]` | ✅ |
| `test_block_encoding_from_lcu[coeffs2]` | Complex `[1.0+0.5j, 0.9j, 0.4, 0.2]` | ✅ |
| `test_block_encoding_from_lcu[coeffs3]` | Purely imaginary `[-0.6j, 0.9j, 0.4, 0.7+0.2j]` | ✅ |
| `test_block_encoding_from_lcu[coeffs4]` | Mixed imaginary/negative real `[0.3j, 0.9j, -0.4, 0.2]` | ✅ |
| `test_block_encoding_from_lcu_single_unitary_raises_value_error` | `ValueError` for complex single-unitary coefficient | ✅ |

Full block-encodings test suite (`pytest -n 4`) passes without regressions.

## Checklist
- [x] My code follows the project's coding standards
- [x] I have performed a self-review
- [x] I have added/updated tests (referencing issue Test-IDs)
- [x] All tests pass locally and in CI
- [x] I have updated the documentation
- [ ] I have added a changelog entry
- [ ] Breaking changes are documented with migration path

## Reviewer Notes

The test uses a **swap test** rather than direct amplitude comparison, which correctly verifies the output state up to a global phase — appropriate for verifying quantum state equality after a RUS procedure.