### PR TITLE
fix: Corrected the qiskit examples to use AerSimulator as per documentation

### DIFF
--- a/documentation/source/general/changelog/0.9.rst
+++ b/documentation/source/general/changelog/0.9.rst
@@ -200,8 +200,7 @@ MaxCut module refactored (`PR #542 <https://github.com/eclipse-qrisp/Qrisp/pull/
 benchmarking callback threshold (`PR #505 <https://github.com/eclipse-qrisp/Qrisp/pull/505>`_);
 depth metric negative slicing (`PR #451 <https://github.com/eclipse-qrisp/Qrisp/pull/451>`_);
 controlled-U3 compilation fixes (`PR #551 <https://github.com/eclipse-qrisp/Qrisp/pull/551>`_);
-Catalyst 0.15 compatibility (`PR #568 <https://github.com/eclipse-qrisp/Qrisp/pull/568>`_);
-deprecated Aer API updated to ``AerSimulator`` in landing page and examples (`PR #690 <https://github.com/eclipse-qrisp/Qrisp/pull/690>`_).
+Catalyst 0.15 compatibility (`PR #568 <https://github.com/eclipse-qrisp/Qrisp/pull/568>`_).
 
 Compatibility
 -------------

--- a/documentation/source/general/changelog/0.9.rst
+++ b/documentation/source/general/changelog/0.9.rst
@@ -200,7 +200,8 @@ MaxCut module refactored (`PR #542 <https://github.com/eclipse-qrisp/Qrisp/pull/
 benchmarking callback threshold (`PR #505 <https://github.com/eclipse-qrisp/Qrisp/pull/505>`_);
 depth metric negative slicing (`PR #451 <https://github.com/eclipse-qrisp/Qrisp/pull/451>`_);
 controlled-U3 compilation fixes (`PR #551 <https://github.com/eclipse-qrisp/Qrisp/pull/551>`_);
-Catalyst 0.15 compatibility (`PR #568 <https://github.com/eclipse-qrisp/Qrisp/pull/568>`_).
+Catalyst 0.15 compatibility (`PR #568 <https://github.com/eclipse-qrisp/Qrisp/pull/568>`_);
+deprecated Aer API updated to ``AerSimulator`` in landing page and examples (`PR #690 <https://github.com/eclipse-qrisp/Qrisp/pull/690>`_).
 
 Compatibility
 -------------

--- a/documentation/source/index.rst
+++ b/documentation/source/index.rst
@@ -314,7 +314,7 @@ Qrisp enables developers to express quantum algorithms in substantially fewer li
          
 		from qiskit import (QuantumCircuit, QuantumRegister,
 		ClassicalRegister, transpile)
-		from qiskit_aer import Aer
+		from qiskit_aer import AerSimulator
 		from qiskit.circuit.library import RGQFTMultiplier
 		n = 6
 		a = QuantumRegister(n)
@@ -329,7 +329,7 @@ Qrisp enables developers to express quantum algorithms in substantially fewer li
 		qc.append(RGQFTMultiplier(n, 2*n),
 		list(a) + list(b) + list(res))
 		qc.measure(res, cl_res)
-		backend = Aer.get_backend('qasm_simulator')
+		backend = AerSimulator()
 		qc = transpile(qc, backend)
 		counts_dic = backend.run(qc).result().get_counts()
 		print({int(k, 2) : v for k, v in counts_dic.items()})

--- a/src/qrisp/examples/quantum_arithmetic_example.py
+++ b/src/qrisp/examples/quantum_arithmetic_example.py
@@ -48,7 +48,7 @@ qc.qubits.reverse()
 qiskit_qc = qc.to_qiskit()
 
 start_time = time.time()
-simulator = AerSimulator(method='statevector')
+simulator = AerSimulator(method="statevector")
 qiskit_qc.save_statevector()
 result = simulator.run(qiskit_qc).result()
 qiskit_res = result.get_statevector(qiskit_qc).data

--- a/src/qrisp/examples/quantum_arithmetic_example.py
+++ b/src/qrisp/examples/quantum_arithmetic_example.py
@@ -13,7 +13,7 @@ import time
 
 import numpy as np
 from numpy.linalg import norm
-from qiskit import Aer, execute
+from qiskit_aer import AerSimulator
 
 from qrisp import QuantumFloat, transpile
 from qrisp.simulator import statevector_sim
@@ -48,9 +48,9 @@ qc.qubits.reverse()
 qiskit_qc = qc.to_qiskit()
 
 start_time = time.time()
-# simulator = Aer.get_backend('qasm_simulator')
-simulator = Aer.get_backend("statevector_simulator")
-result = execute(qiskit_qc, simulator).result()
+simulator = AerSimulator(method='statevector')
+qiskit_qc.save_statevector()
+result = simulator.run(qiskit_qc).result()
 qiskit_res = result.get_statevector(qiskit_qc).data
 print("Qiskit simulator time: ", time.time() - start_time)
 

--- a/src/qrisp/examples/unitary_calculation.py
+++ b/src/qrisp/examples/unitary_calculation.py
@@ -44,7 +44,7 @@ qc.qubits = qc.qubits[::-1]
 qiskit_qc = convert_to_qiskit(qc)
 
 
-backend = AerSimulator(method='unitary')
+backend = AerSimulator(method="unitary")
 
 start = time.time()
 qiskit_qc.save_unitary()

--- a/src/qrisp/examples/unitary_calculation.py
+++ b/src/qrisp/examples/unitary_calculation.py
@@ -18,7 +18,7 @@
 import time
 
 from numpy.linalg import norm
-from qiskit import Aer, execute
+from qiskit_aer import AerSimulator
 
 from qrisp import QuantumFloat, transpile
 from qrisp.interface import convert_to_qiskit
@@ -44,10 +44,11 @@ qc.qubits = qc.qubits[::-1]
 qiskit_qc = convert_to_qiskit(qc)
 
 
-backend = Aer.get_backend("unitary_simulator")
+backend = AerSimulator(method='unitary')
 
 start = time.time()
-job = execute(qiskit_qc, backend)
+qiskit_qc.save_unitary()
+job = backend.run(qiskit_qc)
 result = job.result()
 test_unitary_2 = result.get_unitary(qiskit_qc).data
 end = time.time()


### PR DESCRIPTION
## Description
Updated landing page and example files to replace the deprecated Aer.get_backend() API with AerSimulator(), and removed the execute import (removed in Qiskit 2.x), using backend.run() instead.

## Related Issues

<!-- Link related issues. Use closing keywords to auto-close them on merge. -->
Closes #635 

## Type of Change

<!-- Check all that apply -->
- [ ] Feature (new functionality)
- [ ] Change Request (modification of existing functionality)
- [x] Bug Fix
- [ ] Refactoring (no behavior change)
- [ ] Performance improvement
- [x] Documentation
- [ ] CI / Build

## Breaking Change?
- [ ] Yes
- [x] No

If yes, describe the impact and migration path:

N/A

## What was changed?

Updated 3 files:
- Landing page (documentation/source/index.rst): 

```
- from qiskit_aer import Aer
+ from qiskit_aer import AerSimulator
```

```
- backend = Aer.get_backend('qasm_simulator')
+ backend = AerSimulator() 
```

- src/qrisp/examples/quantum_arithmetic_example.py: 

```
- from qiskit import Aer, execute
+ from qiskit_aer import AerSimulator
```

```
- # simulator = Aer.get_backend('qasm_simulator')
- simulator = Aer.get_backend("statevector_simulator")
- result = execute(qiskit_qc, simulator).result()
+ simulator = AerSimulator(method='statevector')
+ qiskit_qc.save_statevector()
+ result = simulator.run(qiskit_qc).result()
```

- src/qrisp/examples/unitary_calculation.py: 

```
- from qiskit import Aer, execute
+ from qiskit_aer import AerSimulator
```
```
- backend = Aer.get_backend("unitary_simulator")
+ backend = AerSimulator(method='unitary')
```
```
- job = execute(qiskit_qc, backend)
+ qiskit_qc.save_unitary()
+ job = backend.run(qiskit_qc)
```

## How was it tested?

<!-- Optional - Reference Test-IDs from the linked issue(s) and describe any additional testing. -->

1. Landing page example produces `{12: 1024}` with new API.  
2. `make html` builds without errors. 
3. Ran the two example files:
    1. uv run python src/qrisp/examples/quantum_arithmetic_example.py crashes my PC since it is a state vector simulation of 29 qubits!
    2. uv run python src/qrisp/examples/unitary_calculation.py
        output:
        ```
        13
        Qrisp calculation time = 27.176098823547363
        Qiskit calculation time = 25.690049171447754
        Unitaries matching: True
        ```

## Screenshots / Output (if applicable)
<!-- Add additional information if it helps -->
<img width="1262" height="646" alt="image" src="https://github.com/user-attachments/assets/2cbe7e92-e70f-4763-a164-fca5e3d368d2" />

## Checklist
- [x] My code follows the project's coding standards
- [x] I have performed a self-review
- [ ] I have added/updated tests (referencing issue Test-IDs)
- [ ] All tests pass locally and in CI
- [ ] I have updated the documentation
- [x] I have added a changelog entry
- [ ] Breaking changes are documented with migration path
