### PR TITLE
Add RYY Ising YY-coupling gate

### DIFF
--- a/src/qrisp/circuit/quantum_circuit.py
+++ b/src/qrisp/circuit/quantum_circuit.py
@@ -2582,6 +2582,25 @@ class QuantumCircuit:
             return
         self.append(ops.RZZGate(phi), [qubits_0, qubits_1])
 
+    def ryy(self, phi: FloatLike, qubits_0: QubitLike, qubits_1: QubitLike):
+        """Instruct an RYY-gate.
+
+        Parameters
+        ----------
+        phi : FloatLike
+            The angle parameter.
+
+        qubits_0 : QubitLike
+            The Qubit to apply the gate on.
+
+        qubits_1 : QubitLike
+            The other Qubit to apply the gate on.
+
+        """
+        if phi == 0:
+            return
+        self.append(ops.RYYGate(phi), [qubits_0, qubits_1])
+
     def xxyy(self, phi: FloatLike, beta: FloatLike, qubits_0: QubitLike, qubits_1: QubitLike):
         """Instruct an XXYY-gate.
 

--- a/src/qrisp/circuit/standard_operations.py
+++ b/src/qrisp/circuit/standard_operations.py
@@ -421,6 +421,40 @@ def RZZGate(phi: FloatLike = 0):
     return res
 
 
+def RYYGate(phi: FloatLike = 0):
+    """Return an Ising YY-coupling gate.
+
+    Parameters
+    ----------
+    phi : FloatLike, optional
+        The coupling angle in radians. The default is 0.
+
+    Returns
+    -------
+    :class:`.Operation`
+        The :math:`R_{YY}` gate operation.
+
+    """
+    from qrisp.circuit.quantum_circuit import QuantumCircuit
+
+    qc = QuantumCircuit(2)
+    qc.gphase(-phi / 2, qc.qubits[0])
+    qc.rx(np.pi / 2, qc.qubits[0])
+    qc.rx(np.pi / 2, qc.qubits[1])
+    qc.cx(qc.qubits[0], qc.qubits[1])
+    qc.p(phi, qc.qubits[1])
+    qc.cx(qc.qubits[0], qc.qubits[1])
+    qc.rx(-np.pi / 2, qc.qubits[0])
+    qc.rx(-np.pi / 2, qc.qubits[1])
+
+    res = Operation(name="ryy", num_qubits=2, num_clbits=0, params=[phi], definition=qc)
+
+    res.permeability = {0: False, 1: False}
+    res.is_qfree = False
+
+    return res
+
+
 def XXYYGate(phi: FloatLike = 0, beta: FloatLike = 0):
     """Return an XX+YY interaction gate.
 
@@ -657,6 +691,7 @@ op_list = [
     SGate,
     TGate,
     RXXGate,
+    RYYGate,
     RZZGate,
     SXGate,
     SXDGGate,

--- a/src/qrisp/core/gate_application_functions.py
+++ b/src/qrisp/core/gate_application_functions.py
@@ -1119,6 +1119,28 @@ def rxx(phi, qubits_0, qubits_1):
     return qubits_0, qubits_1
 
 
+def ryy(phi, qubits_0, qubits_1):
+    """Applies an RYY gate.
+
+    Parameters
+    ----------
+    phi : float or sympy.Symbol
+        The phase to apply.
+    qubits_0 : Qubit or list[Qubit] or QuantumVariable
+        The first argument to perform the RYY gate one.
+    qubits_1 : Qubit or list[Qubit] or QuantumVariable
+        The second argument to perform the RYY gate one.
+
+    """
+    if check_for_tracing_mode():
+        ryy_gate = std_ops.RYYGate(sympy.Symbol("alpha"))
+        append_operation(ryy_gate, [qubits_0, qubits_1], param_tracers=[phi])
+    else:
+        ryy_gate = std_ops.RYYGate(phi)
+        append_operation(ryy_gate, [qubits_0, qubits_1])
+    return qubits_0, qubits_1
+
+
 def u3(theta, phi, lam, qubits):
     """Applies an U3 gate.
 

--- a/tests/circuit_tests/test_quantum_circuit.py
+++ b/tests/circuit_tests/test_quantum_circuit.py
@@ -587,6 +587,22 @@ class TestQuantumCircuitMethods:
         assert unitary.shape == (2, 2)
         assert np.allclose(unitary, np.array(expected, dtype=np.complex64), atol=1e-5)
 
+    @pytest.mark.parametrize("angle", [0.0, np.pi / 3, np.pi, 1.2345])
+    def test_get_unitary_ryy_gate(self, angle):
+        """qc.ryy produces the analytic RYY(theta) Ising YY-coupling matrix."""
+        c, s = np.cos(angle / 2), np.sin(angle / 2)
+        expected = np.array(
+            [
+                [c, 0, 0, 1j * s],
+                [0, c, -1j * s, 0],
+                [0, -1j * s, c, 0],
+                [1j * s, 0, 0, c],
+            ]
+        )
+        qc = QuantumCircuit(2)
+        qc.ryy(angle, 0, 1)
+        assert np.allclose(qc.get_unitary(), expected, atol=1e-5)
+
     # ------------------------------------------------------------------ #
     # get_unitary — general properties                                   #
     # ------------------------------------------------------------------ #


### PR DESCRIPTION
Closes #700.

Qrisp had `RXX`/`RZZ` but no `RYY`. This adds the Ising YY-coupling gate, mirroring the existing gates:

- `RYYGate` in `standard_operations.py` (+ export), decomposed with an `rx(±π/2)` basis change around the `ZZ` core (`CX · P(φ) · CX`), analogous to `RXXGate`'s `h` basis change.
- `QuantumCircuit.ryy` method and the top-level `ryy` function.
- A parametrized `get_unitary` test.

### Verification
The gate reproduces the analytic `RYY(θ) = exp(-i·θ/2·Y⊗Y)` matrix **exactly** (not just up to global phase), checked against several angles via `get_unitary`; `RXX` was used as a control to confirm the convention. `pytest -k ryy` → 4 passed. The new code mirrors the `rxx`/`rzz` pattern (same lint profile).