### PR TITLE
Fix Cirq 1.6 FutureWarning: add use_repetitions_ids = True 

### DIFF
--- a/documentation/source/general/changelog/changelog-dev.rst
+++ b/documentation/source/general/changelog/changelog-dev.rst
@@ -23,6 +23,10 @@ Bug Fixes
   deprecated ``Aer.get_backend()`` API
   (`PR #690 <https://github.com/eclipse-qrisp/Qrisp/pull/690>`_).
 
+* Fixed Cirq ``FutureWarning`` by explicitly setting ``use_repetition_ids=True``
+  in ``CircuitOperation`` calls
+  (`PR #709 <https://github.com/eclipse-qrisp/Qrisp/pull/709>`_).
+
 Compatibility
 -------------
 

--- a/tests/interface_tests/test_cirq_converter.py
+++ b/tests/interface_tests/test_cirq_converter.py
@@ -516,7 +516,7 @@ def _build_controlled_no_gate_circ():
     """Cirq ControlledOperation wrapping a CircuitOperation (no .gate attribute on sub_op)."""
     q0, q1 = cirq.LineQubit.range(2)
     inner = cirq.FrozenCircuit([cirq.X(q0)])
-    co = cirq.CircuitOperation(inner)
+    co = cirq.CircuitOperation(inner, use_repetition_ids=True)
     return cirq.Circuit([cirq.ControlledOperation([q1], co)])
 
 
@@ -524,7 +524,7 @@ def _build_circuit_op_circ():
     """Cirq circuit with a bare CircuitOperation (no .gate attribute)."""
     q0 = cirq.LineQubit(0)
     inner = cirq.FrozenCircuit([cirq.X(q0)])
-    return cirq.Circuit([cirq.CircuitOperation(inner)])
+    return cirq.Circuit([cirq.CircuitOperation(inner, use_repetition_ids=True)])
 
 
 def _build_iswap_circ():


### PR DESCRIPTION
## Description

<!-- What does this PR do? Keep it concise. -->

Fixes the following:

```
 tests/interface_tests/test_cirq_converter.py::test_convert_from_cirq_raises[controlled_sub_op_no_gate]
tests/interface_tests/test_cirq_converter.py::test_convert_from_cirq_raises[circuit_operation_no_gate]
  /opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/site-packages/cirq/circuits/circuit_operation.py:173: FutureWarning: In cirq 1.6 the default value of `use_repetition_ids` will change to
  `use_repetition_ids=False`. To make this warning go away, please pass
  explicit `use_repetition_ids`, e.g., to preserve current behavior, use
  
    CircuitOperations(..., use_repetition_ids=True)
    warnings.warn(msg, FutureWarning)

```

## Related Issues

<!-- Link related issues. Use closing keywords to auto-close them on merge. -->
Closes #
Related to #

## Type of Change

<!-- Check all that apply -->
- [ ] Feature (new functionality)
- [ ] Change Request (modification of existing functionality)
- [ ] Bug Fix
- [ ] Refactoring (no behavior change)
- [ ] Performance improvement
- [ ] Documentation
- [ ] CI / Build

## Breaking Change?
- [ ] Yes
- [ ] No

If yes, describe the impact and migration path:


## What was changed?

<!-- Bullet list of concrete changes -->
-
-

## How was it tested?

<!-- Optional - Reference Test-IDs from the linked issue(s) and describe any additional testing. -->

| Test-ID | Status |
|---------|--------|
| T-001   | ✅ / ❌ |
| T-002   | ✅ / ❌ |
| T-003   | ✅ / ❌ |
| T-004   | ✅ / ❌ |

## Screenshots / Output (if applicable)

<!-- Add additional information if it helps -->

## Checklist
- [ ] My code follows the project's coding standards
- [ ] I have performed a self-review
- [ ] I have added/updated tests (referencing issue Test-IDs)
- [ ] All tests pass locally and in CI
- [ ] I have updated the documentation
- [ ] I have added a changelog entry
- [ ] Breaking changes are documented with migration path

## Reviewer Notes

<!-- Anything specific the reviewer should focus on? -->