### PR TITLE
Add missing `ryy` gate

### DIFF
--- a/src/qrisp/circuit/quantum_circuit.py
+++ b/src/qrisp/circuit/quantum_circuit.py
@@ -2582,6 +2582,25 @@ class QuantumCircuit:
             return
         self.append(ops.RZZGate(phi), [qubits_0, qubits_1])
 
+    def ryy(self, phi: FloatLike, qubits_0: QubitLike, qubits_1: QubitLike):
+        """Instruct an RYY-gate.
+
+        Parameters
+        ----------
+        phi : FloatLike
+            The angle parameter.
+
+        qubits_0 : QubitLike
+            The Qubit to apply the gate on.
+
+        qubits_1 : QubitLike
+            The other Qubit to apply the gate on.
+
+        """
+        if phi == 0:
+            return
+        self.append(ops.RYYGate(phi), [qubits_0, qubits_1])
+
     def xxyy(self, phi: FloatLike, beta: FloatLike, qubits_0: QubitLike, qubits_1: QubitLike):
         """Instruct an XXYY-gate.
 

--- a/src/qrisp/circuit/standard_operations.py
+++ b/src/qrisp/circuit/standard_operations.py
@@ -421,6 +421,44 @@ def RZZGate(phi: FloatLike = 0):
     return res
 
 
+def RYYGate(phi: FloatLike = 0):
+    """Return an Ising YY-coupling gate.
+
+    Parameters
+    ----------
+    phi : FloatLike, optional
+        The coupling angle in radians. The default is 0.
+
+    Returns
+    -------
+    :class:`.Operation`
+        The :math:`R_{YY}` gate operation.
+
+    """
+    from qrisp.circuit.quantum_circuit import QuantumCircuit
+
+    qc = QuantumCircuit(2)
+    qc.gphase(-phi / 2, qc.qubits[0])
+    qc.s_dg(qc.qubits[0])
+    qc.s_dg(qc.qubits[1])
+    qc.h(qc.qubits[0])
+    qc.h(qc.qubits[1])
+    qc.cx(qc.qubits[0], qc.qubits[1])
+    qc.p(phi, qc.qubits[1])
+    qc.cx(qc.qubits[0], qc.qubits[1])
+    qc.h(qc.qubits[0])
+    qc.h(qc.qubits[1])
+    qc.s(qc.qubits[0])
+    qc.s(qc.qubits[1])
+
+    res = Operation(name="ryy", num_qubits=2, num_clbits=0, params=[phi], definition=qc)
+
+    res.permeability = {0: False, 1: False}
+    res.is_qfree = False
+
+    return res
+
+
 def XXYYGate(phi: FloatLike = 0, beta: FloatLike = 0):
     """Return an XX+YY interaction gate.
 
@@ -658,6 +696,7 @@ op_list = [
     TGate,
     RXXGate,
     RZZGate,
+    RYYGate,
     SXGate,
     SXDGGate,
     XXYYGate,

--- a/src/qrisp/core/gate_application_functions.py
+++ b/src/qrisp/core/gate_application_functions.py
@@ -1119,6 +1119,28 @@ def rxx(phi, qubits_0, qubits_1):
     return qubits_0, qubits_1
 
 
+def ryy(phi, qubits_0, qubits_1):
+    """Applies an RYY gate.
+
+    Parameters
+    ----------
+    phi : float or sympy.Symbol
+        The phase to apply.
+    qubits_0 : Qubit or list[Qubit] or QuantumVariable
+        The first argument to perform the RYY gate one.
+    qubits_1 : Qubit or list[Qubit] or QuantumVariable
+        The second argument to perform the RYY gate one.
+
+    """
+    if check_for_tracing_mode():
+        ryy_gate = std_ops.RYYGate(sympy.Symbol("alpha"))
+        append_operation(ryy_gate, [qubits_0, qubits_1], param_tracers=[phi])
+    else:
+        ryy_gate = std_ops.RYYGate(phi)
+        append_operation(ryy_gate, [qubits_0, qubits_1])
+    return qubits_0, qubits_1
+
+
 def u3(theta, phi, lam, qubits):
     """Applies an U3 gate.
 

--- a/tests/interface_tests/test_converter_qrisp_to_qml.py
+++ b/tests/interface_tests/test_converter_qrisp_to_qml.py
@@ -37,6 +37,7 @@ from qrisp.circuit.standard_operations import (  # Barrier,
     RXGate,
     RXXGate,
     RYGate,
+    RYYGate,
     RZGate,
     RZZGate,
     SGate,
@@ -88,6 +89,7 @@ MULTI_GATE_MAP = [
     (SwapGate, qml.SWAP, 2, []),
     (RXXGate, qml.IsingXX, 2, [np.pi / 2]),
     (RZZGate, qml.IsingZZ, 2, [np.pi / 3]),
+    (RYYGate, qml.IsingYY, 2, [np.pi / 4]),
 ]
 
 CONTROLLED_GATE_MAP = [
@@ -195,6 +197,11 @@ def check_probs_measurement_equivalence(qrisp_qv, qml_res, atol=1e-5):
         (
             RZZGate,
             lambda t: qml.IsingZZ(t, wires=[0, 1]),
+            [(np.pi / 3,), (1.5,), (0.0,)],
+        ),
+        (
+            RYYGate,
+            lambda t: qml.IsingYY(t, wires=[0, 1]),
             [(np.pi / 3,), (1.5,), (0.0,)],
         ),
         (

--- a/tests/interface_tests/test_qiskit_converter.py
+++ b/tests/interface_tests/test_qiskit_converter.py
@@ -139,6 +139,18 @@ class TestQrispToQiskitRoundtrip:
         qc_rt = convert_from_qiskit(convert_to_qiskit(qc))
         assert_unitary_equal(qc, qc_rt)
 
+    def test_rxx(self):
+        qc = QuantumCircuit(2)
+        qc.rxx(0.7, 0, 1)
+        qc_rt = convert_from_qiskit(convert_to_qiskit(qc))
+        assert_unitary_equal(qc, qc_rt)
+
+    def test_ryy(self):
+        qc = QuantumCircuit(2)
+        qc.ryy(0.7, 0, 1)
+        qc_rt = convert_from_qiskit(convert_to_qiskit(qc))
+        assert_unitary_equal(qc, qc_rt)
+
     def test_cp(self):
         qc = QuantumCircuit(2)
         qc.cp(np.pi / 4, 0, 1)

--- a/tests/interface_tests/test_tket_converter.py
+++ b/tests/interface_tests/test_tket_converter.py
@@ -15,6 +15,7 @@ from qrisp.circuit.standard_operations import (
     RXGate,
     RXXGate,
     RYGate,
+    RYYGate,
     RZGate,
     RZZGate,
     SGate,
@@ -40,7 +41,7 @@ def pytket_rand_test():
         SwapGate(),
     ]
 
-    mc_rot_gates = [RXXGate, RZZGate]
+    mc_rot_gates = [RXXGate, RZZGate, RYYGate]
 
     special_gates = [MCXGate(control_amount=3)]
 


### PR DESCRIPTION
## Description

Adds the `RYY` (Ising YY-coupling) two-qubit gate. Qrisp already had `RXX` and `RZZ`, and the `qiskit`, `pytket`, and `pennylane` converters already referenced `ryy`, but the gate itself was never defined, so nothing could ever produce one and the converter branches were dead.

The decomposition mirrors `RXXGate` with the basis change swapped from `H` to `S_dg, H` before the ZZ core and `H, S` after (since `S H Z (S H)^dagger = Y`). This keeps the same global-phase convention, so `RYYGate(phi).get_unitary()` equals `exp(-i*phi/2 * Y (x) Y)` exactly (matching `qiskit.RYYGate` and `pennylane.IsingYY`).

## Related Issues

Closes #700

## Type of Change

- [x] Feature (new functionality)

## Breaking Change?
- [x] No

## What was changed?

- standard_operations.py: new `RYYGate`, added to `op_list` (so `convert_from_qiskit` picks it up).
- quantum_circuit.py: new `QuantumCircuit.ryy` method.
- gate_application_functions.py: new top-level `ryy` function (tracing-aware, like `rxx`/`rzz`).
- test_qiskit_converter.py: roundtrip tests for `ryy` (and `rxx`, which was also uncovered).
- test_converter_qrisp_to_qml.py: `RYYGate` added to the gate maps and the `IsingYY` unitary-equivalence check.
- test_tket_converter.py: `RYYGate` added to the randomized two-qubit rotation set.

## How was it tested?

| Test | Status |
|------|--------|
| `test_ryy` / `test_rxx` (qiskit roundtrip) | ok |
| `test_gate_unitary_equivalence[RYY vs IsingYY]` | ok |
| pennylane conversion tests (`RYYGate`) | ok |

Ran `pytest tests/interface_tests/test_qiskit_converter.py tests/interface_tests/test_converter_qrisp_to_qml.py` locally, 146 passed. Also checked `RYYGate(phi).get_unitary()` against `scipy.linalg.expm` for several angles.

## Checklist
- [x] My code follows the project's coding standards
- [x] I have performed a self-review
- [x] I have added/updated tests
