### PR TITLE
Fix `get_unitary` precision

### DIFF
--- a/documentation/source/general/changelog/changelog-dev.rst
+++ b/documentation/source/general/changelog/changelog-dev.rst
@@ -62,6 +62,12 @@ Other New Features
 Bug Fixes
 ---------
 
+* Fixed the precision of :meth:`get_unitary <qrisp.QuantumCircuit.get_unitary>`.
+  Unitary matrices are now computed in ``complex128`` precision, removing the
+  spurious ~1e-7 off-diagonal entries that previously appeared where a
+  unitary should vanish exactly (e.g. phase-tolerant controlled gates).
+  (`PR #787 <https://github.com/eclipse-qrisp/Qrisp/pull/787>`_).
+
 * Fixed a bug where :func:`dot <qrisp.dot>` failed with a
   ``TypeError: 'QuantumArrayIterator' object is not iterable``
   (`PR #642 <https://github.com/eclipse-qrisp/Qrisp/pull/642>`_).

--- a/documentation/source/general/changelog/changelog-dev.rst
+++ b/documentation/source/general/changelog/changelog-dev.rst
@@ -37,6 +37,12 @@ Other New Features
 Bug Fixes
 ---------
 
+* Fixed the precision of :meth:`get_unitary <qrisp.QuantumCircuit.get_unitary>`.
+  Unitary matrices are now computed in ``complex128`` precision, removing the
+  spurious ~1e-7 off-diagonal entries that previously appeared where a
+  unitary should vanish exactly (e.g. phase-tolerant controlled gates).
+  (`PR #787 <https://github.com/eclipse-qrisp/Qrisp/pull/787>`_).
+
 * Fixed a bug where :func:`dot <qrisp.dot>` failed with a
   ``TypeError: 'QuantumArrayIterator' object is not iterable``
   (`PR #642 <https://github.com/eclipse-qrisp/Qrisp/pull/642>`_).

--- a/src/qrisp/circuit/operation.py
+++ b/src/qrisp/circuit/operation.py
@@ -205,7 +205,7 @@ class Operation:
         array([[1.+0.j, 0.+0.j, 0.+0.j, 0.+0.j],
                [0.+0.j, 1.+0.j, 0.+0.j, 0.+0.j],
                [0.+0.j, 0.+0.j, 1.+0.j, 0.+0.j],
-               [0.+0.j, 0.+0.j, 0.+0.j, 0.+1.j]], dtype=complex64)
+               [0.+0.j, 0.+0.j, 0.+0.j, 0.+1.j]], dtype=complex128)
 
         """
         if self.name == "barrier":

--- a/src/qrisp/circuit/quantum_circuit.py
+++ b/src/qrisp/circuit/quantum_circuit.py
@@ -722,7 +722,7 @@ class QuantumCircuit:
         Returns
         -------
         numpy.ndarray
-            The unitary matrix. ``dtype`` is ``complex64`` for numeric
+            The unitary matrix. ``dtype`` is ``complex128`` for numeric
             circuits and ``object`` for symbolic ones.
 
 
@@ -743,7 +743,7 @@ class QuantumCircuit:
         array([[ 1.+0.j,  0.+0.j,  0.+0.j,  0.+0.j],
                [ 0.+0.j,  1.+0.j,  0.+0.j,  0.+0.j],
                [ 0.+0.j,  0.+0.j,  1.+0.j,  0.+0.j],
-               [ 0.+0.j,  0.+0.j,  0.+0.j, -1.+0.j]], dtype=complex64)
+               [ 0.+0.j,  0.+0.j,  0.+0.j, -1.+0.j]], dtype=complex128)
 
         We now synthesize the exact same QuantumCircuit, but this time ``phi`` is a SymPy
         symbol.

--- a/src/qrisp/simulator/tensor_factor.py
+++ b/src/qrisp/simulator/tensor_factor.py
@@ -73,9 +73,13 @@ class TensorFactor:
             matrix = matrix * (np.abs(matrix) > float_thresh)
 
         # Match the dtype of the state to avoid mixing e.g. complex64 states with
-        # complex128 unitaries, which the numba contraction kernels cannot handle
-        if matrix.dtype != self.tensor_array.data.dtype and self.tensor_array.data.dtype != np.dtype("O"):
-            matrix = matrix.astype(self.tensor_array.data.dtype)
+        # complex128 unitaries, which the numba contraction kernels cannot handle.
+        # Object arrays (symbolic circuits) are handled by tensordot and must not
+        # be cast - they carry SymPy expressions that have no numeric value yet.
+        object_dtype = np.dtype("O")
+        state_dtype = self.tensor_array.data.dtype
+        if object_dtype not in (matrix.dtype, state_dtype) and matrix.dtype != state_dtype:
+            matrix = matrix.astype(state_dtype)
 
         # Convert matrix to BiArray
         matrix = DenseBiArray(matrix)

--- a/src/qrisp/simulator/tensor_factor.py
+++ b/src/qrisp/simulator/tensor_factor.py
@@ -72,6 +72,11 @@ class TensorFactor:
         if matrix.size >= 2**6 and matrix.dtype != np.dtype("O"):
             matrix = matrix * (np.abs(matrix) > float_thresh)
 
+        # Match the dtype of the state to avoid mixing e.g. complex64 states with
+        # complex128 unitaries, which the numba contraction kernels cannot handle
+        if matrix.dtype != self.tensor_array.data.dtype and self.tensor_array.data.dtype != np.dtype("O"):
+            matrix = matrix.astype(self.tensor_array.data.dtype)
+
         # Convert matrix to BiArray
         matrix = DenseBiArray(matrix)
 

--- a/src/qrisp/simulator/unitary_management.py
+++ b/src/qrisp/simulator/unitary_management.py
@@ -23,7 +23,7 @@ from numba import njit
 from qrisp import ControlledOperation, fast_append
 from qrisp.simulator.bi_arrays import BiArray, DenseBiArray, SparseBiArray, tensordot
 
-np_dtype = np.complex64
+np_dtype = np.complex128
 
 id_matrix = np.eye(2, dtype=np_dtype)
 

--- a/tests/circuit_tests/passes/test_combine_single_qubit_gates.py
+++ b/tests/circuit_tests/passes/test_combine_single_qubit_gates.py
@@ -18,6 +18,7 @@
 from __future__ import annotations
 
 import numpy as np
+import pytest
 
 from qrisp.circuit.operation import ControlledOperation
 from qrisp.circuit.pass_management.passes.combine_single_qubit_gates import (
@@ -77,6 +78,20 @@ class TestIdentityCancellation:
         qc = QuantumCircuit(1)
         qc.rx(np.pi, 0)
         qc.rx(-np.pi, 0)
+        result = combine_single_qubit_gates(qc)
+        assert len(result.data) == 0
+
+    @pytest.mark.parametrize("gate_name", ["rx", "ry", "rz"])
+    def test_rotation_pi_half_then_inverse_cancels(self, gate_name):
+        """R(π/2) then R(−π/2) on the same qubit → identity.
+
+        The combine pass works in float64 precision, so the residual of
+        R(π/2)·R(−π/2) lies below the cancellation threshold and the two
+        gates cancel.
+        """
+        qc = QuantumCircuit(1)
+        getattr(qc, gate_name)(np.pi / 2, 0)
+        getattr(qc, gate_name)(-np.pi / 2, 0)
         result = combine_single_qubit_gates(qc)
         assert len(result.data) == 0
 

--- a/tests/circuit_tests/passes/test_combine_single_qubit_gates.py
+++ b/tests/circuit_tests/passes/test_combine_single_qubit_gates.py
@@ -60,19 +60,17 @@ class TestIdentityCancellation:
         result = combine_single_qubit_gates(qc)
         assert len(result.data) == 0
 
-    def test_h_then_h_combined(self):
-        """H followed by H on the same qubit is combined into a single gate.
+    def test_h_then_h_cancels(self):
+        """H followed by H on the same qubit → identity.
 
-        Qrisp's H gate has tiny (~1e-16) imaginary components that push
-        the norm of H² − I just above the 1e-10 cancellation threshold,
-        so the two H gates are combined rather than cancelled.
+        The combine pass works in float64 precision, so the norm of H² − I
+        lies below the cancellation threshold and the two H gates cancel.
         """
         qc = QuantumCircuit(1)
         qc.h(0)
         qc.h(0)
         result = combine_single_qubit_gates(qc)
-        # H² ≈ I within ~1e-7, so the pass combines them into one u3 gate.
-        assert len(result.data) == 1
+        assert len(result.data) == 0
 
     def test_rx_pi_then_rx_minus_pi_cancels(self):
         """RX(π) then RX(−π) → identity."""

--- a/tests/circuit_tests/test_quantum_circuit.py
+++ b/tests/circuit_tests/test_quantum_circuit.py
@@ -1911,6 +1911,153 @@ class TestQuantumCircuitRunAndStatevector:
         assert sv.dtype == np.complex64
 
 
+class TestQuantumCircuitSymbolicSimulation:
+    """Tests for simulating circuits that carry unbound SymPy parameters.
+
+    The simulator keeps its state in ``complex64`` while ``get_unitary``
+    produces ``complex128``, so ``TensorFactor.apply_matrix`` casts the gate
+    matrix to the state dtype. Symbolic gates produce ``object`` matrices that
+    have no numeric value yet and must be excluded from that cast, in both
+    directions: an object matrix meeting a numeric state, and a numeric matrix
+    meeting an object state.
+    """
+
+    @staticmethod
+    def _bind(statevector, subs_dic):
+        """Substitute ``subs_dic`` into a symbolic statevector.
+
+        Entries are a mix of Python ``complex``, ``sympy.Float`` and
+        ``sympy.Zero``, so each one is sympified before substituting.
+        """
+        return np.array([complex(sympy.sympify(entry).subs(subs_dic)) for entry in statevector])
+
+    def test_statevector_array_symbolic_keeps_object_dtype(self):
+        """A circuit with an unbound parameter yields an object-dtype statevector."""
+        phi = symbols("phi")
+        qc = QuantumCircuit(2)
+        qc.h(0)
+        qc.h(1)
+        qc.cp(phi, 0, 1)
+        sv = qc.statevector_array()
+        assert sv.dtype == np.dtype("O")
+
+    def test_statevector_array_symbolic_retains_free_symbol(self):
+        """The unbound parameter survives into the amplitudes."""
+        phi = symbols("phi")
+        qc = QuantumCircuit(2)
+        qc.h(0)
+        qc.h(1)
+        qc.cp(phi, 0, 1)
+        sv = qc.statevector_array()
+        free_symbols = set().union(*[sympy.sympify(entry).free_symbols for entry in sv])
+        assert free_symbols == {phi}
+
+    def test_statevector_array_numeric_gate_before_symbolic_gate(self):
+        """A numeric gate followed by a symbolic one does not raise.
+
+        Regression test: the numeric ``h`` leaves the state in ``complex64``,
+        and the symbolic ``cp`` then hands ``apply_matrix`` an ``object``
+        matrix. Casting that matrix to ``complex64`` raises
+        ``TypeError: Cannot convert expression to float``.
+        """
+        phi = symbols("phi")
+        qc = QuantumCircuit(2)
+        qc.h(0)
+        qc.h(1)
+        qc.cp(phi, 0, 1)
+        sv = qc.statevector_array()
+        assert sv.dtype == np.dtype("O")
+        assert np.isclose(complex(sympy.sympify(sv[0])), 0.5, atol=1e-5)
+
+    def test_statevector_array_symbolic_gate_before_numeric_gate(self):
+        """A symbolic gate followed by a numeric one does not raise.
+
+        The reverse ordering: the symbolic ``p`` turns the state into an
+        ``object`` array, and the numeric ``h``/``cx`` then hand
+        ``apply_matrix`` a ``complex128`` matrix, which must not be cast to
+        ``object`` either.
+        """
+        phi = symbols("phi")
+        qc = QuantumCircuit(2)
+        qc.p(phi, 0)
+        qc.h(0)
+        qc.cx(0, 1)
+        sv = qc.statevector_array()
+        assert sv.dtype == np.dtype("O")
+        assert np.isclose(np.linalg.norm(self._bind(sv, {phi: 0.4})), 1.0, atol=1e-5)
+
+    def test_statevector_array_symbolic_matches_numeric_after_substitution(self):
+        """Binding the symbol reproduces the statevector of the numeric circuit."""
+        phi = symbols("phi")
+        value = 0.7
+
+        symbolic_qc = QuantumCircuit(2)
+        symbolic_qc.h(0)
+        symbolic_qc.h(1)
+        symbolic_qc.cp(phi, 0, 1)
+        bound = self._bind(symbolic_qc.statevector_array(), {phi: value})
+
+        numeric_qc = QuantumCircuit(2)
+        numeric_qc.h(0)
+        numeric_qc.h(1)
+        numeric_qc.cp(value, 0, 1)
+        reference = np.asarray(numeric_qc.statevector_array())
+
+        assert np.allclose(bound, reference, atol=1e-5)
+
+    def test_statevector_array_multiple_symbols(self):
+        """Several independent parameters are all retained."""
+        phi, theta = symbols("phi theta")
+        qc = QuantumCircuit(2)
+        qc.rx(phi, 0)
+        qc.rx(theta, 1)
+        sv = qc.statevector_array()
+        free_symbols = set().union(*[sympy.sympify(entry).free_symbols for entry in sv])
+        assert free_symbols == {phi, theta}
+        bound = self._bind(sv, {phi: 0.3, theta: 1.1})
+        assert np.isclose(np.linalg.norm(bound), 1.0, atol=1e-5)
+
+    def test_statevector_array_symbolic_controlled_gate(self):
+        """The documented abstract-parameter example still simulates.
+
+        Mirrors ``documentation/source/reference/Examples/AbstractParameter.rst``:
+        a phase gate with a SymPy symbol, controlled on ``ctrl_state="00"``.
+        """
+        from qrisp.circuit import PGate
+
+        phi = symbols("phi")
+        qc = QuantumCircuit(3)
+        qc.h(-1)
+        qc.append(PGate(phi).control(2, ctrl_state="00"), qc.qubits)
+
+        sv = qc.statevector_array()
+        assert sv.dtype == np.dtype("O")
+
+        bound = self._bind(sv, {phi: np.pi / 2})
+        expected = np.zeros(8, dtype=np.complex128)
+        expected[0] = 1 / np.sqrt(2)
+        expected[1] = np.exp(1j * np.pi / 2) / np.sqrt(2)
+        assert np.allclose(bound, expected, atol=1e-5)
+
+    def test_get_unitary_symbolic_keeps_object_dtype(self):
+        """``get_unitary`` of a symbolic circuit stays an object array."""
+        phi = symbols("phi")
+        qc = QuantumCircuit(2)
+        qc.h(0)
+        qc.cp(phi, 0, 1)
+        unitary = qc.get_unitary()
+        assert unitary.dtype == np.dtype("O")
+
+    def test_bind_parameters_then_run_symbolic_circuit(self):
+        """A bound symbolic circuit simulates back to a numeric result."""
+        phi = symbols("phi")
+        qc = QuantumCircuit(1, 1)
+        qc.rx(phi, 0)
+        qc.measure(0, 0)
+        result = qc.bind_parameters({phi: np.pi}).run()
+        assert np.isclose(result.get("1", 0.0), 1.0, atol=1e-5)
+
+
 class TestQuantumCircuitFromQasmFile:
     """Tests for QuantumCircuit.from_qasm_file."""
 

--- a/tests/circuit_tests/test_quantum_circuit.py
+++ b/tests/circuit_tests/test_quantum_circuit.py
@@ -28,7 +28,7 @@ from sympy import symbols
 
 from qrisp.circuit import Clbit, Instruction, Qubit
 from qrisp.circuit.quantum_circuit import QuantumCircuit
-from qrisp.circuit.standard_operations import CXGate, Measurement, XGate
+from qrisp.circuit.standard_operations import CXGate, Measurement, RXGate, XGate
 from qrisp.permeability import PermeabilityGraph
 
 
@@ -620,6 +620,22 @@ class TestQuantumCircuitMethods:
         qc.h(0)
         u = qc.get_unitary()
         assert np.allclose(u, u.conj().T)
+
+    def test_get_unitary_controlled_gate_precision(self):
+        """Regression test: phase-tolerant controlled gates have vanishing
+        off-diagonal entries.
+
+        The unitary used to be computed in ``complex64``, leaving spurious
+        ~1e-7 entries where the matrix must vanish exactly. With
+        ``complex128`` these sit at float64 round-off level (~1e-16).
+        """
+        qc = QuantumCircuit(4)
+        qc.append(RXGate(0.7).control(3, method="gray_pt"), [0, 1, 2, 3])
+
+        u = qc.get_unitary()
+        assert u.dtype == np.complex128
+        spurious = np.abs(u)[np.abs(u) < 0.1]
+        assert spurious.max() < 1e-12
 
     # ------------------------------------------------------------------ #
     # get_unitary — docstring examples                                   #
@@ -1879,6 +1895,20 @@ class TestQuantumCircuitRunAndStatevector:
         qc.ry(np.pi / 3, 2)
         sv = qc.statevector_array()
         assert np.isclose(np.linalg.norm(sv), 1.0, atol=1e-5)
+
+    def test_statevector_array_dtype_is_complex64(self):
+        """The simulator statevector stays in complex64 precision.
+
+        ``get_unitary`` now computes in ``complex128``, but the simulator
+        keeps its state in ``complex64`` (the gate matrix is cast to the
+        state's dtype in ``apply_matrix``), so the statevector dtype is
+        unchanged.
+        """
+        qc = QuantumCircuit(2)
+        qc.h(0)
+        qc.cx(0, 1)
+        sv = qc.statevector_array()
+        assert sv.dtype == np.complex64
 
 
 class TestQuantumCircuitFromQasmFile:

--- a/tests/core_tests/test_symbolic_statevector.py
+++ b/tests/core_tests/test_symbolic_statevector.py
@@ -1,0 +1,136 @@
+"""********************************************************************************
+* Copyright (c) 2026 the Qrisp authors
+*
+* This program and the accompanying materials are made available under the
+* terms of the Eclipse Public License 2.0 which is available at
+* http://www.eclipse.org/legal/epl-2.0.
+*
+* This Source Code may also be made available under the following Secondary
+* Licenses when the conditions for such availability set forth in the Eclipse
+* Public License, v. 2.0 are satisfied: GNU General Public License, version 2
+* with the GNU Classpath Exception which is
+* available at https://www.gnu.org/software/classpath/license.html.
+*
+* SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+********************************************************************************
+"""
+
+import numpy as np
+import sympy
+from sympy import symbols
+
+from qrisp.core import QuantumVariable
+from qrisp.core.gate_application_functions import cx, h, rx
+
+
+class TestSymbolicStatevector:
+    """Tests for QuantumSession.statevector on circuits with unbound parameters.
+
+    These exercise the same simulator path as the QuantumCircuit-level tests in
+    ``tests/circuit_tests/test_quantum_circuit.py``, but through the
+    user-facing :meth:`QuantumSession.statevector` entry point documented in
+    ``documentation/source/reference/Examples/AbstractParameter.rst``.
+    """
+
+    def test_statevector_sympy_retains_free_symbols(self):
+        """The ket expression keeps the unbound parameters.
+
+        ``free_symbols`` also contains the basis-state kets, so the parameters
+        are checked for as a subset.
+        """
+        phi, theta = symbols("phi theta")
+        qv = QuantumVariable(2)
+        rx(phi, qv[0])
+        rx(theta, qv[1])
+        state = qv.qs.statevector()
+        assert {phi, theta}.issubset(state.free_symbols)
+
+    def test_statevector_sympy_matches_documented_example(self):
+        """Reproduces the ket from the abstract-parameter documentation page.
+
+        ``rx(phi) (x) rx(theta)`` populates all four basis states of the two
+        active qubits, and the amplitudes carry the expected trigonometric
+        factors.
+        """
+        phi, theta = symbols("phi theta")
+        qv = QuantumVariable(4)
+        rx(phi, qv[0])
+        rx(theta, qv[1])
+        state = qv.qs.statevector()
+
+        assert len(state.args) == 4
+        assert {phi, theta}.issubset(state.free_symbols)
+
+        # rx(0) (x) rx(0) is the identity, so the state collapses to |0000>
+        # with amplitude 1 and only the ket symbol survives.
+        collapsed = sympy.simplify(state.subs({phi: 0, theta: 0}))
+        (ground_ket,) = collapsed.free_symbols
+        assert sympy.simplify(collapsed / ground_ket) == 1
+
+        # rx(pi) maps |0> to -I|1>, so only the |1000> term survives.
+        flipped = sympy.simplify(state.subs({phi: sympy.pi, theta: 0}))
+        (flipped_ket,) = flipped.free_symbols
+        assert flipped_ket != ground_ket
+        assert sympy.simplify(flipped / flipped_ket) == -sympy.I
+
+    def test_statevector_array_symbolic_matches_numeric_after_substitution(self):
+        """Binding the symbols reproduces the numeric session's statevector."""
+        phi, theta = symbols("phi theta")
+        values = {phi: 0.3, theta: 1.1}
+
+        symbolic_qv = QuantumVariable(4)
+        rx(phi, symbolic_qv[0])
+        rx(theta, symbolic_qv[1])
+        symbolic_sv = symbolic_qv.qs.statevector(return_type="array")
+        bound = np.array([complex(sympy.sympify(entry).subs(values)) for entry in symbolic_sv])
+
+        numeric_qv = QuantumVariable(4)
+        rx(values[phi], numeric_qv[0])
+        rx(values[theta], numeric_qv[1])
+        reference = np.asarray(numeric_qv.qs.statevector(return_type="array"))
+
+        assert np.allclose(bound, reference, atol=1e-5)
+
+    def test_statevector_array_symbolic_is_object_dtype(self):
+        """``return_type="array"`` yields an object array for symbolic circuits."""
+        phi = symbols("phi")
+        qv = QuantumVariable(2)
+        h(qv[0])
+        rx(phi, qv[1])
+        sv = qv.qs.statevector(return_type="array")
+        assert sv.dtype == np.dtype("O")
+
+    def test_statevector_array_symbolic_after_entangling_gate(self):
+        """A symbolic gate after an entangling numeric gate does not raise.
+
+        Regression test: ``h``/``cx`` leave the state in ``complex64``, and the
+        symbolic ``rx`` then hands the simulator an ``object`` gate matrix.
+        Casting that matrix to the state dtype raises
+        ``TypeError: Cannot convert expression to float``.
+        """
+        phi = symbols("phi")
+        qv = QuantumVariable(2)
+        h(qv[0])
+        cx(qv[0], qv[1])
+        rx(phi, qv[1])
+
+        sv = qv.qs.statevector(return_type="array")
+        assert sv.dtype == np.dtype("O")
+
+        bound = np.array([complex(sympy.sympify(entry).subs({phi: 0.9})) for entry in sv])
+        assert np.isclose(np.linalg.norm(bound), 1.0, atol=1e-5)
+
+    def test_get_measurement_with_subs_dic_matches_numeric(self):
+        """Binding a symbol via ``subs_dic`` reproduces the numeric measurement."""
+        phi = symbols("phi")
+        symbolic_qv = QuantumVariable(1)
+        rx(phi, symbolic_qv[0])
+        symbolic_result = symbolic_qv.get_measurement(subs_dic={phi: np.pi / 3})
+
+        numeric_qv = QuantumVariable(1)
+        rx(np.pi / 3, numeric_qv[0])
+        numeric_result = numeric_qv.get_measurement()
+
+        assert symbolic_result.keys() == numeric_result.keys()
+        for outcome, probability in numeric_result.items():
+            assert np.isclose(symbolic_result[outcome], probability, atol=1e-4)


### PR DESCRIPTION
## Description

<!-- What does this PR do? Keep it concise. -->

Qrisp was using a "low-precision" number format (`float32`) when building gate matrices. That format is a bit sloppy - every calculation leaves behind tiny leftover errors, about 1e-7. So for a gate that should have zeros in some spots, Qrisp printed tiny non-zero numbers like 2.66e-7 instead. When you compare Qrisp's gate to Qrisp's own gate, both have the same sloppiness - they cancel out. But when you compare Qrisp against another library (pytket) that uses the clean "high-precision" format (float64), Qrisp's tiny fake numbers showed up as real differences.

This PR switches Qrisp's unitary `dtype` to `complex128`. `get_unitary` produces zero entries where it is expected. Originally, this change broke the simulator as it uses the older low precision format; mixing the two led to unit test failures. With the changes in this branch, the new `dtype` is changed to the simulator's `dtype` to avoid mixing the two formats. Switching to the new `dtype` in the simulator would have slowed down the simulator. So, with this branch, only `get_unitary` gets more precise (dtype = complex128) while keeping everything else the same (dtype = complex64). 

## Related Issues

<!-- Link related issues. Use closing keywords to auto-close them on merge. -->
Closes #786 
Related to #

## Type of Change

<!-- Check all that apply -->
- [ ] Feature (new functionality)
- [ ] Change Request (modification of existing functionality)
- [ ] Bug Fix
- [ ] Refactoring (no behavior change)
- [x] Performance improvement
- [ ] Documentation
- [ ] CI / Build

## Breaking Change?
- [ ] Yes
- [ ] No

If yes, describe the impact and migration path:


## What was changed?

<!-- Bullet list of concrete changes -->
-
-

## How was it tested?

<!-- Optional - Reference Test-IDs from the linked issue(s) and describe any additional testing. -->

| Test-ID | Status |
|---------|--------|
| T-001   | ✅ / ❌ |
| T-002   | ✅ / ❌ |
| T-003   | ✅ / ❌ |
| T-004   | ✅ / ❌ |

## Screenshots / Output (if applicable)

<!-- Add additional information if it helps -->

## Checklist
- [ ] My code follows the project's coding standards
- [ ] I have performed a self-review
- [ ] I have added/updated tests (referencing issue Test-IDs)
- [ ] All tests pass locally and in CI
- [ ] I have updated the documentation
- [ ] I have added a changelog entry to `changelog-dev.rst`
- [ ] Breaking changes are documented with migration path

## Reviewer Notes

<!-- Anything specific the reviewer should focus on? -->