### PR TITLE
Preserve SX global phase in Qiskit conversion

### DIFF
--- a/src/qrisp/interface/converter/qiskit_converter.py
+++ b/src/qrisp/interface/converter/qiskit_converter.py
@@ -22,6 +22,8 @@ from qrisp.circuit import ClControlledOperation, ControlledOperation, PRXGate
 from qrisp.circuit.standard_operations import op_list
 from qrisp.misc import bin_rep
 
+_PHASE_TOLERANCE = 1e-10
+
 
 # Function to convert qrisp quantum circuits to Qiskit quantum circuits
 def convert_to_qiskit(qc, transpile=False):
@@ -155,6 +157,7 @@ def create_qiskit_instruction(op, params=[]):
     import qiskit.circuit.library.standard_gates as qsk_gates
     from qiskit import QiskitError
     from qiskit.circuit import Barrier, Measure, Reset
+    from qiskit.circuit.library import UnitaryGate
 
     from qrisp.circuit import ControlledOperation
 
@@ -215,8 +218,6 @@ def create_qiskit_instruction(op, params=[]):
         qiskit_ins = qsk_gates.RYGate(params[0])
     elif op.name == "rz":
         qiskit_ins = qsk_gates.RZGate(params[0])
-    elif op.name == "sx":
-        qiskit_ins = qsk_gates.SXGate()
     elif op.name == "h":
         qiskit_ins = qsk_gates.HGate()
 
@@ -229,9 +230,18 @@ def create_qiskit_instruction(op, params=[]):
     elif op.name == "s_dg":
         qiskit_ins = qsk_gates.SGate().inverse()
     elif op.name == "sx":
+        # Qiskit's SX includes exp(i*pi/4), while Qrisp's SX is a bare RX(pi/2).
         qiskit_ins = qsk_gates.SXGate()
+        phase = getattr(op, "global_phase", 0) - np.pi / 4
+        if abs(phase) > _PHASE_TOLERANCE:
+            qiskit_ins = UnitaryGate(np.exp(1j * phase) * qiskit_ins.to_matrix())
+            qiskit_ins.name = op.name
     elif op.name == "sx_dg":
         qiskit_ins = qsk_gates.SXdgGate()
+        phase = getattr(op, "global_phase", 0) + np.pi / 4
+        if abs(phase) > _PHASE_TOLERANCE:
+            qiskit_ins = UnitaryGate(np.exp(1j * phase) * qiskit_ins.to_matrix())
+            qiskit_ins.name = op.name
     elif op.name == "rzz":
         qiskit_ins = qsk_gates.RZZGate(params[0])
     elif op.name == "xxyy":
@@ -266,11 +276,14 @@ def create_qiskit_instruction(op, params=[]):
 
 op_dic = {op().name: op for op in op_list}
 op_dic["u"] = op_dic["u3"]
+op_dic["sxdg"] = op_dic["sx_dg"]
 
 
 def convert_from_qiskit(qiskit_qc):
     from qiskit import QuantumCircuit as QiskitQuantumCircuit
     from qiskit.circuit import ControlledGate, ParameterExpression
+    from qiskit.circuit.library import SXdgGate as QiskitSXdgGate
+    from qiskit.circuit.library import SXGate as QiskitSXGate
 
     from qrisp import Barrier, Clbit, ControlledOperation, QuantumCircuit, Qubit
 
@@ -358,6 +371,18 @@ def convert_from_qiskit(qiskit_qc):
         else:
             controlled_gate = False
 
+        # Store Qiskit's SX convention on the Qrisp operation itself so the
+        # phase remains relative, rather than global, when the gate is controlled.
+        if isinstance(qiskit_op, QiskitSXGate):
+            qiskit_sx_phase = np.pi / 4
+        elif isinstance(qiskit_op, QiskitSXdgGate):
+            qiskit_sx_phase = -np.pi / 4
+        else:
+            qiskit_sx_phase = 0
+
+        if qiskit_op.name in ["sx", "sx_dg", "sxdg"]:
+            params = []
+
         # Qiskit RGate → PRXGate
         if qiskit_op.name == "r":
             from qrisp.circuit import PRXGate as _PRXGate
@@ -374,6 +399,9 @@ def convert_from_qiskit(qiskit_qc):
                         op = convert_from_qiskit(qiskit_op.definition).to_gate(name=qiskit_op.name)
                     else:
                         raise Exception("Could not convert Qiskit operation " + str(qiskit_op.name) + " to Qrisp")
+
+        if qiskit_sx_phase:
+            op.global_phase += qiskit_sx_phase
 
         if controlled_gate:
             qiskit_op = qiskit_qc.data[i].operation
@@ -398,7 +426,7 @@ def convert_from_qiskit(qiskit_qc):
     # Propagate Qiskit's global phase (stored as a circuit attribute,
     # not an instruction).  Dropping it changes the unitary — critical
     # for controlled operations built from gate definitions with phase.
-    if abs(getattr(qiskit_qc, "global_phase", 0)) > 1e-10:
+    if abs(getattr(qiskit_qc, "global_phase", 0)) > _PHASE_TOLERANCE:
         qc.gphase(qiskit_qc.global_phase, qc.qubits[0])
 
     return qc

--- a/tests/interface_tests/test_qiskit_converter.py
+++ b/tests/interface_tests/test_qiskit_converter.py
@@ -24,6 +24,12 @@ from qiskit.quantum_info import Operator
 
 from qrisp import QuantumCircuit
 from qrisp.circuit import PRXGate
+from qrisp.circuit.standard_operations import (
+    SXDGGate as QrispSXDGGate,
+)
+from qrisp.circuit.standard_operations import (
+    SXGate as QrispSXGate,
+)
 from qrisp.interface.converter.qiskit_converter import (
     convert_from_qiskit,
     convert_to_qiskit,
@@ -425,6 +431,13 @@ class TestQrispToQiskitUnitary:
         qiskit_qc = convert_to_qiskit(qc)
         _assert_qrisp_qiskit_unitary_equal(qc, qiskit_qc)
 
+    @pytest.mark.parametrize("gate", ["sx", "sx_dg"])
+    def test_sx(self, gate):
+        qc = QuantumCircuit(1)
+        getattr(qc, gate)(0)
+        qiskit_qc = convert_to_qiskit(qc)
+        _assert_qrisp_qiskit_unitary_equal(qc, qiskit_qc)
+
     def test_cx(self):
         qc = QuantumCircuit(2)
         qc.cx(0, 1)
@@ -478,6 +491,13 @@ class TestQrispToQiskitUnitary:
         qiskit_qc = convert_to_qiskit(qc)
         _assert_qrisp_qiskit_unitary_equal(qc, qiskit_qc)
 
+    @pytest.mark.parametrize("gate", [QrispSXGate(), QrispSXDGGate()], ids=["sx", "sx_dg"])
+    def test_controlled_sx(self, gate):
+        qc = QuantumCircuit(2)
+        qc.append(gate.control(), [0, 1])
+        qiskit_qc = convert_to_qiskit(qc)
+        _assert_qrisp_qiskit_unitary_equal(qc, qiskit_qc)
+
 
 class TestQiskitToQrispUnitary:
     """Qiskit → Qrisp: compare unitaries directly (no round-trip)."""
@@ -522,6 +542,13 @@ class TestQiskitToQrispUnitary:
         qrisp_qc = convert_from_qiskit(qc)
         _assert_qrisp_qiskit_unitary_equal(qrisp_qc, qc)
 
+    @pytest.mark.parametrize("gate", ["sx", "sxdg"])
+    def test_sx(self, gate):
+        qc = QiskitQC(1)
+        getattr(qc, gate)(0)
+        qrisp_qc = convert_from_qiskit(qc)
+        _assert_qrisp_qiskit_unitary_equal(qrisp_qc, qc)
+
     def test_cx(self):
         qc = QiskitQC(2)
         qc.cx(0, 1)
@@ -551,6 +578,16 @@ class TestQiskitToQrispUnitary:
 
         qc = QiskitQC(2)
         qc.append(RGate(0.6, 0.8).control(1), [0, 1])
+        qrisp_qc = convert_from_qiskit(qc)
+        _assert_qrisp_qiskit_unitary_equal(qrisp_qc, qc)
+
+    @pytest.mark.parametrize("gate_name", ["SXGate", "SXdgGate"])
+    def test_controlled_sx(self, gate_name):
+        from qiskit.circuit import library as qiskit_gates
+
+        qc = QiskitQC(2)
+        gate = getattr(qiskit_gates, gate_name)()
+        qc.append(gate.control(1), [0, 1])
         qrisp_qc = convert_from_qiskit(qc)
         _assert_qrisp_qiskit_unitary_equal(qrisp_qc, qc)
 


### PR DESCRIPTION
## Description

Preserve exact SX and SX-dagger unitaries when converting between Qrisp and Qiskit.

Qrisp defines these operations as bare `RX(±π/2)` rotations, while Qiskit's native gates include global phases of `exp(±iπ/4)`. Mapping them directly changes the exact unitary and, once controlled, turns that global phase into an observable relative phase.

Closes #673

## Type of Change

- [x] Bug Fix

## Breaking Change?

- [ ] Yes
- [x] No

## What was changed?

- Compensate Qiskit's SX/SX-dagger phase during Qrisp export.
- Use a phase-corrected `UnitaryGate` so Qiskit's `.control()` preserves the corrected matrix.
- Preserve native Qiskit SX/SX-dagger phase conventions during import, including controlled gates.
- Recognize Qiskit's `sxdg` operation name as Qrisp `sx_dg`.
- Add exact-unitary regression coverage in both conversion directions for plain and controlled SX/SX-dagger.

## How was it tested?

| Test-ID | Status |
|---------|--------|
| Qiskit converter suite (`97 passed`) | ✅ |
| SX-focused circuit tests (`4 passed`) | ✅ |
| Ruff format and import/undefined-name checks | ✅ |
| Circuit subsystem (`798 passed`, `5 skipped`) | ✅ |

Three unrelated Stim parity tests could not run locally because the `stim` package has no wheel for this ARM64 environment and its source build requires unavailable Python development headers.

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review
- [x] I have added/updated tests
- [x] Relevant tests pass locally
- [ ] All tests pass in CI
- [ ] I have updated the documentation
- [ ] I have added a changelog entry to `changelog-dev.rst`
- [x] Breaking changes are documented with migration path

## Reviewer Notes

The phase correction is carried by the exported gate matrix instead of only the containing circuit's `global_phase`. This is necessary because controlling the operation makes the phase relative, and Qiskit's control construction does not preserve a custom gate definition's global phase.
