### PR TITLE
Fix QuantumModulus array measurement on invalid states

### DIFF
--- a/src/qrisp/core/quantum_array.py
+++ b/src/qrisp/core/quantum_array.py
@@ -783,8 +783,13 @@ class QuantumArray:
         flattened_array = self.flatten()
 
         from qrisp.qtypes.quantum_float import QuantumFloat
+        from qrisp.qtypes.quantum_modulus import QuantumModulus
 
-        if isinstance(self.qtype, QuantumFloat):
+        is_numeric_qfloat = isinstance(self.qtype, QuantumFloat) and not isinstance(
+            self.qtype, QuantumModulus
+        )
+
+        if is_numeric_qfloat:
             if self.qtype.exponent >= 0:
                 res = np.zeros(len(flattened_array), dtype=np.int32)
             else:
@@ -797,7 +802,7 @@ class QuantumArray:
         bin_string = bin_rep(code_int, len(flattened_array) * n)
 
         for i in range(len(flattened_array)):
-            if isinstance(self.qtype, QuantumFloat):
+            if is_numeric_qfloat:
                 res[i] = self.qtype.decoder(int(bin_string[i * n : (i + 1) * n], 2))
             else:
                 res = res.astype("object")

--- a/tests/core_tests/quantum_array/test_quantum_array.py
+++ b/tests/core_tests/quantum_array/test_quantum_array.py
@@ -469,3 +469,24 @@ def test_quantum_array_injection():
     (r_array << (lambda a, b: a == b))(a_array, b_array)
     for k in r_array.get_measurement().keys():
         assert k == (a_c == b_c)
+
+
+def test_quantum_array_modulus_invalid_state():
+    qa = QuantumArray(QuantumModulus(3), shape=(4,))
+    h(qa[0])
+
+    probs = dict(qa.get_measurement())
+    assert len(probs) == 4
+
+    valid = {}
+    nan_prob = 0.0
+    for outcome, prob in probs.items():
+        arr = np.asarray(outcome, dtype=float)
+        assert list(arr[1:]) == [0.0, 0.0, 0.0]
+        if np.isnan(arr[0]):
+            nan_prob += prob
+        else:
+            valid[int(arr[0])] = prob
+
+    assert set(valid) == {0, 1, 2}
+    assert_allclose(sorted(valid.values()) + [nan_prob], [0.25] * 4)


### PR DESCRIPTION
## Description

`QuantumArray` of `QuantumModulus` returned `<DecodedMeasurementResult pending>`
when an invalid (≥ modulus) state was encoded, instead of decoding it to `nan`.

## Related Issues

Closes #655 

## Type of Change

- [x] Bug Fix

## Breaking Change?
- [x] No

## What was changed?

- Added an `is_numeric_qfloat` check excluding `QuantumModulus`, so such arrays
  decode into an object array and yield `nan` entries.
- Added regression test `test_quantum_array_modulus_invalid_state`.

## How was it tested?

`QuantumArray(QuantumModulus(3), shape=(4,))` + `h(qa[0])` now returns
`[0,0,0,0]`, `[1,0,0,0]`, `[2,0,0,0]`, `[nan,0,0,0]` at 0.25 each.

## Checklist
- [x] Self-review done
- [x] Tests added
- [x] All tests pass locally
