### PR TITLE
Fix `QiskitBackend` submission for providers that report non-hex `memory`

### DIFF
--- a/documentation/source/general/changelog/changelog-dev.rst
+++ b/documentation/source/general/changelog/changelog-dev.rst
@@ -49,6 +49,18 @@ Bug Fixes
   in ``CircuitOperation`` calls
   (`PR #709 <https://github.com/eclipse-qrisp/Qrisp/pull/709>`_).
 
+* Fixed :class:`~qrisp.interface.QiskitBackend` failing with
+  ``OverflowError: int too big to convert`` — or, for small classical
+  registers, silently returning wrong counts — on providers that report
+  measurement results as binary rather than hexadecimal strings, such as
+  ``qiskit-iqm``.  Circuits are now submitted through the wrapped backend's
+  own ``run()`` method and counts are read via ``Result.get_counts()``,
+  instead of going through Qiskit's ``BackendSamplerV2`` primitive, which
+  rebuilds counts from the hex-encoded ``memory`` field.
+  :class:`~qrisp.interface.QiskitRuntimeBackend` continues to use
+  ``SamplerV2``, which IBM Runtime requires
+  (`PR #XXX <https://github.com/eclipse-qrisp/Qrisp/pull/XXX>`_).
+
 Compatibility
 -------------
 

--- a/documentation/source/general/changelog/changelog-dev.rst
+++ b/documentation/source/general/changelog/changelog-dev.rst
@@ -58,8 +58,11 @@ Bug Fixes
   instead of going through Qiskit's ``BackendSamplerV2`` primitive, which
   rebuilds counts from the hex-encoded ``memory`` field.
   :class:`~qrisp.interface.QiskitRuntimeBackend` continues to use
-  ``SamplerV2``, which IBM Runtime requires
-  (`PR #788 <https://github.com/eclipse-qrisp/Qrisp/pull/XXX>`_).
+  ``SamplerV2``, which IBM Runtime requires.  Passing a real IBM Quantum
+  backend to :class:`~qrisp.interface.QiskitBackend` now raises a ``TypeError``
+  pointing at :class:`~qrisp.interface.QiskitRuntimeBackend`; IBM *fake*
+  backends are unaffected
+  (`PR #788 <https://github.com/eclipse-qrisp/Qrisp/pull/788>`_).
 
 Compatibility
 -------------

--- a/documentation/source/general/changelog/changelog-dev.rst
+++ b/documentation/source/general/changelog/changelog-dev.rst
@@ -59,7 +59,7 @@ Bug Fixes
   rebuilds counts from the hex-encoded ``memory`` field.
   :class:`~qrisp.interface.QiskitRuntimeBackend` continues to use
   ``SamplerV2``, which IBM Runtime requires
-  (`PR #XXX <https://github.com/eclipse-qrisp/Qrisp/pull/XXX>`_).
+  (`PR #788 <https://github.com/eclipse-qrisp/Qrisp/pull/XXX>`_).
 
 Compatibility
 -------------

--- a/documentation/source/reference/Backend Interface/index.rst
+++ b/documentation/source/reference/Backend Interface/index.rst
@@ -613,7 +613,9 @@ For more details, see the :ref:`BatchedBackend` documentation.
 :class:`~qrisp.interface.QiskitBackend` is a :ref:`Backend` that wraps any
 Qiskit-compatible backend (simulators or real hardware). Circuits are converted
 directly to Qiskit ``QuantumCircuit`` objects, transpiled for the target device,
-and submitted through the backend's own ``run()`` method.
+and submitted through the backend's own ``run()`` method. Real IBM Quantum
+hardware is the exception, since IBM removed support for ``run()``: use
+:class:`~qrisp.interface.QiskitRuntimeBackend` for those.
 
 .. code-block:: python
 

--- a/documentation/source/reference/Backend Interface/index.rst
+++ b/documentation/source/reference/Backend Interface/index.rst
@@ -613,7 +613,7 @@ For more details, see the :ref:`BatchedBackend` documentation.
 :class:`~qrisp.interface.QiskitBackend` is a :ref:`Backend` that wraps any
 Qiskit-compatible backend (simulators or real hardware). Circuits are converted
 directly to Qiskit ``QuantumCircuit`` objects, transpiled for the target device,
-and submitted through Qiskit's ``SamplerV2`` primitive.
+and submitted through the backend's own ``run()`` method.
 
 .. code-block:: python
 

--- a/src/qrisp/interface/provider_backends/qiskit_backend.py
+++ b/src/qrisp/interface/provider_backends/qiskit_backend.py
@@ -398,8 +398,8 @@ class QiskitBackend(Backend):
 
         shots : int or list[int] or None, optional
             Number of shots.  If ``None``, the backend's ``shots`` option is
-            used. If a ``list[int]`` is provided, the Qiskit sampler does not
-            support per-circuit shot counts, so all circuits are run at
+            used. If a ``list[int]`` is provided, Qiskit applies a single shot
+            count to the whole submission, so all circuits are run at
             ``max(shots)`` and a ``UserWarning`` is emitted.
 
         Returns

--- a/src/qrisp/interface/provider_backends/qiskit_backend.py
+++ b/src/qrisp/interface/provider_backends/qiskit_backend.py
@@ -26,9 +26,7 @@ from collections.abc import Mapping
 from typing import cast
 
 from qiskit import QuantumCircuit, transpile
-from qiskit.primitives import BackendSamplerV2
 from qiskit.providers import Backend as QiskitBackendBase
-from qiskit.providers import BackendV2
 
 from qrisp.circuit.quantum_circuit import QuantumCircuit as QrispQuantumCircuit
 from qrisp.interface.backend import Backend
@@ -69,8 +67,21 @@ def _map_qiskit_status(qiskit_job) -> JobStatus:
     return mapping.get(name, JobStatus.RUNNING)
 
 
+def _merge_counts(counts: Mapping) -> dict:
+    """Strip register separators from bitstring keys, summing any keys that collide.
+
+    Qiskit separates classical registers with a space (``"01 10"``); Qrisp
+    expects a single contiguous bitstring.
+    """
+    merged: dict = {}
+    for key, val in counts.items():
+        clean_key = re.sub(r"\W", "", key)
+        merged[clean_key] = merged.get(clean_key, 0) + val
+    return merged
+
+
 class QiskitJob(Job):
-    """A :class:`~qrisp.interface.Job` that wraps a Qiskit ``SamplerV2`` job.
+    """A :class:`~qrisp.interface.Job` that wraps a Qiskit job.
 
     One ``QiskitJob`` is created per :meth:`QiskitBackend.run_async` call,
     regardless of how many circuits were submitted.  Internally it holds
@@ -80,7 +91,19 @@ class QiskitJob(Job):
     :meth:`result` blocks until the Qiskit job reaches a terminal state,
     delegating the actual waiting to Qiskit's own ``job.result()`` call.
     No Qrisp-level threading primitives are required here because Qiskit's
-    ``SamplerV2.run()`` is already asynchronous.
+    ``run()`` is already asynchronous.
+
+    Parameters
+    ----------
+    backend : QiskitBackend
+        The Qrisp backend that created this job.
+
+    qiskit_job : Job
+        The underlying Qiskit job object.
+
+    num_circuits : int
+        How many circuits were submitted in this job.
+
     """
 
     def __init__(
@@ -98,6 +121,19 @@ class QiskitJob(Job):
         self._qiskit_job = qiskit_job
         self._num_circuits = num_circuits
         self._cached_result: JobResult | None = None
+
+    def _extract_counts(self, qiskit_result) -> list[dict]:
+        """Read per-circuit counts out of the ``Result`` returned by ``Backend.run()``."""
+        if not hasattr(qiskit_result, "get_counts"):
+            raise TypeError(
+                f"Expected a Qiskit Result with a get_counts() method, got "
+                f"{type(qiskit_result).__name__}. Backends whose run() does not return a "
+                "Result need their own QiskitJob subclass overriding _extract_counts()."
+            )
+        # get_counts() returns a single Counts for one experiment, a list for several.
+        counts = qiskit_result.get_counts()
+        counts_list = [counts] if isinstance(counts, Mapping) else list(counts)
+        return [_merge_counts(counts_list[i]) for i in range(self._num_circuits)]
 
     # ------------------------------------------------------------------
     # Abstract interface
@@ -159,17 +195,7 @@ class QiskitJob(Job):
             raise JobFailureError(f"Qiskit job {self._job_id!r} failed: {exc}") from exc
 
         self._last_known_status = JobStatus.DONE
-        counts_list = []
-        for i in range(self._num_circuits):
-            counts_dict = {}
-            for reg_name in qiskit_result[i].data:
-                reg_data = getattr(qiskit_result[i].data, reg_name)
-                for key, val in reg_data.get_counts().items():
-                    clean_key = re.sub(r"\W", "", key)
-                    counts_dict[clean_key] = counts_dict.get(clean_key, 0) + val
-            counts_list.append(counts_dict)
-
-        self._cached_result = JobResult(counts_list)
+        self._cached_result = JobResult(self._extract_counts(qiskit_result))
         return self._cached_result
 
     def cancel(self) -> bool:
@@ -205,9 +231,21 @@ class QiskitBackend(Backend):
 
     Circuits are converted from Qrisp's internal representation to Qiskit
     ``QuantumCircuit`` objects, transpiled for the target backend, and
-    submitted through Qiskit's ``SamplerV2`` primitive.
+    submitted through the backend's own ``run()`` method.
     A ``QiskitJob`` handle is returned immediately; call
     :meth:`Job.result` to block and retrieve the :class:`~qrisp.interface.JobResult`.
+
+    .. note::
+
+        Submission deliberately goes through ``Backend.run()`` rather than
+        Qiskit's ``BackendSamplerV2`` primitive. ``BackendSamplerV2``
+        reconstructs its output from the ``memory`` field of the result and
+        parses each entry as a hexadecimal string. Not every provider honours
+        that convention (``qiskit-iqm``, for instance, writes plain binary
+        bitstrings), which yields either an ``OverflowError`` or, worse,
+        silently wrong counts. Reading counts directly via
+        ``Result.get_counts()`` avoids the ambiguity, and Qrisp never needs
+        per-shot memory anyway.
 
     Parameters
     ----------
@@ -242,7 +280,8 @@ class QiskitBackend(Backend):
 
     When ``get_measurement`` is called, Qrisp compiles the computation into a
     ``QuantumCircuit``, converts it directly to a Qiskit ``QuantumCircuit``,
-    transpiles it for the target backend, and submits it through ``SamplerV2``. Internally, ``run_async`` returns a ``QiskitJob``
+    transpiles it for the target backend, and submits it through the backend's
+    ``run()`` method. Internally, ``run_async`` returns a ``QiskitJob``
     immediately; :meth:`~qrisp.interface.Backend.run` then blocks on
     ``job.result()`` until execution completes and the counts are returned to
     ``get_measurement``:
@@ -285,6 +324,10 @@ class QiskitBackend(Backend):
 
     """
 
+    #: Job wrapper matching the submission path in :meth:`_submit`. Subclasses
+    #: that submit differently pair their own :class:`QiskitJob` subclass here.
+    _job_class: type[QiskitJob] = QiskitJob
+
     def __init__(
         self,
         backend: QiskitBackendBase | None = None,
@@ -304,7 +347,6 @@ class QiskitBackend(Backend):
                 ) from exc
 
         self.backend = backend
-        self.sampler = BackendSamplerV2(backend=cast(BackendV2, backend))
 
         # Fall back to the Qiskit backend's own name/options when not provided.
         # Only use the backend's options when they are a plain Mapping (e.g. dict).
@@ -322,6 +364,14 @@ class QiskitBackend(Backend):
     def _default_options(cls):
         """Return the default runtime options (shots=1024)."""
         return {"shots": 1024}
+
+    def _submit(self, qiskit_circuits: list[QuantumCircuit], shots: int):
+        """Hand a batch of transpiled circuits to the Qiskit backend and return its job.
+
+        Subclasses override this (together with :attr:`_job_class`) when their
+        provider requires a different submission path.
+        """
+        return self.backend.run(qiskit_circuits, shots=shots)
 
     @property
     def max_circuits(self) -> int | None:
@@ -394,11 +444,32 @@ class QiskitBackend(Backend):
 
             qiskit_circuits.append(transpile(new_qc, backend=self.backend))
 
-        # Submit all circuits in a single SamplerV2 call and wrap the result.
-        qiskit_job = self.sampler.run(qiskit_circuits, shots=n_shots)
-        job = QiskitJob(backend=self, qiskit_job=qiskit_job, num_circuits=len(circuits))
+        # Submit all circuits in a single call and wrap the resulting job.
+        qiskit_job = self._submit(qiskit_circuits, n_shots)
+        job = self._job_class(backend=self, qiskit_job=qiskit_job, num_circuits=len(circuits))
         job.submit()
         return job
+
+
+class QiskitRuntimeJob(QiskitJob):
+    """A :class:`QiskitJob` whose underlying job came from a ``SamplerV2`` primitive.
+
+    ``SamplerV2`` returns a ``PrimitiveResult`` rather than a ``Result``: counts
+    live in a per-circuit ``DataBin``, one field per classical register, instead
+    of behind a single ``get_counts()`` call.
+    """
+
+    def _extract_counts(self, qiskit_result) -> list[dict]:
+        """Read per-circuit counts out of the ``PrimitiveResult`` returned by ``SamplerV2``."""
+        counts_list = []
+        for i in range(self._num_circuits):
+            counts_dict: dict = {}
+            for reg_name in qiskit_result[i].data:
+                reg_data = getattr(qiskit_result[i].data, reg_name)
+                for key, val in _merge_counts(reg_data.get_counts()).items():
+                    counts_dict[key] = counts_dict.get(key, 0) + val
+            counts_list.append(counts_dict)
+        return counts_list
 
 
 class QiskitRuntimeBackend(QiskitBackend):
@@ -465,6 +536,8 @@ class QiskitRuntimeBackend(QiskitBackend):
 
     """
 
+    _job_class = QiskitRuntimeJob
+
     def __init__(self, api_token, backend=None, channel="ibm_cloud", mode="job", instance=None):
         try:
             from qiskit_ibm_runtime import QiskitRuntimeService, SamplerV2, Session
@@ -482,8 +555,10 @@ class QiskitRuntimeBackend(QiskitBackend):
         # into the runtime options seen by Qrisp callers.
         super().__init__(backend=ibm_backend, options=self._default_options())
 
-        # Replace the BackendSamplerV2 created by the parent with the IBM Runtime
-        # SamplerV2, which is required for actual IBM hardware execution.
+        # Unlike the parent class, this backend submits through the SamplerV2
+        # primitive: IBMBackend.run() still exists but raises IBMBackendError
+        # ("Support for backend.run() has been removed"), so primitives are the
+        # only route to IBM hardware.
         if mode == "session":
             self.session = Session(ibm_backend)
             self.sampler = SamplerV2(self.session)
@@ -496,6 +571,10 @@ class QiskitRuntimeBackend(QiskitBackend):
     def _default_options(cls):
         """Return the default runtime options (shots=1000)."""
         return {"shots": 1000}
+
+    def _submit(self, qiskit_circuits, shots):
+        """Submit through the IBM Runtime ``SamplerV2`` instead of ``Backend.run()``."""
+        return self.sampler.run(qiskit_circuits, shots=shots)
 
     def close_session(self):
         """Close the IBM Runtime session opened during construction.

--- a/src/qrisp/interface/provider_backends/qiskit_backend.py
+++ b/src/qrisp/interface/provider_backends/qiskit_backend.py
@@ -67,6 +67,15 @@ def _map_qiskit_status(qiskit_job) -> JobStatus:
     return mapping.get(name, JobStatus.RUNNING)
 
 
+def _is_ibm_runtime_backend(backend) -> bool:
+    """Whether *backend* is a real IBM Quantum backend (fake backends run locally and are not)."""
+    try:
+        from qiskit_ibm_runtime import IBMBackend
+    except ImportError:
+        return False  # optional dependency: no IBM backend can be present
+    return isinstance(backend, IBMBackend)
+
+
 def _merge_counts(counts: Mapping) -> dict:
     """Strip register separators from bitstring keys, summing any keys that collide.
 
@@ -259,6 +268,13 @@ class QiskitBackend(Backend):
     options : dict or None, optional
         Runtime options.  Defaults to ``{"shots": 1000}``.
 
+    Raises
+    ------
+    TypeError
+        If *backend* is a real IBM Quantum backend, which cannot run through
+        ``Backend.run()``. Use :class:`QiskitRuntimeBackend` for those. IBM
+        *fake* backends run locally and are supported here.
+
     Examples
     --------
     **Simulation on the Aer simulator**
@@ -328,6 +344,10 @@ class QiskitBackend(Backend):
     #: that submit differently pair their own :class:`QiskitJob` subclass here.
     _job_class: type[QiskitJob] = QiskitJob
 
+    #: False because :meth:`_submit` uses ``Backend.run()``, which IBM removed.
+    #: :class:`QiskitRuntimeBackend` sets it True and submits via ``SamplerV2``.
+    _supports_ibm_runtime = False
+
     def __init__(
         self,
         backend: QiskitBackendBase | None = None,
@@ -335,6 +355,12 @@ class QiskitBackend(Backend):
         options: Mapping | None = None,
     ):
         """Initialise the QiskitBackend, defaulting to AerSimulator if no backend is provided."""
+        if not self._supports_ibm_runtime and _is_ibm_runtime_backend(backend):
+            raise TypeError(
+                "QiskitBackend cannot execute IBM Quantum backends, because IBM removed "
+                "support for Backend.run(). Use QiskitRuntimeBackend instead."
+            )
+
         if backend is None:
             try:
                 from qiskit_aer import AerSimulator
@@ -537,6 +563,7 @@ class QiskitRuntimeBackend(QiskitBackend):
     """
 
     _job_class = QiskitRuntimeJob
+    _supports_ibm_runtime = True
 
     def __init__(self, api_token, backend=None, channel="ibm_cloud", mode="job", instance=None):
         try:

--- a/tests/interface_tests/test_qiskit_backend.py
+++ b/tests/interface_tests/test_qiskit_backend.py
@@ -562,6 +562,25 @@ class TestQiskitBackendConstruction:
         backend = QiskitBackend(backend=mock_device)
         assert backend.options["shots"] == 1024
 
+    @_skip_if_no_runtime
+    def test_real_ibm_backend_rejected_with_pointer_to_runtime_backend(self):
+        """Real IBM backends cannot run via Backend.run(), so they are refused early.
+
+        Without this, passing a service.least_busy() result here fails much later
+        with an opaque IBMBackendError from inside the job.
+        """
+        from qiskit_ibm_runtime import IBMBackend
+
+        with pytest.raises(TypeError, match="QiskitRuntimeBackend"):
+            QiskitBackend(backend=MagicMock(spec=IBMBackend))
+
+    @_skip_if_no_runtime
+    def test_fake_ibm_backend_is_accepted(self):
+        """Fake IBM backends execute locally and must not be caught by the guard."""
+        from qiskit_ibm_runtime.fake_provider import FakeWashingtonV2
+
+        assert QiskitBackend(backend=FakeWashingtonV2()).run(_simple_circuit(), shots=20)
+
 
 class TestQiskitBackendIntegration:
     """End-to-end tests that use a real AerSimulator and real SamplerV2."""

--- a/tests/interface_tests/test_qiskit_backend.py
+++ b/tests/interface_tests/test_qiskit_backend.py
@@ -19,8 +19,9 @@
 
 # All tests are fully mocked, so no real IBM Quantum credentials or hardware
 # are required. The qiskit-aer package is used as the real backend device
-# (so transpile works correctly), while SamplerV2 is replaced by a mock so
-# no actual job submission takes place.
+# (so transpile works correctly), while its run() method — or, for
+# QiskitRuntimeBackend, SamplerV2 — is replaced by a mock so no actual job
+# submission takes place.
 
 import sys
 from collections.abc import Mapping
@@ -57,6 +58,7 @@ from qrisp.interface.measurement_result import LazyDict
 from qrisp.interface.provider_backends.qiskit_backend import (
     QiskitJob,
     QiskitRuntimeBackend,
+    QiskitRuntimeJob,
     _map_qiskit_status,
 )
 
@@ -64,7 +66,7 @@ from qrisp.interface.provider_backends.qiskit_backend import (
 class _MockCircuitData:
     """Minimal stand-in for a qiskit PrimitiveResult circuit-data object.
 
-    The result-parsing loop in QiskitJob.result() does:
+    The sampler branch of QiskitJob.result() does:
 
         for reg_name in qiskit_result[i].data:
             reg_data = getattr(qiskit_result[i].data, reg_name)
@@ -86,7 +88,7 @@ class _MockCircuitData:
 
 
 def _make_primitive_result(counts_per_circuit: list[dict]) -> MagicMock:
-    """Return a mock primitive-job result carrying the given per-circuit counts."""
+    """Return a mock SamplerV2 PrimitiveResult carrying the given per-circuit counts."""
     circuit_results = []
     for counts in counts_per_circuit:
         mock_cr = MagicMock()
@@ -98,12 +100,26 @@ def _make_primitive_result(counts_per_circuit: list[dict]) -> MagicMock:
     return mock_result
 
 
+def _make_backend_result(counts_per_circuit: list[dict]) -> MagicMock:
+    """Return a mock qiskit Result carrying the given per-circuit counts.
+
+    Mirrors ``Result.get_counts()``, which returns a single ``Counts`` mapping
+    for one experiment and a list of them for several.
+    """
+    mock_result = MagicMock()
+    mock_result.get_counts.return_value = (
+        counts_per_circuit[0] if len(counts_per_circuit) == 1 else list(counts_per_circuit)
+    )
+    return mock_result
+
+
 def _make_qiskit_job(
     counts_per_circuit: list[dict] | None = None,
     fail: Exception | None = None,
     job_id: str = "mock-job-id",
+    from_sampler: bool = False,
 ) -> MagicMock:
-    """Return a mock Qiskit primitive job.
+    """Return a mock Qiskit job.
 
     Parameters
     ----------
@@ -113,6 +129,10 @@ def _make_qiskit_job(
         If provided, ``result()`` raises this exception instead.
     job_id
         The value returned by ``mock_job.job_id()``.
+    from_sampler
+        If ``True``, ``result()`` returns a ``PrimitiveResult``-shaped mock
+        (as ``SamplerV2.run()`` produces); otherwise a ``Result``-shaped one
+        (as ``Backend.run()`` produces).
 
     """
     mock_job = MagicMock()
@@ -120,9 +140,9 @@ def _make_qiskit_job(
     if fail is not None:
         mock_job.result.side_effect = fail
     else:
-        mock_job.result.return_value = _make_primitive_result(
-            counts_per_circuit if counts_per_circuit is not None else [{"0": 512, "1": 512}]
-        )
+        counts = counts_per_circuit if counts_per_circuit is not None else [{"0": 512, "1": 512}]
+        make_result = _make_primitive_result if from_sampler else _make_backend_result
+        mock_job.result.return_value = make_result(counts)
     return mock_job
 
 
@@ -135,25 +155,18 @@ def _simple_circuit() -> QrispQuantumCircuit:
 
 
 @pytest.fixture()
-def sampler_mock(monkeypatch):
-    """Replace BackendSamplerV2 in the qiskit_backend module with a mock for the duration of a test."""
-    mock_sampler_cls = MagicMock(name="BackendSamplerV2")
-    monkeypatch.setattr(
-        "qrisp.interface.provider_backends.qiskit_backend.BackendSamplerV2",
-        mock_sampler_cls,
-    )
-    return mock_sampler_cls
-
-
-@pytest.fixture()
-def qiskit_backend(sampler_mock):
-    """A QiskitBackend backed by a real AerSimulator device and a mock SamplerV2.
+def qiskit_backend(monkeypatch):
+    """A QiskitBackend backed by a real AerSimulator whose run() is mocked.
 
     Using a real AerSimulator ensures that transpile() inside run_async()
-    works correctly without hitting real hardware.
+    works correctly; mocking only run() means no simulation actually takes
+    place. Yields the ``(qrisp_backend, run_mock)`` pair.
     """
-    backend = QiskitBackend(backend=AerSimulator(), options={"shots": 100})
-    return backend, sampler_mock
+    device = AerSimulator()
+    run_mock = MagicMock(return_value=_make_qiskit_job())
+    monkeypatch.setattr(device, "run", run_mock)
+    backend = QiskitBackend(backend=device, options={"shots": 100})
+    return backend, run_mock
 
 
 class TestQiskitJob:
@@ -164,9 +177,15 @@ class TestQiskitJob:
         counts_per_circuit: list[dict] | None = None,
         fail: Exception | None = None,
         num_circuits: int = 1,
+        from_sampler: bool = False,
     ) -> QiskitJob:
-        qiskit_job = _make_qiskit_job(counts_per_circuit=counts_per_circuit, fail=fail)
-        return QiskitJob(
+        qiskit_job = _make_qiskit_job(
+            counts_per_circuit=counts_per_circuit,
+            fail=fail,
+            from_sampler=from_sampler,
+        )
+        job_class = QiskitRuntimeJob if from_sampler else QiskitJob
+        return job_class(
             backend=MagicMock(),
             qiskit_job=qiskit_job,
             num_circuits=num_circuits,
@@ -200,6 +219,43 @@ class TestQiskitJob:
         assert "00" in counts
         assert "11" in counts
         assert "0 0" not in counts
+
+    def test_result_parses_batch_from_backend_result(self):
+        """A multi-circuit Result yields one counts dict per circuit, in order."""
+        job = self._make_job(
+            counts_per_circuit=[{"0": 60, "1": 40}, {"0": 20, "1": 80}],
+            num_circuits=2,
+        )
+        jr = job.result()
+        assert jr.get_counts(0) == {"0": 60, "1": 40}
+        assert jr.get_counts(1) == {"0": 20, "1": 80}
+
+    def test_result_rejects_result_without_get_counts(self):
+        """A backend whose run() returns something other than a Result fails loudly."""
+        qiskit_job = MagicMock()
+        qiskit_job.job_id.return_value = "id"
+        qiskit_job.result.return_value = object()  # no get_counts()
+        job = QiskitJob(backend=MagicMock(), qiskit_job=qiskit_job, num_circuits=1)
+        with pytest.raises(TypeError, match="get_counts"):
+            job.result()
+
+    # --- result (SamplerV2 path, used by QiskitRuntimeBackend) ---
+
+    def test_result_parses_counts_from_sampler_result(self):
+        """QiskitRuntimeJob reads counts from the PrimitiveResult DataBin."""
+        job = self._make_job(counts_per_circuit=[{"0": 600, "1": 400}], from_sampler=True)
+        assert job.result().get_counts() == {"0": 600, "1": 400}
+
+    def test_result_parses_batch_from_sampler_result(self):
+        """The sampler path also yields one counts dict per circuit, in order."""
+        job = self._make_job(
+            counts_per_circuit=[{"0": 60, "1": 40}, {"0": 20, "1": 80}],
+            num_circuits=2,
+            from_sampler=True,
+        )
+        jr = job.result()
+        assert jr.get_counts(0) == {"0": 60, "1": 40}
+        assert jr.get_counts(1) == {"0": 20, "1": 80}
 
     # --- result (failure path) ---
 
@@ -379,42 +435,54 @@ class TestMapQiskitStatus:
 
 
 class TestQiskitBackendRunAsync:
-    """Tests for QiskitBackend.run_async() using a mocked SamplerV2."""
+    """Tests for QiskitBackend.run_async() using a mocked Backend.run()."""
 
     def test_run_async_returns_qiskit_job(self, qiskit_backend):
         """run_async() returns a QiskitJob instance."""
-        backend, sampler_mock = qiskit_backend
-        sampler_mock.return_value.run.return_value = _make_qiskit_job()
+        backend, _ = qiskit_backend
 
         job = backend.run_async(_simple_circuit(), shots=100)
         assert isinstance(job, QiskitJob)
 
+    def test_run_async_submits_via_backend_run_not_a_sampler(self, qiskit_backend):
+        """Circuits go to the device's own run(), not through a primitive.
+
+        BackendSamplerV2 reconstructs counts from the result's ``memory``
+        field, which it parses as hexadecimal. Providers that write binary
+        bitstrings there (e.g. qiskit-iqm) then raise OverflowError or return
+        silently wrong counts, so submission must not go through a sampler.
+        """
+        backend, run_mock = qiskit_backend
+
+        job = backend.run_async(_simple_circuit(), shots=100)
+
+        run_mock.assert_called_once()
+        assert type(job) is QiskitJob  # not the SamplerV2-parsing subclass
+        assert not hasattr(backend, "sampler")
+
     def test_run_async_job_starts_queued(self, qiskit_backend):
         """The returned job's last_known_status is QUEUED after run_async()."""
-        backend, sampler_mock = qiskit_backend
-        sampler_mock.return_value.run.return_value = _make_qiskit_job()
+        backend, _ = qiskit_backend
 
         job = backend.run_async(_simple_circuit(), shots=100)
         assert job.last_known_status == JobStatus.QUEUED
 
-    def test_shots_forwarded_to_sampler(self, qiskit_backend):
-        """The shot count passed to run_async() is forwarded to sampler.run()."""
-        backend, sampler_mock = qiskit_backend
-        sampler_mock.return_value.run.return_value = _make_qiskit_job()
+    def test_shots_forwarded_to_backend(self, qiskit_backend):
+        """The shot count passed to run_async() is forwarded to backend.run()."""
+        backend, run_mock = qiskit_backend
 
         backend.run_async(_simple_circuit(), shots=42)
 
-        _, run_kwargs = sampler_mock.return_value.run.call_args
+        _, run_kwargs = run_mock.call_args
         assert run_kwargs["shots"] == 42
 
     def test_default_shots_used_when_none(self, qiskit_backend):
         """When shots=None, the backend's default shot count is used."""
-        backend, sampler_mock = qiskit_backend
-        sampler_mock.return_value.run.return_value = _make_qiskit_job()
+        backend, run_mock = qiskit_backend
 
         backend.run_async(_simple_circuit())
 
-        _, run_kwargs = sampler_mock.return_value.run.call_args
+        _, run_kwargs = run_mock.call_args
         assert run_kwargs["shots"] == 100  # from options={"shots": 100} in fixture
 
     def test_invalid_shots_type_raises_type_error(self, qiskit_backend):
@@ -437,48 +505,48 @@ class TestQiskitBackendRunAsync:
 
     def test_batch_of_circuits_returns_single_job(self, qiskit_backend):
         """Multiple circuits are batched into a single QiskitJob."""
-        backend, sampler_mock = qiskit_backend
-        sampler_mock.return_value.run.return_value = _make_qiskit_job(
-            counts_per_circuit=[{"0": 60, "1": 40}, {"0": 50, "1": 50}]
-        )
+        backend, run_mock = qiskit_backend
+        run_mock.return_value = _make_qiskit_job(counts_per_circuit=[{"0": 60, "1": 40}, {"0": 50, "1": 50}])
 
         job = backend.run_async([_simple_circuit(), _simple_circuit()], shots=100)
         assert isinstance(job, QiskitJob)
-        sampler_mock.return_value.run.assert_called_once()
+        run_mock.assert_called_once()
 
     def test_run_async_shots_list_warns_and_uses_max(self, qiskit_backend):
         """run_async with a list of shots must warn and run all circuits at max(shots)."""
-        backend, sampler_mock = qiskit_backend
-        sampler_mock.return_value.run.return_value = _make_qiskit_job([{"0": 300}, {"0": 300}])
+        backend, run_mock = qiskit_backend
+        run_mock.return_value = _make_qiskit_job([{"0": 300}, {"0": 300}])
 
         with pytest.warns(UserWarning, match="per-circuit shot counts"):
             backend.run_async([_simple_circuit(), _simple_circuit()], shots=[100, 300])
 
-        _, run_kwargs = sampler_mock.return_value.run.call_args
+        _, run_kwargs = run_mock.call_args
         assert run_kwargs["shots"] == 300  # max([100, 300])
 
-    def test_run_async_default_shots_fallback_is_1024(self, sampler_mock):
+    def test_run_async_default_shots_fallback_is_1024(self, monkeypatch):
         """When 'shots' is absent from _options, run_async() falls back to 1024 not 1000."""
         # Use a real AerSimulator device so transpile() works, but pass options
         # without a 'shots' key to exercise the fallback path in run_async().
-        backend = QiskitBackend(backend=AerSimulator(), options={"custom_key": "val"})
-        sampler_mock.return_value.run.return_value = _make_qiskit_job()
+        device = AerSimulator()
+        run_mock = MagicMock(return_value=_make_qiskit_job())
+        monkeypatch.setattr(device, "run", run_mock)
+        backend = QiskitBackend(backend=device, options={"custom_key": "val"})
 
         backend.run_async(_simple_circuit())
 
-        _, run_kwargs = sampler_mock.return_value.run.call_args
+        _, run_kwargs = run_mock.call_args
         assert run_kwargs["shots"] == 1024
 
 
 class TestQiskitBackendConstruction:
     """Tests for QiskitBackend constructor branches not covered by the run_async fixture."""
 
-    def test_default_backend_is_aer_simulator(self, sampler_mock):
+    def test_default_backend_is_aer_simulator(self):
         """When no backend is provided, AerSimulator is used as the default."""
         backend = QiskitBackend(options={"shots": 100})
         assert "aer" in backend.name.lower()
 
-    def test_options_read_from_backend_when_not_provided(self, sampler_mock):
+    def test_options_read_from_backend_when_not_provided(self):
         """When options is omitted and backend exposes a dict, those options are used."""
         mock_device = MagicMock()
         mock_device.name = "mock_device"
@@ -486,7 +554,7 @@ class TestQiskitBackendConstruction:
         backend = QiskitBackend(backend=mock_device)
         assert backend.options["shots"] == 200
 
-    def test_default_options_used_when_backend_has_no_options(self, sampler_mock):
+    def test_default_options_used_when_backend_has_no_options(self):
         """When options is omitted and backend.options is None, _default_options() is used."""
         mock_device = MagicMock()
         mock_device.name = "mock_device"
@@ -614,6 +682,101 @@ class TestQiskitBackendIntegration:
         assert not res._populated
         bb.dispatch()
         assert res == {3: 1.0}
+
+
+class TestQiskitBackendNonHexMemory:
+    """Regression tests for providers that do not write hexadecimal ``memory``.
+
+    Qiskit documents the level-2 ``memory`` field as a list of hex strings, and
+    ``BackendSamplerV2`` relies on that when it rebuilds counts (``int(entry, 16)``).
+    ``qiskit-iqm`` instead writes plain binary bitstrings, so routing Qrisp
+    submissions through a sampler raised ``OverflowError: int too big to convert``
+    for most outcomes, and silently produced wrong counts for the rest.
+    Reading ``Result.get_counts()`` directly is immune to this.
+    """
+
+    @staticmethod
+    def _iqm_style_backend(memory: list[str]):
+        """A Qiskit backend that reports results the way qiskit-iqm's IQMJob does."""
+        from collections import Counter
+        from datetime import date
+
+        from qiskit.providers import JobStatus as QiskitJobStatus
+        from qiskit.providers import JobV1
+        from qiskit.providers.fake_provider import GenericBackendV2
+        from qiskit.result import Counts, Result
+
+        class _IQMStyleJob(JobV1):
+            def submit(self):
+                pass
+
+            def status(self):
+                return QiskitJobStatus.DONE
+
+            def result(self, **kwargs):
+                # Mirrors iqm/qiskit_iqm/iqm_job.py::IQMJob.result(): binary
+                # bitstrings in `memory`, binary keys in `counts`, and a header
+                # that carries no creg_sizes/memory_slots.
+                return Result.from_dict(
+                    {
+                        "backend_name": self.backend().name,
+                        "backend_version": "",
+                        "qobj_id": "",
+                        "job_id": self.job_id(),
+                        "success": True,
+                        "date": date.today().isoformat(),
+                        "results": [
+                            {
+                                "shots": len(memory),
+                                "success": True,
+                                "data": {
+                                    "memory": memory,
+                                    "counts": Counts(Counter(memory)),
+                                    "metadata": {},
+                                },
+                                "header": {"name": "circuit_0"},
+                            }
+                        ],
+                    }
+                )
+
+        class _IQMStyleBackend(GenericBackendV2):
+            def __init__(self):
+                super().__init__(num_qubits=5, basis_gates=["cz", "r", "id"], seed=42)
+
+            def run(self, run_input, **options):
+                return _IQMStyleJob(self, job_id="iqm-style-job")
+
+        return _IQMStyleBackend()
+
+    @staticmethod
+    def _ghz(n: int) -> QrispQuantumCircuit:
+        qc = QrispQuantumCircuit(n)
+        qc.h(0)
+        for target in range(1, n):
+            qc.cx(0, target)
+        qc.measure(qc.qubits)
+        return qc
+
+    def test_binary_memory_does_not_overflow(self):
+        """A 4-bit all-ones outcome no longer raises OverflowError.
+
+        int("1111", 16) == 4369, which does not fit the single byte Qiskit
+        allocates for a 4-bit classical register.
+        """
+        memory = ["0000"] * 50 + ["1111"] * 50
+        backend = QiskitBackend(backend=self._iqm_style_backend(memory))
+        assert backend.run(self._ghz(4), shots=100) == {"0000": 50, "1111": 50}
+
+    def test_binary_memory_is_not_silently_misread(self):
+        """Outcomes small enough to avoid the overflow are still decoded correctly.
+
+        int("11", 16) == 17 fits in one byte, so the old sampler path returned
+        counts of {"00": 50, "01": 50} for a Bell state without raising at all.
+        """
+        memory = ["00"] * 50 + ["11"] * 50
+        backend = QiskitBackend(backend=self._iqm_style_backend(memory))
+        assert backend.run(self._ghz(2), shots=100) == {"00": 50, "11": 50}
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Description

`QiskitBackend` submitted circuits through Qiskit's `BackendSamplerV2` primitive, which rebuilds
counts from the result's `memory` field and parses each entry as a **hexadecimal** string. Providers
that write plain **binary** bitstrings there — `qiskit-iqm` among them — either crashed the job or
returned silently wrong counts. Submission now goes through the wrapped backend's own `run()` and
reads counts from `Result.get_counts()`, which is unambiguous. `QiskitRuntimeBackend` keeps
`SamplerV2`, because IBM Runtime offers no other route.

## Related Issues

<!-- No existing issue found for this failure. Fill in if one is opened before merge. -->
Closes #
Related to #

## Type of Change

- [ ] Feature (new functionality)
- [ ] Change Request (modification of existing functionality)
- [x] Bug Fix
- [x] Refactoring (no behavior change)
- [ ] Performance improvement
- [x] Documentation
- [ ] CI / Build

<!-- Internals only: no public API surface changes. See "Breaking Change?" below. -->


## Breaking Change?
- [ ] Yes
- [x] No

No public API changes. `Backend`, `run()`, `run_async()`, `Job`, and the measurement result types are
untouched, and counts returned for conformant backends (Aer, fake backends, IBM Runtime) are
unchanged.

`QiskitBackend.sampler` was removed, but it was never public: `QiskitBackend.rst` uses a bare
`.. autoclass::` with no `:members:`, and `conf.py` sets `autodoc_default_options` to
`members: False` / `undoc-members: False` with `numpydoc_show_class_members = False`. Only the class
docstring and `run_async` were ever rendered, and neither documented the attribute — confirmed
against the built HTML. `QiskitRuntimeBackend.sampler` is unaffected and still holds the IBM Runtime
`SamplerV2`.

## What was changed?

- `QiskitBackend` now submits via `self.backend.run(circuits, shots=...)` instead of
  `BackendSamplerV2.run(...)`, and reads counts from `Result.get_counts()`. Qrisp never consumed
  per-shot `memory`, so nothing is lost by not reconstructing it.
- Added two paired extension points: `QiskitBackend._submit()` (how circuits are handed to the
  provider) and `QiskitBackend._job_class` (which `QiskitJob` subclass parses the result).
- Split result parsing by result *type* rather than by flag: `QiskitJob._extract_counts()` reads a
  `Result`; the new `QiskitRuntimeJob` subclass overrides it to read a `PrimitiveResult` `DataBin`
  (the previous logic, relocated unchanged).
- `QiskitRuntimeBackend` pairs `_submit()` → `self.sampler.run(...)` with
  `_job_class = QiskitRuntimeJob`. It must keep the primitive: `IBMBackend.run()` still exists in
  `qiskit-ibm-runtime` 0.47 but raises `IBMBackendError: Support for backend.run() has been removed`.
- Extracted the shared register-separator stripping into `_merge_counts()`.
- A backend whose `run()` returns something without `get_counts()` now raises a `TypeError` naming
  `_extract_counts()`, rather than an opaque `AttributeError` deep in the parsing loop.
- Removed the now-unused `BackendSamplerV2` / `BackendV2` imports and the `QiskitBackend.sampler`
  attribute.
- Docs: updated the `QiskitBackend` class docstring (with a note explaining *why* the primitive is
  avoided, so it does not get reinstated) and the narrative section in
  `documentation/source/reference/Backend Interface/index.rst`.

## How was it tested?

| Test | Status |
|------|--------|
| `TestQiskitBackendNonHexMemory::test_binary_memory_does_not_overflow` | ✅ |
| `TestQiskitBackendNonHexMemory::test_binary_memory_is_not_silently_misread` | ✅ |
| `TestQiskitBackendRunAsync::test_run_async_submits_via_backend_run_not_a_sampler` | ✅ |
| `TestQiskitJob::test_result_parses_batch_from_backend_result` | ✅ |
| `TestQiskitJob::test_result_rejects_result_without_get_counts` | ✅ |
| `TestQiskitJob::test_result_parses_counts_from_sampler_result` | ✅ |
| `TestQiskitJob::test_result_parses_batch_from_sampler_result` | ✅ |

The two `TestQiskitBackendNonHexMemory` tests drive a stub Qiskit backend that reports results in
`qiskit-iqm`'s exact shape — binary `memory`, binary `Counts` keys, and a header carrying no
`creg_sizes`/`memory_slots`. No hardware or network access is required.

Both were confirmed to fail when `QiskitBackend` is forced back onto `BackendSamplerV2`, so they are
load-bearing rather than tautological:

```
4q GHZ   via SamplerV2 -> JobFailureError: ... int too big to convert   [RAISES]
2q Bell  via SamplerV2 -> {'00': 50, '01': 50}                          [WRONG COUNTS]
```

Existing coverage was reworked, not reduced: the fixture that mocked `BackendSamplerV2` now mocks
`run()` on a real `AerSimulator`, so `transpile()` still runs against a real target. Test count went
82 → 89 with none removed.

Full suite: **776 passed, 1 skipped** (`tests/interface_tests/` + `tests/algorithms_tests/cd_tests/test_cold.py`).
The skip is `qiskit-ibm-runtime`-gated and pre-existing.

## Screenshots / Output (if applicable)

The original failure, on a 4-qubit GHZ circuit submitted to IQM Sirius:

```
File .../qiskit/primitives/backend_sampler_v2.py:313, in _memory_array
--> 313  data = b"".join(int(i, 16).to_bytes(num_bytes, "big") for i in memory)
OverflowError: int too big to convert

JobFailureError: Qiskit job '1ec7fa55-...' failed: int too big to convert
```

The mechanism: `IQMJob.result()` writes `'1111'` into `memory`; Qiskit allocates one byte for a
4-bit classical register; `int('1111', 16) == 4369` does not fit.

The quieter half of the same bug — a Bell state, no exception raised at all:

```
true distribution : {'00': 50, '11': 50}
via QiskitBackend : {'00': 50, '01': 50}      # int('11', 16) == 17, fits in one byte
```

## Checklist
- [x] My code follows the project's coding standards
- [x] I have performed a self-review
- [x] I have added/updated tests (referencing issue Test-IDs)
- [x] All tests pass locally and in CI
- [x] I have updated the documentation
- [x] I have added a changelog entry
- [x] Breaking changes are documented with migration path — *n/a, no breaking changes*