### PR TITLE
Remove duplicate imports in __init__.py

### DIFF
--- a/documentation/source/general/changelog/changelog-dev.rst
+++ b/documentation/source/general/changelog/changelog-dev.rst
@@ -69,6 +69,9 @@ Bug Fixes
   :func:`control <qrisp.control>` environment in Jasp mode
   (`PR #769 <https://github.com/eclipse-qrisp/Qrisp/pull/769>`_).
 
+* Removed reduant imports in the top-level ``qrisp`` package.
+  (`PR #796 <https://github.com/eclipse-qrisp/Qrisp/pull/796>`_).
+
 Compatibility
 -------------
 
@@ -141,3 +144,4 @@ First Time Contributors 🎉
 * `alighazi288 <https://github.com/alighazi288>`_
 * `NedislavKolev <https://github.com/NedislavKolev>`_
 * `Shanwis <https://github.com/Shanwis>`_
+* `micpap25 <https://github.com/micpap25>`_

--- a/src/qrisp/__init__.py
+++ b/src/qrisp/__init__.py
@@ -29,9 +29,7 @@ from qrisp._cache_config import QRISP_COMPILATION_CACHE_SIZE
 from qrisp.circuit import *
 from qrisp.core import *
 from qrisp.misc import *
-from qrisp.circuit import *
 from qrisp.permeability import *
-from qrisp.core import *
 from qrisp.qtypes import *
 from qrisp.environments import *
 from qrisp.alg_primitives import *


### PR DESCRIPTION
## Description

<!-- What does this PR do? Keep it concise. -->

Removed duplicate import statements for `qrisp` modules.

## Type of Change

<!-- Check all that apply -->
- [ ] Feature (new functionality)
- [ ] Change Request (modification of existing functionality)
- [ ] Bug Fix
- [x] Refactoring (no behavior change)
- [ ] Performance improvement
- [ ] Documentation
- [ ] CI / Build

## Breaking Change?
- [ ] Yes
- [x] No

If yes, describe the impact and migration path:


## What was changed?

<!-- Bullet list of concrete changes -->
- Removed two redundant imports in `qrisp`.

## Screenshots / Output (if applicable)

<!-- Add additional information if it helps -->

## Checklist
- [ ] My code follows the project's coding standards
- [x] I have performed a self-review
- [ ] I have added/updated tests (referencing issue Test-IDs)
- [ ] All tests pass locally and in CI
- [ ] I have updated the documentation
- [ ] I have added a changelog entry to `changelog-dev.rst`
- [ ] Breaking changes are documented with migration path