### PR TITLE
Fix Jasp quantum-quantum QuantumModulus multiplication in QuantumArray

### DIFF
--- a/src/qrisp/alg_primitives/arithmetic/jasp_arithmetic/jasp_montgomery.py
+++ b/src/qrisp/alg_primitives/arithmetic/jasp_arithmetic/jasp_montgomery.py
@@ -333,13 +333,19 @@ def qq_montgomery_multiply_modulus(x: QuantumModulus, y: QuantumModulus):
     inpl_adder = x.inpl_adder
     N = x.modulus
 
-    # Compute the reduction shift m = ceil(log2((N-1)^2 + 1)) - n.
+    # Compute the reduction shift m = ceil(log2((N-1)^2) + 1) - n. This must
+    # match the static montgomery_mod_mul (and create_output_qf, which the
+    # QuantumArray element-wise path uses to preallocate the output's
+    # Montgomery shift); otherwise the result's res.m disagrees with the
+    # decoder and the value comes out scaled by a power of two (see #640).
+    # Note ceil(log2((N-1)^2) + 1) == ceil(log2((N-1)^2)) + 1, hence the "+ 1"
+    # sits outside smallest_power_of_two rather than inside its argument.
     # When N is a BigInteger with traced digits, both n and m will be
     # JAX tracers.  That is fine: jrange / jlen handle traced loop bounds,
     # QuantumFloat accepts traced sizes, and jdecoder handles a traced
     # Montgomery shift (res.m) via BigInteger arithmetic.
     n = smallest_power_of_two(N)
-    m = smallest_power_of_two((N - 1) ** 2 + 1) - n
+    m = smallest_power_of_two((N - 1) ** 2) + 1 - n
 
     if check_for_tracing_mode():
         xrange = jrange

--- a/tests/jax_tests/test_jasp_quantum_array.py
+++ b/tests/jax_tests/test_jasp_quantum_array.py
@@ -270,10 +270,6 @@ instances = [
 @pytest.mark.parametrize("instance", instances)
 def test_quantum_array_element_wise_ops_qm(op, rhs_type, instance):
     """Test element-wise operations on QuantumArrays of QuantumModulus against their classical counterparts."""
-    if op == operator.mul and rhs_type == "quantum":
-        # qq multiplication fixed in separate pull request, but for now we skip this test to avoid CI failures
-        pytest.skip("Quantum-quantum multiplication for QuantumModulus is currently unsupported in Jasp.")
-
     a_c, b_c, modulus = instance
 
     @jaspify


### PR DESCRIPTION
## Description

Fixes element-wise quantum-quantum multiplication of `QuantumArray`s of `QuantumModulus` in dynamic (Jasp) mode, which returned a value scaled by a power of two. e.g. `1 * 5 mod 7` gave `3` instead of `5`.

Root cause: `qq_montgomery_multiply_modulus` computed the Montgomery reduction shift as `smallest_power_of_two((N-1)**2 + 1) - n`, whereas the static `montgomery_mod_mul` and `create_output_qf` use `ceil(log2((N-1)**2) + 1) - n`. Since `ceil(log2(k²+1)) ≠ ceil(log2(k²)) + 1`, the jasp result's `res.m` came out one too small for many moduli (7, 11, 13, …). A single `QuantumModulus` product returns that result directly and still decodes correctly, but the `QuantumArray` element-wise path preallocates the output's Montgomery shift via `create_output_qf`, so the injected result was decoded against a mismatching shift and came out off by `2¹`. The fix aligns the jasp shift with the static formula (JAX/BigInteger-safe — the `+ 1` moves outside `smallest_power_of_two`).

## Related Issues

Closes #640

## Type of Change

- [x] Bug Fix

## Breaking Change?
- [x] No

## What was changed?

- Corrected the Montgomery reduction shift in `qq_montgomery_multiply_modulus` (`smallest_power_of_two((N-1)**2 + 1) - n` → `smallest_power_of_two((N-1)**2) + 1 - n`) so it matches the static `montgomery_mod_mul` / `create_output_qf` convention, with a comment documenting the invariant.
- Removed the `pytest.skip` guarding the `QuantumModulus` quantum-quantum cases in `test_quantum_array_element_wise_ops_qm`, so they now run.

## How was it tested?

| Test-ID | Description | Status |
|---------|-------------|--------|
| T-001 (Positive) | `a * b` element-wise on `QuantumArray[QuantumModulus]` returns `(A*B) % N` - issue repro (`1*5 mod 7 = 5`) + random 2×2/3×2 arrays over N ∈ {7,11,13,15,23,31,47} | ✅ |
| T-002 (Negative) | Quantum-classical mul on a `QuantumArray` of non-`QuantumModulus` still raises `NotImplementedError` (unchanged) | ✅ |
| T-003 (Boundary) | Standard-form (`m=0`) and pre-shifted (`m≠0`) single-`QuantumModulus` products remain correct; smallest modulus exercised via scalar-RHS quantum case (N=3) | ✅ |
| T-004 (Boundary) | Chained `(a*b)*c` and non-square arrays across several moduli | ✅ |

Local suites green: `test_jasp_quantum_array.py` (113), `test_jasp_modulus.py` (56, incl. the qq standard-form / non-standard-`m` / traced-BigInteger regressions), `test_montgomery.py`. Also confirmed the corrected shift equals the static formula for every odd modulus 3–63.

## Checklist
- [x] My code follows the project's coding standards
- [x] I have performed a self-review
- [x] I have added/updated tests (referencing issue Test-IDs)
- [x] All tests pass locally and in CI
- [ ] I have updated the documentation
- [ ] I have added a changelog entry <!-- 0.9.rst is curated by maintainers at release; omitting per prior contributions -->
- [ ] Breaking changes are documented with migration path

## Reviewer Notes

The previously-skipped `test_quantum_array_element_wise_ops_qm` (mul, quantum RHS) is now un-skipped and serves as the regression guard (its N=7 array case reproduces the bug).

Design note: this aligns the jasp shift with the *existing* canonical formula, which makes it one larger for affected moduli so `qq_montgomery_multiply_modulus` uses ~1 extra ancilla qubit, matching what the static path already allocates. I chose this fix over the qubit-optimal alternative (keep the tighter jasp shift and instead have the injection carry the actual `res.m`), which would touch the well-tested `create_output_qf`/injection machinery. Happy to go the other route if you'd prefer.