### PR TITLE
Fix missing imports in truth_tables (int_encoder, get_ordered_symbol_list)

### DIFF
--- a/src/qrisp/alg_primitives/logic_synthesis/truth_tables.py
+++ b/src/qrisp/alg_primitives/logic_synthesis/truth_tables.py
@@ -372,6 +372,8 @@ def NZ(f):
 
 
 def synth_poly(truth_table, column=0, coeff=None):
+    from qrisp.alg_primitives.arithmetic.poly_tools import get_ordered_symbol_list
+
     if coeff is None:
         coeff = sp.symbols("".join([" x" + str(i) for i in range(truth_table.bit_amount)]))
         if truth_table.bit_amount == 1:
@@ -428,6 +430,7 @@ class LogicSynthGate(Operation):
 def check_synthesis(tt, gate, log_output=False):
     synth_correct = True
     from qrisp.core import QuantumSession, QuantumVariable
+    from qrisp.misc import int_encoder
 
     for i in range(tt.shape[0]):
         qs = QuantumSession()


### PR DESCRIPTION
Fixes two of the confirmed undefined-name (F821) cases from #758.

`src/qrisp/alg_primitives/logic_synthesis/truth_tables.py` calls two functions that are never imported:

- **`check_synthesis()`** calls `int_encoder` — defined in `qrisp.misc` (and imported that way elsewhere, e.g. `core/quantum_variable.py`, `arithmetic/adders/cuccaro_adder.py`), but this module only imported `int_as_array`.
- **`synth_poly()`** calls `get_ordered_symbol_list` — defined in `alg_primitives/arithmetic/poly_tools.py`, not imported here. This call sits inside a bare `except: pass`, so the `NameError` was silently swallowed and the function returned `None` instead of the synthesized polynomial.

Both are fixed with local (in-function) imports, matching the existing import style already used in this file (e.g. `check_synthesis` already does `from qrisp.core import ...` locally). Verified with the repo's own ruff config — `ruff check --select F821` no longer flags these two, and `ruff format --check` is clean.

I deliberately left the remaining F821 cases from #758 (the commented-out `D` in `calc_complexity`, `init_state` in `initial_state_mkcs`, `l` in `matrix_multiplication`) out of this PR, since fixing them involves a design decision rather than a mechanical import — happy to follow up on those per the discussion in #758.