### PR TITLE
Bosonic operator

### DIFF
--- a/documentation/source/general/changelog/changelog-dev.rst
+++ b/documentation/source/general/changelog/changelog-dev.rst
@@ -45,6 +45,8 @@ API Changes
 Development
 -----------
 
+* Added a BosonicOperator class analogous to the FermionicOperator one
+
 * Added Dependabot configuration for automated dependency updates
   (grouped by type, with labels applied automatically).
 
@@ -65,6 +67,7 @@ Development
 First Time Contributors 🎉
 --------------------------
 
+* `philipp-heinen <https://github.com/philipp-heinen>`_
 * `alighazi288 <https://github.com/alighazi288>`_
 * `NedislavKolev <https://github.com/NedislavKolev>`_
 * `Shanwis <https://github.com/Shanwis>`_

--- a/documentation/source/reference/Operators/BosonicOperator.rst
+++ b/documentation/source/reference/Operators/BosonicOperator.rst
@@ -1,0 +1,22 @@
+.. _BosonicOperator:
+
+BosonicOperator
+====================
+
+.. currentmodule:: qrisp.operators.bosonic
+.. autoclass:: BosonicOperator
+
+Methods
+=======
+
+.. autosummary::
+   :toctree: generated/
+   
+   BosonicOperator.coeffs
+   BosonicOperator.dagger
+   BosonicOperator.expectation_value
+   BosonicOperator.ground_state_energy
+   BosonicOperator.hermitize
+   BosonicOperator.reduce
+   BosonicOperator.to_qubit_operator
+   BosonicOperator.trotterization

--- a/documentation/source/reference/Operators/generated/qrisp.operators.bosonic.BosonicOperator.coeffs.rst
+++ b/documentation/source/reference/Operators/generated/qrisp.operators.bosonic.BosonicOperator.coeffs.rst
@@ -1,0 +1,6 @@
+﻿qrisp.operators.bosonic.BosonicOperator.coeffs
+==============================================
+
+.. currentmodule:: qrisp.operators.bosonic
+
+.. automethod:: BosonicOperator.coeffs

--- a/documentation/source/reference/Operators/generated/qrisp.operators.bosonic.BosonicOperator.dagger.rst
+++ b/documentation/source/reference/Operators/generated/qrisp.operators.bosonic.BosonicOperator.dagger.rst
@@ -1,0 +1,6 @@
+﻿qrisp.operators.bosonic.BosonicOperator.dagger
+==============================================
+
+.. currentmodule:: qrisp.operators.bosonic
+
+.. automethod:: BosonicOperator.dagger

--- a/documentation/source/reference/Operators/generated/qrisp.operators.bosonic.BosonicOperator.expectation_value.rst
+++ b/documentation/source/reference/Operators/generated/qrisp.operators.bosonic.BosonicOperator.expectation_value.rst
@@ -1,0 +1,6 @@
+﻿qrisp.operators.bosonic.BosonicOperator.expectation\_value
+==========================================================
+
+.. currentmodule:: qrisp.operators.bosonic
+
+.. automethod:: BosonicOperator.expectation_value

--- a/documentation/source/reference/Operators/generated/qrisp.operators.bosonic.BosonicOperator.ground_state_energy.rst
+++ b/documentation/source/reference/Operators/generated/qrisp.operators.bosonic.BosonicOperator.ground_state_energy.rst
@@ -1,0 +1,6 @@
+﻿qrisp.operators.bosonic.BosonicOperator.ground\_state\_energy
+=============================================================
+
+.. currentmodule:: qrisp.operators.bosonic
+
+.. automethod:: BosonicOperator.ground_state_energy

--- a/documentation/source/reference/Operators/generated/qrisp.operators.bosonic.BosonicOperator.hermitize.rst
+++ b/documentation/source/reference/Operators/generated/qrisp.operators.bosonic.BosonicOperator.hermitize.rst
@@ -1,0 +1,6 @@
+﻿qrisp.operators.bosonic.BosonicOperator.hermitize
+=================================================
+
+.. currentmodule:: qrisp.operators.bosonic
+
+.. automethod:: BosonicOperator.hermitize

--- a/documentation/source/reference/Operators/generated/qrisp.operators.bosonic.BosonicOperator.reduce.rst
+++ b/documentation/source/reference/Operators/generated/qrisp.operators.bosonic.BosonicOperator.reduce.rst
@@ -1,0 +1,6 @@
+﻿qrisp.operators.bosonic.BosonicOperator.reduce
+==============================================
+
+.. currentmodule:: qrisp.operators.bosonic
+
+.. automethod:: BosonicOperator.reduce

--- a/documentation/source/reference/Operators/generated/qrisp.operators.bosonic.BosonicOperator.to_qubit_operator.rst
+++ b/documentation/source/reference/Operators/generated/qrisp.operators.bosonic.BosonicOperator.to_qubit_operator.rst
@@ -1,0 +1,6 @@
+﻿qrisp.operators.bosonic.BosonicOperator.to\_qubit\_operator
+===========================================================
+
+.. currentmodule:: qrisp.operators.bosonic
+
+.. automethod:: BosonicOperator.to_qubit_operator

--- a/documentation/source/reference/Operators/generated/qrisp.operators.bosonic.BosonicOperator.trotterization.rst
+++ b/documentation/source/reference/Operators/generated/qrisp.operators.bosonic.BosonicOperator.trotterization.rst
@@ -1,0 +1,6 @@
+﻿qrisp.operators.bosonic.BosonicOperator.trotterization
+======================================================
+
+.. currentmodule:: qrisp.operators.bosonic
+
+.. automethod:: BosonicOperator.trotterization

--- a/documentation/source/reference/Operators/index.rst
+++ b/documentation/source/reference/Operators/index.rst
@@ -5,7 +5,7 @@ Operators
 
 This Operators submodule of Qrisp provides a unified framework to describe, optimize and simulate quantum Hamiltonians.
 It provides a collection of different types of Operators that can be used to model and solve a variety of problems in physics, chemistry, or optimization.
-(Up to now, :ref:`QubitOperators <QubitOperator>` and :ref:`FermionicOperators <FermionicOperator>` have been implemented, but stay tuned for future updates!)
+(Up to now, :ref:`QubitOperators <QubitOperator>`, :ref:`FermionicOperators <FermionicOperator>` and :ref:`BosonicOperators <BosonicOperator>` have been implemented, but stay tuned for future updates!)
 Each type of Operator comes with comprehensive documentation and brief examples to help you understand its implementation and usage:
 
 .. list-table::
@@ -18,6 +18,8 @@ Each type of Operator comes with comprehensive documentation and brief examples 
      - describe Hamiltonians in terms of Qubit operators
    * - :ref:`FermionicOperator <FermionicOperator>`
      - describe Hamiltonians in terms of fermionic ladder operators
+   * - :ref:`BosonicOperator <BosonicOperator>`
+     - describe Hamiltonians in terms of bosonic ladder operators
 
 We encourage you to explore these Operators, delve into their documentation, and experiment with their implementations.
 
@@ -28,6 +30,7 @@ We encourage you to explore these Operators, delve into their documentation, and
    
    QubitOperator
    FermionicOperator
+   BosonicOperator
 
 
 Examples

--- a/src/qrisp/operators/__init__.py
+++ b/src/qrisp/operators/__init__.py
@@ -20,3 +20,4 @@ from qrisp.operators.hamiltonian import *
 from qrisp.operators.hamiltonian_tools import *
 from qrisp.operators.qubit import *
 from qrisp.operators.fermionic import *
+from qrisp.operators.bosonic import *

--- a/src/qrisp/operators/bosonic/__init__.py
+++ b/src/qrisp/operators/bosonic/__init__.py
@@ -1,0 +1,21 @@
+"""
+********************************************************************************
+* Copyright (c) 2024 the Qrisp authors
+*
+* This program and the accompanying materials are made available under the
+* terms of the Eclipse Public License 2.0 which is available at
+* http://www.eclipse.org/legal/epl-2.0.
+*
+* This Source Code may also be made available under the following Secondary
+* Licenses when the conditions for such availability set forth in the Eclipse
+* Public License, v. 2.0 are satisfied: GNU General Public License, version 2
+* with the GNU Classpath Exception which is
+* available at https://www.gnu.org/software/classpath/license.html.
+*
+* SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+********************************************************************************
+"""
+
+# -*- coding: utf-8 -*-
+from qrisp.operators.bosonic.bosonic_operator import *
+from qrisp.operators.bosonic.bosonic import *

--- a/src/qrisp/operators/bosonic/bosonic.py
+++ b/src/qrisp/operators/bosonic/bosonic.py
@@ -19,14 +19,14 @@ from qrisp.operators.bosonic.bosonic_operator import BosonicOperator
 from qrisp.operators.bosonic.bosonic_term import BosonicTerm
 
 
-def a_b(arg):
+def a_b(arg: int):
     if isinstance(arg, int):
         return BosonicOperator({BosonicTerm([(arg, False)]): 1})
     else:
         raise Exception("Cannot initialize operator from type " + str(type(arg)))
 
 
-def c_b(arg):
+def c_b(arg: int):
     if isinstance(arg, int):
         return BosonicOperator({BosonicTerm([(arg, True)]): 1})
     else:

--- a/src/qrisp/operators/bosonic/bosonic.py
+++ b/src/qrisp/operators/bosonic/bosonic.py
@@ -19,14 +19,14 @@ from qrisp.operators.bosonic.bosonic_operator import BosonicOperator
 from qrisp.operators.bosonic.bosonic_term import BosonicTerm
 
 
-def a(arg):
+def a_b(arg):
     if isinstance(arg, int):
         return BosonicOperator({BosonicTerm([(arg, False)]): 1})
     else:
         raise Exception("Cannot initialize operator from type " + str(type(arg)))
 
 
-def c(arg):
+def c_b(arg):
     if isinstance(arg, int):
         return BosonicOperator({BosonicTerm([(arg, True)]): 1})
     else:

--- a/src/qrisp/operators/bosonic/bosonic.py
+++ b/src/qrisp/operators/bosonic/bosonic.py
@@ -1,0 +1,33 @@
+"""********************************************************************************
+* Copyright (c) 2024 the Qrisp authors
+*
+* This program and the accompanying materials are made available under the
+* terms of the Eclipse Public License 2.0 which is available at
+* http://www.eclipse.org/legal/epl-2.0.
+*
+* This Source Code may also be made available under the following Secondary
+* Licenses when the conditions for such availability set forth in the Eclipse
+* Public License, v. 2.0 are satisfied: GNU General Public License, version 2
+* with the GNU Classpath Exception which is
+* available at https://www.gnu.org/software/classpath/license.html.
+*
+* SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+********************************************************************************
+"""
+
+from qrisp.operators.bosonic.bosonic_operator import BosonicOperator
+from qrisp.operators.bosonic.bosonic_term import BosonicTerm
+
+
+def a(arg):
+    if isinstance(arg, int):
+        return BosonicOperator({BosonicTerm([(arg, False)]): 1})
+    else:
+        raise Exception("Cannot initialize operator from type " + str(type(arg)))
+
+
+def c(arg):
+    if isinstance(arg, int):
+        return BosonicOperator({BosonicTerm([(arg, True)]): 1})
+    else:
+        raise Exception("Cannot initialize operator from type " + str(type(arg)))

--- a/src/qrisp/operators/bosonic/bosonic.py
+++ b/src/qrisp/operators/bosonic/bosonic.py
@@ -1,4 +1,5 @@
 """********************************************************************************
+
 * Copyright (c) 2024 the Qrisp authors
 *
 * This program and the accompanying materials are made available under the
@@ -13,6 +14,7 @@
 *
 * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
 ********************************************************************************
+
 """
 
 from qrisp.operators.bosonic.bosonic_operator import BosonicOperator
@@ -20,6 +22,19 @@ from qrisp.operators.bosonic.bosonic_term import BosonicTerm
 
 
 def a_b(arg: int):
+    """Return BosonicOperator containing a single annihilation operator.
+
+    Parameters
+    ----------
+    arg : int
+        The index of the annihilation operator.
+
+    Returns
+    -------
+    BosonicOperator
+        The single annihilation operator.
+
+    """
     if isinstance(arg, int):
         return BosonicOperator({BosonicTerm([(arg, False)]): 1})
     else:
@@ -27,6 +42,19 @@ def a_b(arg: int):
 
 
 def c_b(arg: int):
+    """BosonicOperator containing a single creation operator.
+
+    Parameters
+    ----------
+    arg : int
+        The index of the creation operator.
+
+    Returns
+    -------
+    BosonicOperator
+        The single creation operator.
+
+    """
     if isinstance(arg, int):
         return BosonicOperator({BosonicTerm([(arg, True)]): 1})
     else:

--- a/src/qrisp/operators/bosonic/bosonic_operator.py
+++ b/src/qrisp/operators/bosonic/bosonic_operator.py
@@ -31,7 +31,7 @@ threshold = 1e-9
 
 
 class BosonicOperator(Hamiltonian):
-    r"""This class provides an efficient implementation of ladder term operators, i.e.,
+    r"""This class provides an efficient implementation of bosonic ladder term operators, i.e.,
     operators of the form
 
     .. math::
@@ -49,13 +49,13 @@ class BosonicOperator(Hamiltonian):
 
     Examples
     --------
-    A ladder term operator can be specified conveniently in terms of ``a`` (lowering, i.e., annihilation), ``c`` (raising, i.e., creation) operators:
+    A ladder term operator can be specified conveniently in terms of ``a_b`` (lowering, i.e., annihilation), ``c_b`` (raising, i.e., creation) operators:
 
     ::
         
-        from qrisp.operators.bosonic import a, c
+        from qrisp.operators.bosonic import a_b, c_b
 
-        O = a(2)*c(1)+a(3)*c(2)
+        O = a_b(2)*c_b(1)+a_b(3)*c_b(2)
         O
 
     Yields $a_2c_1+a_3c_2$.
@@ -95,7 +95,7 @@ class BosonicOperator(Hamiltonian):
 
             from qrisp.operators.bosonic import *
 
-            O = a(0)*a(1) - a(1)*a(0)
+            O = a_b(0)*a_b(1) - a_b(1)*a_b(0)
             print(O.reduce())
             # Yields: 2*a0*a1
 
@@ -103,7 +103,7 @@ class BosonicOperator(Hamiltonian):
         that has redundant terms, if hermitized.
 
 
-        >>> O = a(0)*a(1) + c(1)*c(0)
+        >>> O = a_b(0)*a_b(1) + c_b(1)*c_b(0)
         >>> reduced_O = O.reduce(assume_hermitian = True)
         >>> print(reduced_O)
         2*a0*a1
@@ -114,35 +114,12 @@ class BosonicOperator(Hamiltonian):
         1.0*a0*a1 + 1.0*c1*c0
 
         """
-        # This function performs some non trivial logic.
-
-        # The problem here is that each bosonic term can
-        # be reshaped into several different forms and still express
-        # the same operator.
-        # For instance, the operator can be arbitrarily reordered
-        # if the permutation sign is take care of and no creators/annihilators
-        # with the same index are swapped.
-        # Furthermore the Hamiltonian must be Hermitian, so each
-        # term must be equivalent to is Hermitian conjugate.
-
-        # This function implements a storage system, that combines
-        # the coefficients of differing terms representing the same operator
-        # into a single term.
-
-        # This dictionary will contain the new terms, where redundancies
-        # are taken care of.
+        # code is adapted from the FermionicOperator class
         new_terms_dict = {}
 
         for term, coeff in self.terms_dict.items():
-            # We only store the sorted version of each term.
-            # Sorting here means permuting the creators/annihilators
-            # while considering the sign of the permutation applied by the sort.
-            # The sort is performed in a stable manner, so terms like a(0)*c(0)
-            # don't get permuted (this would be a non-trivial anti-commutator).
             sorted_term = term.sort()
             if sorted_term not in new_terms_dict and assume_hermitian:
-                # If the sorted term is not in the terms dict, the sorted version
-                # of the daggering might be.
                 daggered_sorted_term = term.dagger().sort()
                 if daggered_sorted_term in new_terms_dict:
                     sorted_term = daggered_sorted_term
@@ -170,8 +147,8 @@ class BosonicOperator(Hamiltonian):
 
         Examples
         --------
-        >>> from qrisp.operators import a, c
-        >>> O = a(0)*c(1)+a(1)*c(0)+0.5*a(1)+0.5*c(1)
+        >>> from qrisp.operators import a_b, c_b
+        >>> O = a_b(0)*c_b(1)+a_b(1)*c_b(0)+0.5*a_b(1)+0.5*c_b(1)
         >>> O.coeffs()
         array([1. , 1. , 0.5, 0.5])
 
@@ -226,7 +203,7 @@ class BosonicOperator(Hamiltonian):
 
             from qrisp.operators import *
 
-            O = a(0)*c(1)*a(2) + a(3)
+            O = a_b(0)*c_b(1)*a_b(2) + a_b(3)
             print(O.dagger())
             # Yields: c2*a1*c0 + c3
 
@@ -252,7 +229,7 @@ class BosonicOperator(Hamiltonian):
 
             from qrisp.operators import *
 
-            O = a(0)*c(1)*a(2) + a(3)
+            O = a_b(0)*c_b(1)*a_b(2) + a_b(3)
             print(O.hermitize())
             # Yields: 0.5*a0*c1*a2 + 0.5*a3 + 0.5*c2*a1*c0 + 0.5*c3
 
@@ -516,7 +493,7 @@ class BosonicOperator(Hamiltonian):
             A sparse matrix representing the operator.
         truncation: How many bosonic occupation numbers to take into account.
         binary_encoding : string, optional
-            How to embed the bosonic terms into a QubitOperator.
+            How to embed the bosonic terms into a QubitOperator. Possible values are "gray_code", "standard_binary" and "one_hot".
 
         """
         return self.to_qubit_operator(truncation=truncation, binary_encoding=binary_encoding).to_sparse_matrix()
@@ -540,7 +517,7 @@ class BosonicOperator(Hamiltonian):
         truncation : int, optional
             How many bosonic occupation numbers to take into account
         binary_encoding : str, optional
-            The way of embedding the bosonic operator into qubits
+            How to embed the bosonic terms into a QubitOperator. Possible values are "gray_code", "standard_binary" and "one_hot".
 
         Returns
         -------
@@ -575,7 +552,7 @@ class BosonicOperator(Hamiltonian):
             This is because a quantum value would need to be copied for each sampling iteration, which is prohibited by the no-cloning theorem.
         truncation: How many bosonic occupation numbers to take into account.
         binary_encoding : string, optional
-            How to embed the bosonic terms into a QubitOperator.
+            How to embed the bosonic terms into a QubitOperator. Possible values are "gray_code", "standard_binary" and "one_hot".
         measurement_kwargs : dict, optional
             The keyword arguments of :meth:`QubitOperator.expectation_value <qrisp.operators.qubit.QubitOperator.expectation_value>`.
 
@@ -593,9 +570,7 @@ class BosonicOperator(Hamiltonian):
     #
 
     def trotterization(self, truncation=8, binary_encoding="gray_code", forward_evolution=True):
-        r"""Returns a function for performing Hamiltonian simulation, i.e., approximately implementing the unitary operator $U(t) = e^{-itH}$ via Trotterization.
-
-        """
+        r"""Returns a function for performing Hamiltonian simulation, i.e., approximately implementing the unitary operator $U(t) = e^{-itH}$ via Trotterization."""
         qubit_operator = self.to_qubit_operator(truncation=truncation, binary_encoding=binary_encoding)
         return qubit_operator.trotterization(forward_evolution=forward_evolution)
 

--- a/src/qrisp/operators/bosonic/bosonic_operator.py
+++ b/src/qrisp/operators/bosonic/bosonic_operator.py
@@ -1,0 +1,611 @@
+"""********************************************************************************
+* Copyright (c) 2024 the Qrisp authors
+*
+* This program and the accompanying materials are made available under the
+* terms of the Eclipse Public License 2.0 which is available at
+* http://www.eclipse.org/legal/epl-2.0.
+*
+* This Source Code may also be made available under the following Secondary
+* Licenses when the conditions for such availability set forth in the Eclipse
+* Public License, v. 2.0 are satisfied: GNU General Public License, version 2
+* with the GNU Classpath Exception which is
+* available at https://www.gnu.org/software/classpath/license.html.
+*
+* SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+********************************************************************************
+"""
+
+import numpy as np
+import sympy as sp
+
+from qrisp.operators import Hamiltonian
+from qrisp.operators.bosonic.bosonic_term import BosonicTerm
+from qrisp.operators.hamiltonian_tools import group_up_iterable
+from qrisp.operators.qubit import QubitOperator
+
+threshold = 1e-9
+
+#
+# BosonicOperator
+#
+
+
+class BosonicOperator(Hamiltonian):
+    r"""This class provides an efficient implementation of ladder term operators, i.e.,
+    operators of the form
+
+    .. math::
+        
+        O=\sum\limits_{j}\alpha_jO_j 
+            
+    where each term $O_j$ is a product of bosonic raising $a_i^{\dagger}$ and lowering $a_i$ operators acting on the $i$ th bosonic mode.
+
+    The ladder operators satisfy the commutation relations
+
+    .. math::
+
+        [a_i,a_j^{\dagger}] &= a_ia_j^{\dagger}+a_j^{\dagger}a_i = \delta_{ij}\\
+        [a_i^{\dagger},a_j^{\dagger}] &= [a_i,a_j] = 0
+
+    Examples
+    --------
+    A ladder term operator can be specified conveniently in terms of ``a`` (lowering, i.e., annihilation), ``c`` (raising, i.e., creation) operators:
+
+    ::
+        
+        from qrisp.operators.bosonic import a, c
+
+        O = a(2)*c(1)+a(3)*c(2)
+        O
+
+    Yields $a_2c_1+a_3c_2$.
+
+    """
+
+    def __init__(self, terms_dict={}):
+
+        self.terms_dict = dict(terms_dict)
+
+    def reduce(self, assume_hermitian=False):
+        """Applies the bosonic commutation laws to bring the operator into
+        a standard form. This can reduce the amount of terms because several
+        terms might be the permuted version of each other and therefore their
+        coefficients add up.
+
+        This function can reduce the amount of terms even further if the user
+        can guarantee that the operator will be hermitized. In this case more
+        identifications can be made.
+
+        Parameters
+        ----------
+        assume_hermitian : bool, optional
+            If set to True the function will assume that the result will be
+            hermitized. The default is False.
+
+        Returns
+        -------
+        BosonicOperator
+            The reduced BosonicOperator.
+
+        Examples
+        --------
+        We create a BosonicOperator with redundant term definitions:
+
+        ::
+
+            from qrisp.operators.bosonic import *
+
+            O = a(0)*a(1) - a(1)*a(0)
+            print(O.reduce())
+            # Yields: 2*a0*a1
+
+        To demonstrate the ``assume_hermitian`` feature, we create a BosonicOperator
+        that has redundant terms, if hermitized.
+
+
+        >>> O = a(0)*a(1) + c(1)*c(0)
+        >>> reduced_O = O.reduce(assume_hermitian = True)
+        >>> print(reduced_O)
+        2*a0*a1
+
+        Hermitizing gives the original operator.
+
+        >>> print(reduced_O.hermitize())
+        1.0*a0*a1 + 1.0*c1*c0
+
+        """
+        # This function performs some non trivial logic.
+
+        # The problem here is that each bosonic term can
+        # be reshaped into several different forms and still express
+        # the same operator.
+        # For instance, the operator can be arbitrarily reordered
+        # if the permutation sign is take care of and no creators/annihilators
+        # with the same index are swapped.
+        # Furthermore the Hamiltonian must be Hermitian, so each
+        # term must be equivalent to is Hermitian conjugate.
+
+        # This function implements a storage system, that combines
+        # the coefficients of differing terms representing the same operator
+        # into a single term.
+
+        # This dictionary will contain the new terms, where redundancies
+        # are taken care of.
+        new_terms_dict = {}
+
+        for term, coeff in self.terms_dict.items():
+            # We only store the sorted version of each term.
+            # Sorting here means permuting the creators/annihilators
+            # while considering the sign of the permutation applied by the sort.
+            # The sort is performed in a stable manner, so terms like a(0)*c(0)
+            # don't get permuted (this would be a non-trivial anti-commutator).
+            sorted_term = term.sort()
+            if sorted_term not in new_terms_dict and assume_hermitian:
+                # If the sorted term is not in the terms dict, the sorted version
+                # of the daggering might be.
+                daggered_sorted_term = term.dagger().sort()
+                if daggered_sorted_term in new_terms_dict:
+                    sorted_term = daggered_sorted_term
+
+            # Compute the new coefficient.
+            new_terms_dict[sorted_term] = coeff + new_terms_dict.get(sorted_term, 0)
+
+        for term, coeff in list(new_terms_dict.items()):
+            if isinstance(coeff, (int, float)):
+                if coeff == 0:
+                    del new_terms_dict[term]
+
+        return BosonicOperator(new_terms_dict)
+
+    def len(self):
+        return len(self.terms_dict)
+
+    def coeffs(self):
+        """Returns the coefficients of the operator.
+
+        Returns
+        -------
+        ndarray
+            The coefficients.
+
+        Examples
+        --------
+        >>> from qrisp.operators import a, c
+        >>> O = a(0)*c(1)+a(1)*c(0)+0.5*a(1)+0.5*c(1)
+        >>> O.coeffs()
+        array([1. , 1. , 0.5, 0.5])
+
+        """
+        return np.array(list(self.terms_dict.values()))
+
+    #
+    # Printing
+    #
+
+    def _repr_latex_(self):
+        # Convert the sympy expression to LaTeX and return it
+        expr = self.to_expr()
+        return f"${sp.latex(expr)}$"
+
+    def __str__(self):
+        # Convert the sympy expression to a string and return it
+        expr = self.to_expr()
+        return str(expr)
+
+    def to_expr(self):
+        """Returns a SymPy expression representing the operator.
+
+        Returns
+        -------
+        expr : sympy.expr
+            A SymPy expression representing the operator.
+
+        """
+        expr = 0
+        for ladder_term, coeff in self.terms_dict.items():
+            expr += coeff * ladder_term.to_expr()
+        return expr
+
+    #
+    # Arithmetic
+    #
+
+    def dagger(self):
+        r"""Returns the daggered/adjoint version of self.
+
+        Returns
+        -------
+        BosonicOperator
+            The Operator $O^\dagger$.
+
+        Examples
+        --------
+        We create a BosonicOperator and dagger it:
+
+        ::
+
+            from qrisp.operators import *
+
+            O = a(0)*c(1)*a(2) + a(3)
+            print(O.dagger())
+            # Yields: c2*a1*c0 + c3
+
+        """
+        terms_dict = {}
+        for term, coeff in self.terms_dict.items():
+            terms_dict[term.dagger()] = np.conj(coeff)
+        return BosonicOperator(terms_dict)
+
+    def hermitize(self):
+        r"""Returns the hermitized version of self.
+
+        Returns
+        -------
+        BosonicOperator
+            The Operator $(O + O^\dagger)/2$.
+
+        Examples
+        --------
+        We create a BosonicOperator and hermitize it:
+
+        ::
+
+            from qrisp.operators import *
+
+            O = a(0)*c(1)*a(2) + a(3)
+            print(O.hermitize())
+            # Yields: 0.5*a0*c1*a2 + 0.5*a3 + 0.5*c2*a1*c0 + 0.5*c3
+
+        """
+        return 0.5 * (self + self.dagger())
+
+    def __eq__(self, other):
+        reduced_self = self.reduce()
+        reduced_other = other.reduce()
+
+        if len(reduced_self.terms_dict) != len(reduced_other.terms_dict):
+            return False
+
+        for term, coeff in reduced_self.terms_dict.items():
+            if term not in other.terms_dict:
+                daggered_sorted_term = term.dagger().sort()
+                if daggered_sorted_term not in reduced_other.terms_dict:
+                    return False
+                elif reduced_self.terms_dict[term] != reduced_other.terms_dict[daggered_sorted_term]:
+                    return False
+                continue
+
+            if reduced_self.terms_dict[term] != reduced_other.terms_dict[term]:
+                return False
+
+        return True
+
+    def __neg__(self):
+        return -1 * self
+
+    def __add__(self, other):
+        """Returns the sum of the operator self and other.
+
+        Parameters
+        ----------
+        other : int, float, complex or BosonicOperator
+            A scalar or a BosonicOperator to add to the operator self.
+
+        Returns
+        -------
+        result : BosonicOperator
+            The sum of the operator self and other.
+
+        """
+        if isinstance(other, (int, float, complex)):
+            other = BosonicOperator({BosonicTerm(): other})
+        if not isinstance(other, BosonicOperator):
+            raise TypeError("Cannot add BosonicOperator and " + str(type(other)))
+
+        res_terms_dict = {}
+
+        for ladder_term, coeff in self.terms_dict.items():
+            res_terms_dict[ladder_term] = res_terms_dict.get(ladder_term, 0) + coeff
+            if abs(res_terms_dict[ladder_term]) < threshold:
+                del res_terms_dict[ladder_term]
+
+        for ladder_term, coeff in other.terms_dict.items():
+            res_terms_dict[ladder_term] = res_terms_dict.get(ladder_term, 0) + coeff
+            if abs(res_terms_dict[ladder_term]) < threshold:
+                del res_terms_dict[ladder_term]
+
+        result = BosonicOperator(res_terms_dict)
+        return result
+
+    def __sub__(self, other):
+        """Returns the difference of the operator self and other.
+
+        Parameters
+        ----------
+        other : int, float, complex or BosonicOperator
+            A scalar or a BosonicOperator to substract from the operator self.
+
+        Returns
+        -------
+        result : BosonicOperator
+            The difference of the operator self and other.
+
+        """
+        if isinstance(other, (int, float, complex)):
+            other = BosonicOperator({BosonicTerm(): other})
+        if not isinstance(other, BosonicOperator):
+            raise TypeError("Cannot substract BosonicOperator and " + str(type(other)))
+
+        res_terms_dict = {}
+
+        for ladder_term, coeff in self.terms_dict.items():
+            res_terms_dict[ladder_term] = res_terms_dict.get(ladder_term, 0) + coeff
+            if abs(res_terms_dict[ladder_term]) < threshold:
+                del res_terms_dict[ladder_term]
+
+        for ladder_term, coeff in other.terms_dict.items():
+            res_terms_dict[ladder_term] = res_terms_dict.get(ladder_term, 0) - coeff
+            if abs(res_terms_dict[ladder_term]) < threshold:
+                del res_terms_dict[ladder_term]
+
+        result = BosonicOperator(res_terms_dict)
+        return result
+
+    def __rsub__(self, other):
+        """Returns the difference of the operator other and self.
+
+        Parameters
+        ----------
+        other : int, float, complex or BosonicOperator
+            A scalar or a BosonicOperator to substract from the operator self from.
+
+        Returns
+        -------
+        result : BosonicOperator
+            The difference of the operator other and self.
+
+        """
+        if isinstance(other, (int, float, complex)):
+            other = BosonicOperator({BosonicTerm(): other})
+        if not isinstance(other, BosonicOperator):
+            raise TypeError("Cannot substract BosonicOperator and " + str(type(other)))
+
+        res_terms_dict = {}
+
+        for ladder_term, coeff in self.terms_dict.items():
+            res_terms_dict[ladder_term] = res_terms_dict.get(ladder_term, 0) - coeff
+            if abs(res_terms_dict[ladder_term]) < threshold:
+                del res_terms_dict[ladder_term]
+
+        for ladder_term, coeff in other.terms_dict.items():
+            res_terms_dict[ladder_term] = res_terms_dict.get(ladder_term, 0) + coeff
+            if abs(res_terms_dict[ladder_term]) < threshold:
+                del res_terms_dict[ladder_term]
+
+        result = BosonicOperator(res_terms_dict)
+        return result
+
+    def __mul__(self, other):
+        """Returns the product of the operator self and other.
+
+        Parameters
+        ----------
+        other : int, float, complex or BosonicOperator
+            A scalar or a BosonicOperator to multiply with the operator self.
+
+        Returns
+        -------
+        result : BosonicOperator
+            The product of the operator self and other.
+
+        """
+        if isinstance(other, (int, float, complex)):
+            other = BosonicOperator({BosonicTerm(): other})
+        if not isinstance(other, BosonicOperator):
+            raise TypeError("Cannot multipliy BosonicOperator and " + str(type(other)))
+
+        res_terms_dict = {}
+
+        for ladder_term1, coeff1 in self.terms_dict.items():
+            for ladder_term2, coeff2 in other.terms_dict.items():
+                curr_ladder_term = ladder_term1 * ladder_term2
+                res_terms_dict[curr_ladder_term] = res_terms_dict.get(curr_ladder_term, 0) + coeff1 * coeff2
+
+        result = BosonicOperator(res_terms_dict)
+        return result
+
+    __radd__ = __add__
+    __rmul__ = __mul__
+
+    #
+    # Inplace arithmetic
+    #
+
+    def __iadd__(self, other):
+        """Adds other to the operator self.
+
+        Parameters
+        ----------
+        other : int, float, complex or BosonicOperator
+            A scalar or a BosonicOperator to add to the operator self.
+
+        """
+        if isinstance(other, (int, float, complex)):
+            self.terms_dict[BosonicTerm()] = self.terms_dict.get(BosonicTerm(), 0) + other
+            return self
+        if not isinstance(other, BosonicOperator):
+            raise TypeError("Cannot add BosonicOperator and " + str(type(other)))
+
+        for ladder_term, coeff in other.terms_dict.items():
+            self.terms_dict[ladder_term] = self.terms_dict.get(ladder_term, 0) + coeff
+            if abs(self.terms_dict[ladder_term]) < threshold:
+                del self.terms_dict[ladder_term]
+        self.terms_dict = BosonicOperator(self.terms_dict).terms_dict
+        return self
+
+    def __isub__(self, other):
+        """Substracts other from the operator self.
+
+        Parameters
+        ----------
+        other : int, float, complex or BosonicOperator
+            A scalar or a BosonicOperator to substract from the operator self.
+
+        """
+        if isinstance(other, (int, float, complex)):
+            self.terms_dict[BosonicTerm()] = self.terms_dict.get(BosonicTerm(), 0) - other
+            return self
+        if not isinstance(other, BosonicOperator):
+            raise TypeError("Cannot add BosonicOperator and " + str(type(other)))
+
+        for ladder_term, coeff in other.terms_dict.items():
+            self.terms_dict[ladder_term] = self.terms_dict.get(ladder_term, 0) - coeff
+            if abs(self.terms_dict[ladder_term]) < threshold:
+                del self.terms_dict[ladder_term]
+        return self
+
+    def __imul__(self, other):
+        """Multiplys other to the operator self.
+
+        Parameters
+        ----------
+        other : int, float, complex or BosonicOperator
+            A scalar or a BosonicOperator to multiply with the operator self.
+
+        """
+        if isinstance(other, (int, float, complex)):
+            other = BosonicOperator({BosonicTerm(): other})
+        if not isinstance(other, BosonicOperator):
+            raise TypeError("Cannot multipliy BosonicOperator and " + str(type(other)))
+
+        res_terms_dict = {}
+
+        for ladder_term1, coeff1 in self.terms_dict.items():
+            for ladder_term2, coeff2 in other.terms_dict.items():
+                curr_ladder_term = ladder_term1 * ladder_term2
+                res_terms_dict[curr_ladder_term] = res_terms_dict.get(curr_ladder_term, 0) + coeff1 * coeff2
+
+        self.terms_dict = res_terms_dict
+
+    #
+    # Miscellaneous
+    #
+
+    def apply_threshold(self, threshold):
+        """Removes all ladder_term terms with coefficient absolute value below the specified threshold.
+
+        Parameters
+        ----------
+        threshold : float
+            The threshold for the coefficients of the ladder_term terms.
+
+        """
+        delete_list = []
+        for ladder_term, coeff in self.terms_dict.items():
+            if abs(coeff) < threshold:
+                delete_list.append(ladder_term)
+        for ladder_term in delete_list:
+            del self.terms_dict[ladder_term]
+
+    def to_sparse_matrix(self, truncation=8, binary_encoding="gray_code"):
+        """Returns a matrix representing the operator.
+
+        Returns
+        -------
+        M : scipy.sparse.csr_matrix
+            A sparse matrix representing the operator.
+        truncation: How many bosonic occupation numbers to take into account.
+        binary_encoding : string, optional
+            How to embed the bosonic terms into a QubitOperator.
+
+        """
+        return self.to_qubit_operator(truncation=truncation, binary_encoding=binary_encoding).to_sparse_matrix()
+
+    def ground_state_energy(self, truncation=8):
+        """Calculates the ground state energy (i.e., the minimum eigenvalue) of the operator classically.
+
+        Returns
+        -------
+        float
+            The ground state energy.
+
+        """
+        return self.to_qubit_operator(truncation=truncation).ground_state_energy()
+
+    def to_qubit_operator(self, truncation=8, binary_encoding="gray_code"):
+        """Transforms the BosonicOperator to a :ref:`QubitOperator`.
+
+        Parameters
+        ----------
+        truncation : int, optional
+            How many bosonic occupation numbers to take into account
+        binary_encoding : str, optional
+            The way of embedding the bosonic operator into qubits
+
+        Returns
+        -------
+        O : :ref:`QubitOperator`
+            The resulting QubitOperator.
+        """
+        if binary_encoding in ["gray_code", "standard_binary", "one_hot"]:
+            res = QubitOperator({})
+            for term, coeff in self.terms_dict.items():
+                res += coeff * term.to_qubit_term(truncation=truncation, binary_encoding=binary_encoding)
+            return res
+        else:
+            raise Exception(f"Don't know bosonic mapping {binary_encoding}.")
+
+    def expectation_value(self, state_prep, truncation=8, binary_encoding="gray_code", **measurement_kwargs):
+        r"""The ``expectation value`` function allows to estimate the expectation value of a Hamiltonian for a state that is specified by a preparation procedure.
+        This preparation procedure can be supplied via a Python function that returns a :ref:`QuantumVariable`.
+
+        Note that this method measures the **hermitized** version of the operator:
+
+        .. math::
+
+            H = (O + O^\dagger)/2
+
+
+        Parameters
+        ----------
+        state_prep : callable
+            A function returning a QuantumVariable.
+            The expectation of the Hamiltonian for the state of this QuantumVariable will be measured.
+            The state preparation function can only take classical values as arguments.
+            This is because a quantum value would need to be copied for each sampling iteration, which is prohibited by the no-cloning theorem.
+        truncation: How many bosonic occupation numbers to take into account.
+        binary_encoding : string, optional
+            How to embed the bosonic terms into a QubitOperator.
+        measurement_kwargs : dict, optional
+            The keyword arguments of :meth:`QubitOperator.expectation_value <qrisp.operators.qubit.QubitOperator.expectation_value>`.
+
+        Returns
+        -------
+        callable
+            A function returning an array containing the expectation value.
+
+        """
+        qubit_operator = self.to_qubit_operator(truncation=truncation, binary_encoding=binary_encoding)
+        return qubit_operator.expectation_value(state_prep, **measurement_kwargs)
+
+    #
+    # Trotterization
+    #
+
+    def trotterization(self, truncation=8, binary_encoding="gray_code", forward_evolution=True):
+        r"""Returns a function for performing Hamiltonian simulation, i.e., approximately implementing the unitary operator $U(t) = e^{-itH}$ via Trotterization.
+
+        """
+        qubit_operator = self.to_qubit_operator(truncation=truncation, binary_encoding=binary_encoding)
+        return qubit_operator.trotterization(forward_evolution=forward_evolution)
+
+    def group_up(self, denominator):
+        term_groups = group_up_iterable(list(self.terms_dict.keys()), denominator)
+        if len(term_groups) == 0:
+            return [self]
+        groups = []
+        for term_group in term_groups:
+            O = BosonicOperator({term: self.terms_dict[term] for term in term_group})
+            groups.append(O)
+
+        return groups

--- a/src/qrisp/operators/bosonic/bosonic_operator.py
+++ b/src/qrisp/operators/bosonic/bosonic_operator.py
@@ -49,18 +49,62 @@ class BosonicOperator(Hamiltonian):
         [a_i,a_j^{\dagger}] &= a_ia_j^{\dagger}-a_j^{\dagger}a_i = \delta_{ij}\\
         [a_i^{\dagger},a_j^{\dagger}] &= [a_i,a_j] = 0
 
+    In contrast to fermions, which can be represented by a two-dimensional Fock space, the bosonic Fock space is infinite-dimensional and needs to be truncated for representation on a quantum computer.
+    Furthermore, there are several possibilities to encode the single Fock states in qubit states. Three such encodings are supported:
+
+    - A one-hot encoding requires as many qubits as Fock states are represented. It is thus the most inefficient in terms of qubits, but typically leads to the smallest number of gates in Hamiltonian simulation.
+    - A standard binary encoding needs only $\log_2 n$ qubits to represent $n$ Fock states. E.g. when representing 8 Fock states, the qubit states $|000\rangle, |001\rangle, |010\rangle, \dots$ are mapped to the Fock states $|0\rangle, |1\rangle, |2\rangle, \dots$.
+    - A Gray code encoding works very similar to standard binary encoding, with the only difference that the qubit states are ordered differently such that subsequent states always differ in only one qubit. This is particularly efficient for the representation of ladder operators, which possess only one non-zero off-diagonal. Hence, gate count is typically slightly reduced compared to the standard binary encoding.
+
+    Details on these three encodings and their respective advantages and disadvantages can be found in https://www.nature.com/articles/s41534-020-0278-0.
+
+    The representation of bosonic ladder operators by finite matrices comes with the particular problem that it is impossible to get the correct bosonic commutation relations with finite matrices, as for a finite matrix $a$ we have $\mathrm{Tr}(aa^\dagger-a^\dagger a) = 0 \neq \mathrm{Tr}(\mathbb{1})$.
+    As a consequence, there is an ambiguity in the representation of bosonic operators, because applying the Fock space truncation before or after the application of a commutation relation can lead to different results.
+    Here, this ambiguity is removed by truncating the normal-ordered version (with all creators moved to the left) of an operator.
+
+    Both the truncation and the encoding need not to be specified until the point where a ``BosonicOperator`` is converted to a ``QubitOperator``. The latter becomes necessary internally also if its expectation value, ground state energy, sparse matrix representation or trotterized version are computed.
+    Until this point, a purely abstract representation of the operator is stored internally.
+
+    For convenience, the module contains also a function ``prepare_bosonic_fock_state`` that creates a qubit state representing a bosonic Fock state with a specific truncation and in a specific encoding.
+
     Examples
     --------
     A ladder term operator can be specified conveniently in terms of ``a_b`` (lowering, i.e., annihilation), ``c_b`` (raising, i.e., creation) operators:
 
     ::
-        
+
         from qrisp.operators.bosonic import a_b, c_b
 
         O = a_b(2)*c_b(1)+a_b(3)*c_b(2)
         O
 
     Yields $a_2c_1+a_3c_2$.
+
+    Convert an operator to a Pauli representation for a particular encoding and truncation:
+
+    ::
+        from qrisp.operators.bosonic import a_b, c_b
+
+        O = c_b(0)*a_b(0)
+
+        print(O.to_qubit_operator(truncation=3, binary_encoding="one_hot").to_pauli())
+        # yields 0.375 + 0.375*Z(0) + 0.125*Z(0)*Z(1) - 0.375*Z(0)*Z(1)*Z(2) - 0.125*Z(0)*Z(2) + 0.125*Z(1) - 0.375*Z(1)*Z(2) - 0.125*Z(2)
+
+        print(O.to_qubit_operator(truncation=8, binary_encoding="standard_binary").to_pauli())
+        # yields 3.5 - 2.0*Z(0) - 1.0*Z(1) - 0.5*Z(2)
+
+        print(O.to_qubit_operator(truncation=8, binary_encoding="gray_code").to_pauli())
+        # yields 3.5 - 2.0*Z(0) - 1.0*Z(0)*Z(1) - 0.5*Z(0)*Z(1)*Z(2)
+
+    Create a bosonic Fock state $|3\rangle$ and compute the expectation value of the number operator for that state (it is important that the encoding and truncation are chosen the same for both the state preparation function and the expectation value method!):
+
+    ::
+        from qrisp.operators.bosonic import a_b, c_b, prepare_bosonic_fock_state
+
+        O = c_b(0)*a_b(0)
+
+        O.expectation_value(prepare_bosonic_fock_state, truncation=8, binary_encoding="gray_code")(3, 8, "gray_code")
+        # yields 2.9999999999999996
 
     """
 
@@ -536,6 +580,7 @@ class BosonicOperator(Hamiltonian):
 
     def to_qubit_operator(self, truncation: int = 8, binary_encoding: str = "gray_code"):
         """Transforms the BosonicOperator to a :ref:`QubitOperator`.
+        To that end, the bosonic Fock space is truncated to `truncation`. The remaining states are encoded in qubit states by one of three methods, a one-hot, standard binary or Gray code representation. See the general documentation of `BosonicOperator` and https://www.nature.com/articles/s41534-020-0278-0 for more details.
 
         Parameters
         ----------
@@ -548,6 +593,25 @@ class BosonicOperator(Hamiltonian):
         -------
         O : :ref:`QubitOperator`
             The resulting QubitOperator.
+
+        Examples
+        --------
+        Convert an operator to a Pauli representation for a particular encoding and truncation:
+
+        ::
+            from qrisp.operators.bosonic import a_b, c_b
+
+            O = c_b(0)*a_b(0)
+
+            print(O.to_qubit_operator(truncation=3, binary_encoding="one_hot").to_pauli())
+            # yields 0.375 + 0.375*Z(0) + 0.125*Z(0)*Z(1) - 0.375*Z(0)*Z(1)*Z(2) - 0.125*Z(0)*Z(2) + 0.125*Z(1) - 0.375*Z(1)*Z(2) - 0.125*Z(2)
+
+            print(O.to_qubit_operator(truncation=8, binary_encoding="standard_binary").to_pauli())
+            # yields 3.5 - 2.0*Z(0) - 1.0*Z(1) - 0.5*Z(2)
+
+            print(O.to_qubit_operator(truncation=8, binary_encoding="gray_code").to_pauli())
+            # yields 3.5 - 2.0*Z(0) - 1.0*Z(0)*Z(1) - 0.5*Z(0)*Z(1)*Z(2)
+
         """
         if binary_encoding in ["gray_code", "standard_binary", "one_hot"]:
             res = QubitOperator({})
@@ -588,6 +652,19 @@ class BosonicOperator(Hamiltonian):
         callable
             A function returning an array containing the expectation value.
 
+
+        Examples
+        --------
+        Create a bosonic Fock state $|3\rangle$ and compute the expectation value of the number operator for that state (it is important that the encoding and truncation are chosen the same for both the state preparation function and the expectation value method!):
+
+        ::
+            from qrisp.operators.bosonic import a_b, c_b, prepare_bosonic_fock_state
+
+            O = c_b(0)*a_b(0)
+
+            O.expectation_value(prepare_bosonic_fock_state, truncation=8, binary_encoding="gray_code")(3, 8, "gray_code")
+            # yields 2.9999999999999996
+
         """
         qubit_operator = self.to_qubit_operator(truncation=truncation, binary_encoding=binary_encoding)
         return qubit_operator.expectation_value(state_prep, **measurement_kwargs)
@@ -597,7 +674,35 @@ class BosonicOperator(Hamiltonian):
     #
 
     def trotterization(self, truncation: int = 8, binary_encoding: str = "gray_code", forward_evolution: bool = True):
-        r"""Returns a function for performing Hamiltonian simulation, i.e., approximately implementing the unitary operator $U(t) = e^{-itH}$ via Trotterization."""
+        r"""Returns a function for performing Hamiltonian simulation, i.e., approximately implementing the unitary operator $U(t) = e^{-itH}$ via Trotterization.
+
+        Parameters
+        ----------
+        truncation : int, optional
+            How many bosonic occupation numbers to take into account
+        binary_encoding : str, optional
+            How to embed the bosonic terms into a QubitOperator. Possible values are "gray_code", "standard_binary" and "one_hot".
+
+        Returns
+        -------
+        callable
+            A function that takes a quantum variable qv and a time t as arguments and applies an evolution of exp(-itH) to qv, with H being the `BosonicOperator` instance itself.
+
+        Examples
+        --------
+        Apply an evolution with $H = a + a^\dagger$ to a Fock state:
+
+        ::
+            from qrisp.operators.bosonic import a_b, c_b, prepare_bosonic_fock_state
+            H = a_b(0) + c_b(0)
+            N = c_b(0)*a_b(0)
+            U = H.trotterization(truncation=8, binary_encoding="gray_code")
+            psi = prepare_bosonic_fock_state(n=3, truncation=8, binary_encoding="gray_code")
+            U(psi, t=0.5)
+            N.expectation_value(lambda: psi, truncation=8, binary_encoding="gray_code")()
+            # yields ~4.1
+
+        """
         qubit_operator = self.to_qubit_operator(truncation=truncation, binary_encoding=binary_encoding)
         return qubit_operator.trotterization(forward_evolution=forward_evolution)
 

--- a/src/qrisp/operators/bosonic/bosonic_operator.py
+++ b/src/qrisp/operators/bosonic/bosonic_operator.py
@@ -14,6 +14,7 @@
 * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
 ********************************************************************************
 """
+
 from typing import Self
 
 import numpy as np
@@ -533,7 +534,9 @@ class BosonicOperator(Hamiltonian):
         else:
             raise Exception(f"Don't know bosonic mapping {binary_encoding}.")
 
-    def expectation_value(self, state_prep: callable, truncation: int = 8, binary_encoding: str = "gray_code", **measurement_kwargs):
+    def expectation_value(
+        self, state_prep: callable, truncation: int = 8, binary_encoding: str = "gray_code", **measurement_kwargs
+    ):
         r"""The ``expectation value`` function allows to estimate the expectation value of a Hamiltonian for a state that is specified by a preparation procedure.
         This preparation procedure can be supplied via a Python function that returns a :ref:`QuantumVariable`.
 

--- a/src/qrisp/operators/bosonic/bosonic_operator.py
+++ b/src/qrisp/operators/bosonic/bosonic_operator.py
@@ -305,10 +305,10 @@ class BosonicOperator(Hamiltonian):
 
         return True
 
-    def __neg__(self):
+    def __neg__(self) -> Self:
         return -1 * self
 
-    def __add__(self, other: Self):
+    def __add__(self, other: int | float | complex | Self) -> Self:
         """Returns the sum of the operator self and other.
 
         Parameters
@@ -342,7 +342,7 @@ class BosonicOperator(Hamiltonian):
         result = BosonicOperator(res_terms_dict)
         return result
 
-    def __sub__(self, other: Self):
+    def __sub__(self, other: int | float | complex | Self) -> Self:
         """Returns the difference of the operator self and other.
 
         Parameters
@@ -376,7 +376,7 @@ class BosonicOperator(Hamiltonian):
         result = BosonicOperator(res_terms_dict)
         return result
 
-    def __rsub__(self, other: Self):
+    def __rsub__(self, other: int | float | complex | Self) -> Self:
         """Returns the difference of the operator other and self.
 
         Parameters
@@ -410,7 +410,7 @@ class BosonicOperator(Hamiltonian):
         result = BosonicOperator(res_terms_dict)
         return result
 
-    def __mul__(self, other: Self):
+    def __mul__(self, other: int | float | complex | Self) -> Self:
         """Returns the product of the operator self and other.
 
         Parameters
@@ -442,7 +442,7 @@ class BosonicOperator(Hamiltonian):
     __radd__ = __add__
     __rmul__ = __mul__
 
-    def __pow__(self, exp: int):
+    def __pow__(self, exp: int) -> Self:
         """Returns the operator self exponentiated by int.
 
         Parameters
@@ -469,7 +469,7 @@ class BosonicOperator(Hamiltonian):
     # Inplace arithmetic
     #
 
-    def __iadd__(self, other: Self):
+    def __iadd__(self, other: int | float | complex | Self) -> Self:
         """Adds other to the operator self.
 
         Parameters
@@ -491,7 +491,7 @@ class BosonicOperator(Hamiltonian):
         self.terms_dict = BosonicOperator(self.terms_dict).terms_dict
         return self
 
-    def __isub__(self, other: Self):
+    def __isub__(self, other: int | float | complex | Self) -> Self:
         """Substracts other from the operator self.
 
         Parameters
@@ -512,7 +512,7 @@ class BosonicOperator(Hamiltonian):
                 del self.terms_dict[ladder_term]
         return self
 
-    def __imul__(self, other: Self):
+    def __imul__(self, other: int | float | complex | Self) -> Self:
         """Multiplys other to the operator self.
 
         Parameters

--- a/src/qrisp/operators/bosonic/bosonic_operator.py
+++ b/src/qrisp/operators/bosonic/bosonic_operator.py
@@ -396,6 +396,29 @@ class BosonicOperator(Hamiltonian):
     __radd__ = __add__
     __rmul__ = __mul__
 
+    def __pow__(self, exp: int):
+        """Returns the operator self exponentiated by int.
+
+        Parameters
+        ----------
+        exp : int
+            A positive integer with which self is exponentiated.
+
+        Returns
+        -------
+        result : BosonicOperator
+            The exponentiated operator self.
+
+        """
+        if not (isinstance(exp, int) and exp > 0):
+            raise TypeError("Operators can be exponentiated only with positive integers.")
+
+        res = self
+        for _ in range(exp - 1):
+            res = res * self
+
+        return res
+
     #
     # Inplace arithmetic
     #

--- a/src/qrisp/operators/bosonic/bosonic_operator.py
+++ b/src/qrisp/operators/bosonic/bosonic_operator.py
@@ -46,7 +46,7 @@ class BosonicOperator(Hamiltonian):
 
     .. math::
 
-        [a_i,a_j^{\dagger}] &= a_ia_j^{\dagger}+a_j^{\dagger}a_i = \delta_{ij}\\
+        [a_i,a_j^{\dagger}] &= a_ia_j^{\dagger}-a_j^{\dagger}a_i = \delta_{ij}\\
         [a_i^{\dagger},a_j^{\dagger}] &= [a_i,a_j] = 0
 
     Examples

--- a/src/qrisp/operators/bosonic/bosonic_operator.py
+++ b/src/qrisp/operators/bosonic/bosonic_operator.py
@@ -14,6 +14,7 @@
 * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
 ********************************************************************************
 """
+from typing import Self
 
 import numpy as np
 import sympy as sp
@@ -62,11 +63,11 @@ class BosonicOperator(Hamiltonian):
 
     """
 
-    def __init__(self, terms_dict={}):
+    def __init__(self, terms_dict: dict = {}):
 
         self.terms_dict = dict(terms_dict)
 
-    def reduce(self, assume_hermitian=False):
+    def reduce(self, assume_hermitian: bool = False):
         """Applies the bosonic commutation laws to bring the operator into
         a standard form. This can reduce the amount of terms because several
         terms might be the permuted version of each other and therefore their
@@ -236,7 +237,7 @@ class BosonicOperator(Hamiltonian):
         """
         return 0.5 * (self + self.dagger())
 
-    def __eq__(self, other):
+    def __eq__(self, other: Self):
         reduced_self = self.reduce()
         reduced_other = other.reduce()
 
@@ -260,7 +261,7 @@ class BosonicOperator(Hamiltonian):
     def __neg__(self):
         return -1 * self
 
-    def __add__(self, other):
+    def __add__(self, other: Self):
         """Returns the sum of the operator self and other.
 
         Parameters
@@ -294,7 +295,7 @@ class BosonicOperator(Hamiltonian):
         result = BosonicOperator(res_terms_dict)
         return result
 
-    def __sub__(self, other):
+    def __sub__(self, other: Self):
         """Returns the difference of the operator self and other.
 
         Parameters
@@ -328,7 +329,7 @@ class BosonicOperator(Hamiltonian):
         result = BosonicOperator(res_terms_dict)
         return result
 
-    def __rsub__(self, other):
+    def __rsub__(self, other: Self):
         """Returns the difference of the operator other and self.
 
         Parameters
@@ -362,7 +363,7 @@ class BosonicOperator(Hamiltonian):
         result = BosonicOperator(res_terms_dict)
         return result
 
-    def __mul__(self, other):
+    def __mul__(self, other: Self):
         """Returns the product of the operator self and other.
 
         Parameters
@@ -398,7 +399,7 @@ class BosonicOperator(Hamiltonian):
     # Inplace arithmetic
     #
 
-    def __iadd__(self, other):
+    def __iadd__(self, other: Self):
         """Adds other to the operator self.
 
         Parameters
@@ -420,7 +421,7 @@ class BosonicOperator(Hamiltonian):
         self.terms_dict = BosonicOperator(self.terms_dict).terms_dict
         return self
 
-    def __isub__(self, other):
+    def __isub__(self, other: Self):
         """Substracts other from the operator self.
 
         Parameters
@@ -441,7 +442,7 @@ class BosonicOperator(Hamiltonian):
                 del self.terms_dict[ladder_term]
         return self
 
-    def __imul__(self, other):
+    def __imul__(self, other: Self):
         """Multiplys other to the operator self.
 
         Parameters
@@ -468,7 +469,7 @@ class BosonicOperator(Hamiltonian):
     # Miscellaneous
     #
 
-    def apply_threshold(self, threshold):
+    def apply_threshold(self, threshold: float):
         """Removes all ladder_term terms with coefficient absolute value below the specified threshold.
 
         Parameters
@@ -484,7 +485,7 @@ class BosonicOperator(Hamiltonian):
         for ladder_term in delete_list:
             del self.terms_dict[ladder_term]
 
-    def to_sparse_matrix(self, truncation=8, binary_encoding="gray_code"):
+    def to_sparse_matrix(self, truncation: int = 8, binary_encoding: str = "gray_code"):
         """Returns a matrix representing the operator.
 
         Returns
@@ -498,7 +499,7 @@ class BosonicOperator(Hamiltonian):
         """
         return self.to_qubit_operator(truncation=truncation, binary_encoding=binary_encoding).to_sparse_matrix()
 
-    def ground_state_energy(self, truncation=8):
+    def ground_state_energy(self, truncation: int = 8):
         """Calculates the ground state energy (i.e., the minimum eigenvalue) of the operator classically.
 
         Returns
@@ -509,7 +510,7 @@ class BosonicOperator(Hamiltonian):
         """
         return self.to_qubit_operator(truncation=truncation).ground_state_energy()
 
-    def to_qubit_operator(self, truncation=8, binary_encoding="gray_code"):
+    def to_qubit_operator(self, truncation: int = 8, binary_encoding: str = "gray_code"):
         """Transforms the BosonicOperator to a :ref:`QubitOperator`.
 
         Parameters
@@ -532,7 +533,7 @@ class BosonicOperator(Hamiltonian):
         else:
             raise Exception(f"Don't know bosonic mapping {binary_encoding}.")
 
-    def expectation_value(self, state_prep, truncation=8, binary_encoding="gray_code", **measurement_kwargs):
+    def expectation_value(self, state_prep: callable, truncation: int = 8, binary_encoding: str = "gray_code", **measurement_kwargs):
         r"""The ``expectation value`` function allows to estimate the expectation value of a Hamiltonian for a state that is specified by a preparation procedure.
         This preparation procedure can be supplied via a Python function that returns a :ref:`QuantumVariable`.
 
@@ -569,12 +570,12 @@ class BosonicOperator(Hamiltonian):
     # Trotterization
     #
 
-    def trotterization(self, truncation=8, binary_encoding="gray_code", forward_evolution=True):
+    def trotterization(self, truncation: int = 8, binary_encoding: str = "gray_code", forward_evolution: bool = True):
         r"""Returns a function for performing Hamiltonian simulation, i.e., approximately implementing the unitary operator $U(t) = e^{-itH}$ via Trotterization."""
         qubit_operator = self.to_qubit_operator(truncation=truncation, binary_encoding=binary_encoding)
         return qubit_operator.trotterization(forward_evolution=forward_evolution)
 
-    def group_up(self, denominator):
+    def group_up(self, denominator: callable):
         term_groups = group_up_iterable(list(self.terms_dict.keys()), denominator)
         if len(term_groups) == 0:
             return [self]

--- a/src/qrisp/operators/bosonic/bosonic_operator.py
+++ b/src/qrisp/operators/bosonic/bosonic_operator.py
@@ -83,6 +83,7 @@ class BosonicOperator(Hamiltonian):
     Convert an operator to a Pauli representation for a particular encoding and truncation:
 
     ::
+
         from qrisp.operators.bosonic import a_b, c_b
 
         O = c_b(0)*a_b(0)
@@ -99,6 +100,7 @@ class BosonicOperator(Hamiltonian):
     Create a bosonic Fock state $|3\rangle$ and compute the expectation value of the number operator for that state (it is important that the encoding and truncation are chosen the same for both the state preparation function and the expectation value method!):
 
     ::
+
         from qrisp.operators.bosonic import a_b, c_b, prepare_bosonic_fock_state
 
         O = c_b(0)*a_b(0)
@@ -580,7 +582,7 @@ class BosonicOperator(Hamiltonian):
 
     def to_qubit_operator(self, truncation: int = 8, binary_encoding: str = "gray_code"):
         """Transforms the BosonicOperator to a :ref:`QubitOperator`.
-        To that end, the bosonic Fock space is truncated to `truncation`. The remaining states are encoded in qubit states by one of three methods, a one-hot, standard binary or Gray code representation. See the general documentation of `BosonicOperator` and https://www.nature.com/articles/s41534-020-0278-0 for more details.
+        To that end, the bosonic Fock space is truncated to ``truncation`` states. These states are encoded in qubit states by one of three methods, a one-hot, standard binary or Gray code representation. See the general documentation of :ref:`BosonicOperator` and https://www.nature.com/articles/s41534-020-0278-0 for more details.
 
         Parameters
         ----------
@@ -599,6 +601,7 @@ class BosonicOperator(Hamiltonian):
         Convert an operator to a Pauli representation for a particular encoding and truncation:
 
         ::
+
             from qrisp.operators.bosonic import a_b, c_b
 
             O = c_b(0)*a_b(0)
@@ -658,6 +661,7 @@ class BosonicOperator(Hamiltonian):
         Create a bosonic Fock state $|3\rangle$ and compute the expectation value of the number operator for that state (it is important that the encoding and truncation are chosen the same for both the state preparation function and the expectation value method!):
 
         ::
+
             from qrisp.operators.bosonic import a_b, c_b, prepare_bosonic_fock_state
 
             O = c_b(0)*a_b(0)
@@ -693,6 +697,7 @@ class BosonicOperator(Hamiltonian):
         Apply an evolution with $H = a + a^\dagger$ to a Fock state:
 
         ::
+
             from qrisp.operators.bosonic import a_b, c_b, prepare_bosonic_fock_state
             H = a_b(0) + c_b(0)
             N = c_b(0)*a_b(0)

--- a/src/qrisp/operators/bosonic/bosonic_operator.py
+++ b/src/qrisp/operators/bosonic/bosonic_operator.py
@@ -611,3 +611,38 @@ class BosonicOperator(Hamiltonian):
             groups.append(O)
 
         return groups
+
+
+def get_bosonic_encoding_qubit_number(truncation, binary_encoding):
+    if binary_encoding != "one_hot":
+        return int(np.ceil(np.log2(truncation)))
+    else:
+        return truncation
+
+
+from qrisp.operators.bosonic.bosonic_term import gray_code, standard_binary, one_hot
+from qrisp import QuantumVariable, x
+
+
+def prepare_bosonic_fock_state(n: int, truncation: int = 8, binary_encoding: str = "gray_code"):
+    if not 0 <= n < truncation:
+        raise ValueError("n must be between 0 an truncation-1")
+
+    n_qubits = get_bosonic_encoding_qubit_number(truncation, binary_encoding)
+
+    qv = QuantumVariable(n_qubits)
+
+    if binary_encoding == "gray_code":
+        qubits = gray_code(n_qubits)[n]
+    elif binary_encoding == "standard_binary":
+        qubits = standard_binary(n_qubits)[n]
+    elif binary_encoding == "one_hot":
+        qubits = one_hot(n_qubits)[n]
+    else:
+        raise Exception(f"Don't know binary encoding type {binary_encoding}")
+
+    for i, q in enumerate(qubits):
+        if q:
+            x(qv[i])
+
+    return qv

--- a/src/qrisp/operators/bosonic/bosonic_operator.py
+++ b/src/qrisp/operators/bosonic/bosonic_operator.py
@@ -1,4 +1,5 @@
 """********************************************************************************
+
 * Copyright (c) 2024 the Qrisp authors
 *
 * This program and the accompanying materials are made available under the
@@ -13,6 +14,7 @@
 *
 * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
 ********************************************************************************
+
 """
 
 from typing import Self
@@ -20,9 +22,9 @@ from typing import Self
 import numpy as np
 import sympy as sp
 
+from qrisp import QuantumVariable, x
 from qrisp.operators import Hamiltonian
-from qrisp.operators.bosonic.bosonic_term import BosonicTerm
-from qrisp.operators.hamiltonian_tools import group_up_iterable
+from qrisp.operators.bosonic.bosonic_term import BosonicTerm, gray_code, one_hot, standard_binary
 from qrisp.operators.qubit import QubitOperator
 
 threshold = 1e-9
@@ -33,14 +35,16 @@ threshold = 1e-9
 
 
 class BosonicOperator(Hamiltonian):
-    r"""This class provides an efficient implementation of bosonic ladder term operators, i.e.,
-    operators of the form
+    r"""An efficient implementation of bosonic ladder term operators.
+
+    The class represents operators of the form
 
     .. math::
-        
-        O=\sum\limits_{j}\alpha_jO_j 
-            
-    where each term $O_j$ is a product of bosonic raising $a_i^{\dagger}$ and lowering $a_i$ operators acting on the $i$ th bosonic mode.
+
+        O=\sum\limits_{j}\alpha_jO_j
+
+    where each term $O_j$ is a product of bosonic raising $a_i^{\dagger}$ and lowering $a_i$ operators
+    acting on the $i$ th bosonic mode.
 
     The ladder operators satisfy the commutation relations
 
@@ -49,27 +53,49 @@ class BosonicOperator(Hamiltonian):
         [a_i,a_j^{\dagger}] &= a_ia_j^{\dagger}-a_j^{\dagger}a_i = \delta_{ij}\\
         [a_i^{\dagger},a_j^{\dagger}] &= [a_i,a_j] = 0
 
-    In contrast to fermions, which can be represented by a two-dimensional Fock space, the bosonic Fock space is infinite-dimensional and needs to be truncated for representation on a quantum computer.
-    Furthermore, there are several possibilities to encode the single Fock states in qubit states. Three such encodings are supported:
+    In contrast to fermions, which can be represented by a two-dimensional Fock space,
+    the bosonic Fock space is infinite-dimensional and needs to be truncated for representation on a quantum computer.
+    Furthermore, there are several possibilities to encode the single Fock states in qubit states.
+    Three such encodings are supported:
 
-    - A one-hot encoding requires as many qubits as Fock states are represented. It is thus the most inefficient in terms of qubits, but typically leads to the smallest number of gates in Hamiltonian simulation.
-    - A standard binary encoding needs only $\log_2 n$ qubits to represent $n$ Fock states. E.g. when representing 8 Fock states, the qubit states $|000\rangle, |001\rangle, |010\rangle, \dots$ are mapped to the Fock states $|0\rangle, |1\rangle, |2\rangle, \dots$.
-    - A Gray code encoding works very similar to standard binary encoding, with the only difference that the qubit states are ordered differently such that subsequent states always differ in only one qubit. This is particularly efficient for the representation of ladder operators, which possess only one non-zero off-diagonal. Hence, gate count is typically slightly reduced compared to the standard binary encoding.
+    - A one-hot encoding requires as many qubits as Fock states are represented.
+      It is thus the most inefficient in terms of qubits,
+      but typically leads to the smallest number of gates in Hamiltonian simulation.
+    - A standard binary encoding needs only $\log_2 n$ qubits to represent $n$ Fock states.
+      E.g. when representing 8 Fock states, the qubit states $|000\rangle, |001\rangle, |010\rangle, \dots$
+      are mapped to the Fock states $|0\rangle, |1\rangle, |2\rangle, \dots$.
+    - A Gray code encoding works very similar to standard binary encoding,
+      with the only difference that the qubit states are ordered differently,
+      such that subsequent states always differ in only one qubit.
+      This is particularly efficient for the representation of ladder operators,
+      which possess only one non-zero off-diagonal.
+      Hence, gate count is typically slightly reduced compared to the standard binary encoding.
 
-    Details on these three encodings and their respective advantages and disadvantages can be found in https://www.nature.com/articles/s41534-020-0278-0.
+    Details on these three encodings and their respective advantages and disadvantages
+    can be found in https://www.nature.com/articles/s41534-020-0278-0.
 
-    The representation of bosonic ladder operators by finite matrices comes with the particular problem that it is impossible to get the correct bosonic commutation relations with finite matrices, as for a finite matrix $a$ we have $\mathrm{Tr}(aa^\dagger-a^\dagger a) = 0 \neq \mathrm{Tr}(\mathbb{1})$.
-    As a consequence, there is an ambiguity in the representation of bosonic operators, because applying the Fock space truncation before or after the application of a commutation relation can lead to different results.
-    Here, this ambiguity is removed by truncating the normal-ordered version (with all creators moved to the left) of an operator.
+    The representation of bosonic ladder operators by finite matrices comes with the particular problem
+    that it is impossible to get the correct bosonic commutation relations with finite matrices,
+    as for a finite matrix $a$ we have $\mathrm{Tr}(aa^\dagger-a^\dagger a) = 0 \neq \mathrm{Tr}(\mathbb{1})$.
+    As a consequence, there is an ambiguity in the representation of bosonic operators,
+    because applying the Fock space truncation before or after the application of a commutation relation
+    can lead to different results.
+    Here, this ambiguity is removed by truncating the normal-ordered version
+    (with all creators moved to the left) of an operator.
 
-    Both the truncation and the encoding need not to be specified until the point where a ``BosonicOperator`` is converted to a ``QubitOperator``. The latter becomes necessary internally also if its expectation value, ground state energy, sparse matrix representation or trotterized version are computed.
+    Both the truncation and the encoding need not to be specified until the point
+    where a ``BosonicOperator`` is converted to a ``QubitOperator``.
+    The latter becomes necessary internally also if its expectation value, ground state energy,
+    sparse matrix representation or trotterized version are computed.
     Until this point, a purely abstract representation of the operator is stored internally.
 
-    For convenience, the module contains also a function ``prepare_bosonic_fock_state`` that creates a qubit state representing a bosonic Fock state with a specific truncation and in a specific encoding.
+    For convenience, the module contains also a function ``prepare_bosonic_fock_state``,
+    which creates a qubit state representing a bosonic Fock state with a specific truncation and in a specific encoding.
 
     Examples
     --------
-    A ladder term operator can be specified conveniently in terms of ``a_b`` (lowering, i.e., annihilation), ``c_b`` (raising, i.e., creation) operators:
+    A ladder term operator can be specified conveniently
+    in terms of ``a_b`` (lowering, i.e., annihilation), ``c_b`` (raising, i.e., creation) operators:
 
     ::
 
@@ -89,7 +115,8 @@ class BosonicOperator(Hamiltonian):
         O = c_b(0)*a_b(0)
 
         print(O.to_qubit_operator(truncation=3, binary_encoding="one_hot").to_pauli())
-        # yields 0.375 + 0.375*Z(0) + 0.125*Z(0)*Z(1) - 0.375*Z(0)*Z(1)*Z(2) - 0.125*Z(0)*Z(2) + 0.125*Z(1) - 0.375*Z(1)*Z(2) - 0.125*Z(2)
+        # yields 0.375 + 0.375*Z(0) + 0.125*Z(0)*Z(1) - 0.375*Z(0)*Z(1)*Z(2)
+        # - 0.125*Z(0)*Z(2) + 0.125*Z(1) - 0.375*Z(1)*Z(2) - 0.125*Z(2)
 
         print(O.to_qubit_operator(truncation=8, binary_encoding="standard_binary").to_pauli())
         # yields 3.5 - 2.0*Z(0) - 1.0*Z(1) - 0.5*Z(2)
@@ -97,7 +124,9 @@ class BosonicOperator(Hamiltonian):
         print(O.to_qubit_operator(truncation=8, binary_encoding="gray_code").to_pauli())
         # yields 3.5 - 2.0*Z(0) - 1.0*Z(0)*Z(1) - 0.5*Z(0)*Z(1)*Z(2)
 
-    Create a bosonic Fock state $|3\rangle$ and compute the expectation value of the number operator for that state (it is important that the encoding and truncation are chosen the same for both the state preparation function and the expectation value method!):
+    Create a bosonic Fock state $|3\rangle$ and compute the expectation value of the number operator for that state
+    (it is important that the encoding and truncation are chosen the same
+    for both the state preparation function and the expectation value method!):
 
     ::
 
@@ -111,14 +140,21 @@ class BosonicOperator(Hamiltonian):
     """
 
     def __init__(self, terms_dict: dict = {}):
+        """Initialize from term list.
 
+        Parameters
+        ----------
+        terms_dict : dict
+            A dictionary containing the terms with which to initialize.
+
+        """
         self.terms_dict = dict(terms_dict)
 
     def reduce(self, assume_hermitian: bool = False):
-        """Applies the bosonic commutation laws to bring the operator into
-        a standard form. This can reduce the amount of terms because several
-        terms might be the permuted version of each other and therefore their
-        coefficients add up.
+        """Apply the bosonic commutation laws to bring the operator into a standard form.
+
+        This can reduce the amount of terms because several terms might be the permuted
+        version of each other and therefore their coefficients add up.
 
         This function can reduce the amount of terms even further if the user
         can guarantee that the operator will be hermitized. In this case more
@@ -183,10 +219,11 @@ class BosonicOperator(Hamiltonian):
         return BosonicOperator(new_terms_dict)
 
     def len(self):
+        """Return the number of terms."""
         return len(self.terms_dict)
 
     def coeffs(self):
-        """Returns the coefficients of the operator.
+        """Return the coefficients of the operator.
 
         Returns
         -------
@@ -213,12 +250,12 @@ class BosonicOperator(Hamiltonian):
         return f"${sp.latex(expr)}$"
 
     def __str__(self):
-        # Convert the sympy expression to a string and return it
+        """Convert the sympy expression to a string."""
         expr = self.to_expr()
         return str(expr)
 
     def to_expr(self):
-        """Returns a SymPy expression representing the operator.
+        """Return a SymPy expression representing the operator.
 
         Returns
         -------
@@ -236,7 +273,7 @@ class BosonicOperator(Hamiltonian):
     #
 
     def dagger(self):
-        r"""Returns the daggered/adjoint version of self.
+        r"""Return the daggered/adjoint version of self.
 
         Returns
         -------
@@ -262,7 +299,7 @@ class BosonicOperator(Hamiltonian):
         return BosonicOperator(terms_dict)
 
     def hermitize(self):
-        r"""Returns the hermitized version of self.
+        r"""Return the hermitized version of self.
 
         Returns
         -------
@@ -285,6 +322,7 @@ class BosonicOperator(Hamiltonian):
         return 0.5 * (self + self.dagger())
 
     def __eq__(self, other: Self):
+        """Check the equality of two operators."""
         reduced_self = self.reduce()
         reduced_other = other.reduce()
 
@@ -305,11 +343,16 @@ class BosonicOperator(Hamiltonian):
 
         return True
 
+    def __hash__(self):
+        """Return a hash value of the operator."""
+        return hash(frozenset([(k, v) for k, v in (self.terms_dict.items())]))
+
     def __neg__(self) -> Self:
+        """Return the negative of an operator."""
         return -1 * self
 
     def __add__(self, other: int | float | complex | Self) -> Self:
-        """Returns the sum of the operator self and other.
+        """Return the sum of the operator self and other.
 
         Parameters
         ----------
@@ -343,7 +386,7 @@ class BosonicOperator(Hamiltonian):
         return result
 
     def __sub__(self, other: int | float | complex | Self) -> Self:
-        """Returns the difference of the operator self and other.
+        """Return the difference of the operator self and other.
 
         Parameters
         ----------
@@ -377,7 +420,7 @@ class BosonicOperator(Hamiltonian):
         return result
 
     def __rsub__(self, other: int | float | complex | Self) -> Self:
-        """Returns the difference of the operator other and self.
+        """Return the difference of the operator other and self.
 
         Parameters
         ----------
@@ -411,7 +454,7 @@ class BosonicOperator(Hamiltonian):
         return result
 
     def __mul__(self, other: int | float | complex | Self) -> Self:
-        """Returns the product of the operator self and other.
+        """Return the product of the operator self and other.
 
         Parameters
         ----------
@@ -443,7 +486,7 @@ class BosonicOperator(Hamiltonian):
     __rmul__ = __mul__
 
     def __pow__(self, exp: int) -> Self:
-        """Returns the operator self exponentiated by int.
+        """Return the operator self exponentiated by int.
 
         Parameters
         ----------
@@ -470,7 +513,7 @@ class BosonicOperator(Hamiltonian):
     #
 
     def __iadd__(self, other: int | float | complex | Self) -> Self:
-        """Adds other to the operator self.
+        """Add other to the operator self.
 
         Parameters
         ----------
@@ -492,7 +535,7 @@ class BosonicOperator(Hamiltonian):
         return self
 
     def __isub__(self, other: int | float | complex | Self) -> Self:
-        """Substracts other from the operator self.
+        """Substract other from the operator self.
 
         Parameters
         ----------
@@ -513,7 +556,7 @@ class BosonicOperator(Hamiltonian):
         return self
 
     def __imul__(self, other: int | float | complex | Self) -> Self:
-        """Multiplys other to the operator self.
+        """Multiply other to the operator self.
 
         Parameters
         ----------
@@ -540,7 +583,7 @@ class BosonicOperator(Hamiltonian):
     #
 
     def apply_threshold(self, threshold: float):
-        """Removes all ladder_term terms with coefficient absolute value below the specified threshold.
+        """Remove all ladder_term terms with coefficient absolute value below the specified threshold.
 
         Parameters
         ----------
@@ -556,7 +599,7 @@ class BosonicOperator(Hamiltonian):
             del self.terms_dict[ladder_term]
 
     def to_sparse_matrix(self, truncation: int = 8, binary_encoding: str = "gray_code"):
-        """Returns a matrix representing the operator.
+        """Return a matrix representing the operator.
 
         Returns
         -------
@@ -564,13 +607,14 @@ class BosonicOperator(Hamiltonian):
             A sparse matrix representing the operator.
         truncation: How many bosonic occupation numbers to take into account.
         binary_encoding : string, optional
-            How to embed the bosonic terms into a QubitOperator. Possible values are "gray_code", "standard_binary" and "one_hot".
+            How to embed the bosonic terms into a QubitOperator.
+            Possible values are "gray_code", "standard_binary" and "one_hot".
 
         """
         return self.to_qubit_operator(truncation=truncation, binary_encoding=binary_encoding).to_sparse_matrix()
 
     def ground_state_energy(self, truncation: int = 8):
-        """Calculates the ground state energy (i.e., the minimum eigenvalue) of the operator classically.
+        """Calculate the ground state energy (i.e., the minimum eigenvalue) of the operator classically.
 
         Returns
         -------
@@ -581,15 +625,21 @@ class BosonicOperator(Hamiltonian):
         return self.to_qubit_operator(truncation=truncation).ground_state_energy()
 
     def to_qubit_operator(self, truncation: int = 8, binary_encoding: str = "gray_code"):
-        """Transforms the BosonicOperator to a :ref:`QubitOperator`.
-        To that end, the bosonic Fock space is truncated to ``truncation`` states. These states are encoded in qubit states by one of three methods, a one-hot, standard binary or Gray code representation. See the general documentation of :ref:`BosonicOperator` and https://www.nature.com/articles/s41534-020-0278-0 for more details.
+        """Transform the BosonicOperator to a :ref:`QubitOperator`.
+
+        To that end, the bosonic Fock space is truncated to ``truncation`` states.
+        These states are encoded in qubit states by one of three methods, a one-hot, standard binary
+        or Gray code representation.
+        See the general documentation of :ref:`BosonicOperator` and https://www.nature.com/articles/s41534-020-0278-0
+        for more details.
 
         Parameters
         ----------
         truncation : int, optional
             How many bosonic occupation numbers to take into account
         binary_encoding : str, optional
-            How to embed the bosonic terms into a QubitOperator. Possible values are "gray_code", "standard_binary" and "one_hot".
+            How to embed the bosonic terms into a QubitOperator. Possible values are "gray_code",
+            "standard_binary" and "one_hot".
 
         Returns
         -------
@@ -607,7 +657,8 @@ class BosonicOperator(Hamiltonian):
             O = c_b(0)*a_b(0)
 
             print(O.to_qubit_operator(truncation=3, binary_encoding="one_hot").to_pauli())
-            # yields 0.375 + 0.375*Z(0) + 0.125*Z(0)*Z(1) - 0.375*Z(0)*Z(1)*Z(2) - 0.125*Z(0)*Z(2) + 0.125*Z(1) - 0.375*Z(1)*Z(2) - 0.125*Z(2)
+            # yields 0.375 + 0.375*Z(0) + 0.125*Z(0)*Z(1) - 0.375*Z(0)*Z(1)*Z(2)
+            # - 0.125*Z(0)*Z(2) + 0.125*Z(1) - 0.375*Z(1)*Z(2) - 0.125*Z(2)
 
             print(O.to_qubit_operator(truncation=8, binary_encoding="standard_binary").to_pauli())
             # yields 3.5 - 2.0*Z(0) - 1.0*Z(1) - 0.5*Z(2)
@@ -627,7 +678,10 @@ class BosonicOperator(Hamiltonian):
     def expectation_value(
         self, state_prep: callable, truncation: int = 8, binary_encoding: str = "gray_code", **measurement_kwargs
     ):
-        r"""The ``expectation value`` function allows to estimate the expectation value of a Hamiltonian for a state that is specified by a preparation procedure.
+        r"""Return the expectation value of the operator.
+
+        This function allows to estimate the expectation value of a Hamiltonian for a state that is specified
+        by a preparation procedure.
         This preparation procedure can be supplied via a Python function that returns a :ref:`QuantumVariable`.
 
         Note that this method measures the **hermitized** version of the operator:
@@ -643,12 +697,16 @@ class BosonicOperator(Hamiltonian):
             A function returning a QuantumVariable.
             The expectation of the Hamiltonian for the state of this QuantumVariable will be measured.
             The state preparation function can only take classical values as arguments.
-            This is because a quantum value would need to be copied for each sampling iteration, which is prohibited by the no-cloning theorem.
-        truncation: How many bosonic occupation numbers to take into account.
+            This is because a quantum value would need to be copied for each sampling iteration,
+            which is prohibited by the no-cloning theorem.
+        truncation : int
+            How many bosonic occupation numbers to take into account.
         binary_encoding : string, optional
-            How to embed the bosonic terms into a QubitOperator. Possible values are "gray_code", "standard_binary" and "one_hot".
+            How to embed the bosonic terms into a QubitOperator. Possible values are "gray_code",
+            "standard_binary" and "one_hot".
         measurement_kwargs : dict, optional
-            The keyword arguments of :meth:`QubitOperator.expectation_value <qrisp.operators.qubit.QubitOperator.expectation_value>`.
+            The keyword arguments of
+            :meth:`QubitOperator.expectation_value <qrisp.operators.qubit.QubitOperator.expectation_value>`.
 
         Returns
         -------
@@ -658,7 +716,9 @@ class BosonicOperator(Hamiltonian):
 
         Examples
         --------
-        Create a bosonic Fock state $|3\rangle$ and compute the expectation value of the number operator for that state (it is important that the encoding and truncation are chosen the same for both the state preparation function and the expectation value method!):
+        Create a bosonic Fock state $|3\rangle$ and compute the expectation value of the number operator for that state
+        (it is important that the encoding and truncation are chosen the same
+        for both the state preparation function and the expectation value method!):
 
         ::
 
@@ -666,7 +726,11 @@ class BosonicOperator(Hamiltonian):
 
             O = c_b(0)*a_b(0)
 
-            O.expectation_value(prepare_bosonic_fock_state, truncation=8, binary_encoding="gray_code")(3, 8, "gray_code")
+            O.expectation_value(
+                    prepare_bosonic_fock_state,
+                    truncation=8,
+                    binary_encoding="gray_code"
+                )(3, 8, "gray_code")
             # yields 2.9999999999999996
 
         """
@@ -678,19 +742,26 @@ class BosonicOperator(Hamiltonian):
     #
 
     def trotterization(self, truncation: int = 8, binary_encoding: str = "gray_code", forward_evolution: bool = True):
-        r"""Returns a function for performing Hamiltonian simulation, i.e., approximately implementing the unitary operator $U(t) = e^{-itH}$ via Trotterization.
+        r"""Return a function for performing Hamiltonian simulation.
+
+        I.e. this method returns a function that approximately implements
+        the unitary operator $U(t) = e^{-itH}$ via Trotterization.
 
         Parameters
         ----------
         truncation : int, optional
             How many bosonic occupation numbers to take into account
         binary_encoding : str, optional
-            How to embed the bosonic terms into a QubitOperator. Possible values are "gray_code", "standard_binary" and "one_hot".
+            How to embed the bosonic terms into a QubitOperator. Possible values are "gray_code",
+            "standard_binary" and "one_hot".
+        forward_evolution : bool, optional
+            If true, evolve forwards in time, else backwards.
 
         Returns
         -------
         callable
-            A function that takes a quantum variable qv and a time t as arguments and applies an evolution of exp(-itH) to qv, with H being the `BosonicOperator` instance itself.
+            A function that takes a quantum variable qv and a time t as arguments and applies an evolution
+            of exp(-itH) to qv, with H being the `BosonicOperator` instance itself.
 
         Examples
         --------
@@ -711,30 +782,49 @@ class BosonicOperator(Hamiltonian):
         qubit_operator = self.to_qubit_operator(truncation=truncation, binary_encoding=binary_encoding)
         return qubit_operator.trotterization(forward_evolution=forward_evolution)
 
-    def group_up(self, denominator: callable):
-        term_groups = group_up_iterable(list(self.terms_dict.keys()), denominator)
-        if len(term_groups) == 0:
-            return [self]
-        groups = []
-        for term_group in term_groups:
-            O = BosonicOperator({term: self.terms_dict[term] for term in term_group})
-            groups.append(O)
-
-        return groups
-
 
 def get_bosonic_encoding_qubit_number(truncation, binary_encoding):
+    """Return the number of qubits a particular bosonic encoding consumes.
+
+    Parameters
+    ----------
+    truncation : int
+       How many bosonic occupation numbers to take into account.
+    binary_encoding : str, optional
+        How to embed the bosonic terms into a QubitOperator. Possible values are "gray_code",
+        "standard_binary" and "one_hot".
+
+    Returns
+    -------
+    int
+        The number of qubits.
+
+    """
     if binary_encoding != "one_hot":
         return int(np.ceil(np.log2(truncation)))
     else:
         return truncation
 
 
-from qrisp.operators.bosonic.bosonic_term import gray_code, standard_binary, one_hot
-from qrisp import QuantumVariable, x
-
-
 def prepare_bosonic_fock_state(n: int, truncation: int = 8, binary_encoding: str = "gray_code"):
+    """Return a QuantumVariable with a bosonic Fock state prepared on it.
+
+    Parameters
+    ----------
+    n : int
+       The occupation number of the Fock state.
+    truncation : int, optional
+       How many bosonic occupation numbers to take into account.
+    binary_encoding : str, optional
+        How to embed the bosonic terms into a QubitOperator. Possible values are "gray_code",
+        "standard_binary" and "one_hot".
+
+    Returns
+    -------
+    QuantumVariable
+        A QuantumVariable with the Fock state prepared on it.
+
+    """
     if not 0 <= n < truncation:
         raise ValueError("n must be between 0 an truncation-1")
 

--- a/src/qrisp/operators/bosonic/bosonic_term.py
+++ b/src/qrisp/operators/bosonic/bosonic_term.py
@@ -20,6 +20,7 @@
 #
 import numpy as np
 import warnings
+from typing import Self
 
 from qrisp.operators.bosonic.visualization import a_, c_
 from qrisp.operators.qubit import A, C, Z, P0, P1
@@ -46,7 +47,7 @@ class BosonicTerm:
     def __hash__(self):
         return self.hash_value
 
-    def __eq__(self, other):
+    def __eq__(self, other: Self):
         return self.hash_value == other.hash_value
 
     def copy(self):
@@ -93,7 +94,7 @@ class BosonicTerm:
     # Arithmetic
     #
 
-    def __mul__(self, other):
+    def __mul__(self, other: Self):
         result_ladder_list = other.ladder_list + self.ladder_list
         return BosonicTerm(result_ladder_list)
 
@@ -124,21 +125,21 @@ class BosonicTerm:
 
         return BosonicTerm(ladder_list)
 
-    def bosonic_swap(self, permutation):
+    def bosonic_swap(self, permutation: list):
 
         permutation = [permutation.index(i) for i in range(len(permutation))]
         new_ladder_list = [(permutation[i], is_creator) for i, is_creator in self.ladder_list]
 
         return BosonicTerm(new_ladder_list)
 
-    def unipolars_intersect(self, other):
+    def unipolars_intersect(self, other: Self):
         """Checks if two terms have intersecting unipolar factos.
         Unipolar factors are factors that are not of the form a(i)*c(i),
         i.e. the index i appears only once.
         """
         return len(set(self.get_unipolars()).intersection(other.get_unipolars())) != 0
 
-    def unipolars_agree(self, other):
+    def unipolars_agree(self, other: Self):
         """Checks if two terms have intersecting unipolar factos.
         Unipolar factors are factors that are not of the form a(i)*c(i),
         i.e. the index i appears only once.
@@ -163,7 +164,7 @@ class BosonicTerm:
             self.unipolars = index_list[::-1]
             return list(self.unipolars)
 
-    def to_qubit_term(self, truncation=8, binary_encoding="gray_code"):
+    def to_qubit_term(self, truncation: int = 8, binary_encoding: str = "gray_code"):
         """Maps a bosonic term to a qubit term.
         Since bosonic operators act on an infinite-dimensional space, a truncation to a finite
         number of bosonic occupation numbers is necessary (provided by the "truncation" argument).
@@ -231,17 +232,17 @@ class BosonicTerm:
 
 
 # Bosonic annihilation operator in matrix representation
-def a_matrix(N):
+def a_matrix(N: int):
     return np.diag(np.sqrt(np.arange(1, N)), k=1).astype(complex)
 
 
 # Bosonic creation operator in matrix representation
-def c_matrix(N):
+def c_matrix(N: int):
     return np.diag(np.sqrt(np.arange(1, N)), k=-1).astype(complex)
 
 
 # Return the Gray code
-def gray_code(n):
+def gray_code(n: int):
     code = []
     for i in range(n):
         temp = []
@@ -257,16 +258,15 @@ def gray_code(n):
     return np.transpose(np.asarray(code)).tolist()
 
 
-# Return standard binary
-def standard_binary(n):
-    code = []
-    for i in range(2**n):
-        code.append([int(x) for x in bin(i)[2:].rjust(n, "0")])
-    return code
+from itertools import product
+
+def standard_binary(n: int):
+    # product returns tuples like (0, 1, 0), so we convert them to lists
+    return [list(bits) for bits in product((0, 1), repeat=n)]
 
 
 # Return one-hot encoding
-def one_hot(n):
+def one_hot(n: int):
     code = []
     for i in range(n):
         code.append(i * [0] + [1] + (n - i - 1) * [0])

--- a/src/qrisp/operators/bosonic/bosonic_term.py
+++ b/src/qrisp/operators/bosonic/bosonic_term.py
@@ -149,13 +149,18 @@ class BosonicTerm:
 
         for ind in indices_present:
             ladder_ops = [x[1] for x in self.ladder_list if x[0] == ind]
+            k = sum(ladder_ops)     # number of creators
+
             # bring term into matrix form
-            M = np.identity(truncation)
+            M = np.identity(truncation+k)   # by temporarily increasing the matrix size to truncation+k we avoid ambiguities due to
+                                            # intermediate running out of truncated space (corresponds to normal ordering the operator first)
             for l in ladder_ops:
                 if l:
-                    M = c_matrix(truncation) @ M
+                    M = c_matrix(truncation+k) @ M
                 else:
-                    M = a_matrix(truncation) @ M
+                    M = a_matrix(truncation+k) @ M
+
+            M = M[:truncation, :truncation]
 
             temp = 0
             for i in range(truncation):

--- a/src/qrisp/operators/bosonic/bosonic_term.py
+++ b/src/qrisp/operators/bosonic/bosonic_term.py
@@ -98,25 +98,6 @@ class BosonicTerm:
         result_ladder_list = other.ladder_list + self.ladder_list
         return BosonicTerm(result_ladder_list)
 
-    def order(self):
-        """Not that important, since relevant Hamiltonians consist of ordered terms.
-        What is needed for trotterization?
-
-        Bosonic commutation relations:
-
-        [a_i,a_j^dagger] = a_i*a_j^dagger - a_j^dagger*a_i = delta_{ij}
-        [a_i^dagger,a_j^dagger] = [a_i,a_j] = 0
-
-
-        Order ladder terms such that
-            1) Raising operators preceed lowering operators
-            2) Operators are ordered in descending order of bosonic modes
-
-        Example: a_5^dagger a_2^dagger a_3 a_1
-
-        """
-        pass
-
     def sort(self):
         # Sort ladder operators (ladder operator semantics are order independent)
         sorting_list = [-index for index, is_creator in self.ladder_list]
@@ -124,45 +105,6 @@ class BosonicTerm:
         ladder_list = [self.ladder_list[i] for i in perm]
 
         return BosonicTerm(ladder_list)
-
-    def bosonic_swap(self, permutation: list):
-
-        permutation = [permutation.index(i) for i in range(len(permutation))]
-        new_ladder_list = [(permutation[i], is_creator) for i, is_creator in self.ladder_list]
-
-        return BosonicTerm(new_ladder_list)
-
-    def unipolars_intersect(self, other: Self):
-        """Checks if two terms have intersecting unipolar factos.
-        Unipolar factors are factors that are not of the form a(i)*c(i),
-        i.e. the index i appears only once.
-        """
-        return len(set(self.get_unipolars()).intersection(other.get_unipolars())) != 0
-
-    def unipolars_agree(self, other: Self):
-        """Checks if two terms have intersecting unipolar factos.
-        Unipolar factors are factors that are not of the form a(i)*c(i),
-        i.e. the index i appears only once.
-        """
-        return set(self.get_unipolars()) == set(other.get_unipolars())
-
-    def get_unipolars(self):
-        if hasattr(self, "unipolars"):
-            return list(self.unipolars)
-        else:
-            index_list = [index for index, is_creator in self.ladder_list]
-            index_list.sort()
-
-            i = 0
-            while i < len(index_list) - 1:
-                if index_list[i] == index_list[i + 1]:
-                    index_list.pop(i)
-                    index_list.pop(i)
-                    continue
-                i += 1
-
-            self.unipolars = index_list[::-1]
-            return list(self.unipolars)
 
     def to_qubit_term(self, truncation: int = 8, binary_encoding: str = "gray_code"):
         """Maps a bosonic term to a qubit term.

--- a/src/qrisp/operators/bosonic/bosonic_term.py
+++ b/src/qrisp/operators/bosonic/bosonic_term.py
@@ -260,6 +260,7 @@ def gray_code(n: int):
 
 from itertools import product
 
+
 def standard_binary(n: int):
     # product returns tuples like (0, 1, 0), so we convert them to lists
     return [list(bits) for bits in product((0, 1), repeat=n)]

--- a/src/qrisp/operators/bosonic/bosonic_term.py
+++ b/src/qrisp/operators/bosonic/bosonic_term.py
@@ -19,6 +19,7 @@
 # BosonicTerm
 #
 import numpy as np
+import warnings
 
 from qrisp.operators.fermionic.visualization import a_, c_
 from qrisp.operators.qubit import A, C, Z, P0, P1
@@ -169,16 +170,30 @@ class BosonicTerm:
         For their embedding into qubits, an arbitrary binary encoding can be chosen,
         but the Gray encoding appears tailor-made for the structure of ladder operators.
         """
-        if not np.isclose(np.log2(truncation)%1, 0):
-            raise Warning("truncation is not a power of 2, could be chosen larger with same amount of qubits.")
+        if not np.isclose(np.log2(truncation)%1, 0) and binary_encoding != "one_hot":
+            warnings.warn("truncation is not a power of 2, could be chosen larger with same amount of qubits.")
         if binary_encoding == "gray_code":
             encoder = gray_code
+        elif binary_encoding == "standard_binary":
+            encoder = standard_binary
+        elif binary_encoding == "one_hot":
+            encoder = one_hot
         else:
             raise Exception(f"Don't know binary encoding type {binary_encoding}")
+            
+        gate_mapping = {
+                (0, 0): P0,
+                (1, 1): P1,
+                (0, 1): A,
+                (1, 0): C
+            }
         
-        indices_present = set([x[0] for x in ladder_list])
+        indices_present = set([x[0] for x in self.ladder_list])
         
-        n_qubits = int(np.log2(truncation)) + 1
+        if binary_encoding != "one_hot":
+            n_qubits = int(np.ceil(np.log2(truncation)))
+        else:
+            n_qubits = truncation
         
         binary_rep = encoder(n_qubits)
         
@@ -198,17 +213,12 @@ class BosonicTerm:
             for i in range(truncation):
                 for j in range(truncation):
                     if not np.isclose(M[i][j], 0.):
+                        temp2 = 1
                         for k in range(n_qubits):
                             c1, c2 = binary_rep[i][k], binary_rep[j][k]
-                            qb_ind = ind*n_qubits+k
-                            if (c1, c2) == (0, 0):
-                                temp += M[i][j] * P0(qb_ind)
-                            elif (c1, c2) == (1, 1):
-                                temp += M[i][j] * P1(qb_ind)
-                            elif (c1, c2) == (0, 1):
-                                temp += M[i][j] * A(qb_ind)
-                            elif (c1, c2) == (1, 0):
-                                temp += M[i][j] * C(qb_ind)
+                            qb_ind = ind*n_qubits + k
+                            temp2 *= gate_mapping[(c1, c2)](qb_ind)
+                        temp += M[i][j] * temp2
             
             res *= temp
       
@@ -228,7 +238,7 @@ def c_matrix(N):
             k=-1
         ).astype(complex)
 
-#Compute the Gray code
+#Return the Gray code
 def gray_code(n):
     code = []
     for i in range(n):
@@ -243,3 +253,17 @@ def gray_code(n):
         code.append(temp)
 
     return np.transpose(np.asarray(code)).tolist()
+    
+#Return standard binary
+def standard_binary(n):
+    code = []
+    for i in range(2**n):
+        code.append([int(x) for x in bin(i)[:1:-1].ljust(n,'0')])
+    return code
+
+#Return one-hot encoding
+def one_hot(n):
+    code = []
+    for i in range(n):
+        code.append(i*[0] + [1] + (n-i-1)*[0]) 
+    return code

--- a/src/qrisp/operators/bosonic/bosonic_term.py
+++ b/src/qrisp/operators/bosonic/bosonic_term.py
@@ -27,7 +27,11 @@ from qrisp.operators.qubit import A, C, Z, P0, P1
 
 
 class BosonicTerm:
-    r""" """
+    r"""This class implements single bosonic terms, which are the constituents of `BosonicOperators`.
+    Such terms are internally represented by a list of 2-tuples, which store the modes onto which the ladder operators act and whether they are creation or annihilation operators.
+    For details on the conversion of bosonic operators to qubit operators and examples, see the documentation of the `BosonicOperator` class.
+
+    """
 
     def __init__(self, ladder_list=[]):
 
@@ -121,7 +125,13 @@ class BosonicTerm:
             The number of bosonic occupation numbers one wants to describe.
             Note that 0 also counts as an occupation number, so occupation numbers from 0 to truncation-1 are represented.
         binary_encoding: str, optional
-            How to embed the bosonic matrix into qubits. Possible values are "gray_code", "standard_binary" and "one_hot".
+            How to embed the bosonic matrix into qubits. Possible values are "gray_code", "standard_binary" and "one_hot". Default is "gray_code".
+
+        Returns
+        -------
+        QubitOperator
+            The qubit operator representation of the term. Depending on the binary_encoding, the size of the qubit operator is either equal to `truncation` ("one_hot" encoding) or to `int(np.ceil(np.log2(truncation)))` ("gray_code" and "standard_binary" encoding).
+
         """
         if not np.isclose(np.log2(truncation) % 1, 0) and binary_encoding != "one_hot":
             warnings.warn("truncation is not a power of 2, could be chosen larger with same amount of qubits.")
@@ -149,16 +159,17 @@ class BosonicTerm:
 
         for ind in indices_present:
             ladder_ops = [x[1] for x in self.ladder_list if x[0] == ind]
-            k = sum(ladder_ops)     # number of creators
+            k = sum(ladder_ops)  # number of creators
 
             # bring term into matrix form
-            M = np.identity(truncation+k)   # by temporarily increasing the matrix size to truncation+k we avoid ambiguities due to
-                                            # intermediate running out of truncated space (corresponds to normal ordering the operator first)
+            M = np.identity(
+                truncation + k
+            )  # by temporarily increasing the matrix size to truncation+k we avoid ambiguities due to intermediate running out of truncated space (corresponds to normal ordering the operator before truncation)
             for l in ladder_ops:
                 if l:
-                    M = c_matrix(truncation+k) @ M
+                    M = c_matrix(truncation + k) @ M
                 else:
-                    M = a_matrix(truncation+k) @ M
+                    M = a_matrix(truncation + k) @ M
 
             M = M[:truncation, :truncation]
 

--- a/src/qrisp/operators/bosonic/bosonic_term.py
+++ b/src/qrisp/operators/bosonic/bosonic_term.py
@@ -1,0 +1,245 @@
+"""********************************************************************************
+* Copyright (c) 2024 the Qrisp authors
+*
+* This program and the accompanying materials are made available under the
+* terms of the Eclipse Public License 2.0 which is available at
+* http://www.eclipse.org/legal/epl-2.0.
+*
+* This Source Code may also be made available under the following Secondary
+* Licenses when the conditions for such availability set forth in the Eclipse
+* Public License, v. 2.0 are satisfied: GNU General Public License, version 2
+* with the GNU Classpath Exception which is
+* available at https://www.gnu.org/software/classpath/license.html.
+*
+* SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+********************************************************************************
+"""
+
+#
+# BosonicTerm
+#
+import numpy as np
+
+from qrisp.operators.fermionic.visualization import a_, c_
+from qrisp.operators.qubit import A, C, Z, P0, P1
+
+
+class BosonicTerm:
+    r""" """
+
+    def __init__(self, ladder_list=[]):
+
+        self.ladder_list = ladder_list
+
+        # Compute the hash value such that
+        # terms receive the same hash as their hermitean conjugate
+        # this way the BosonicOperator does not have
+        # to track both the term and it's dagger
+        index_list = [index for index, is_creator in ladder_list]
+        is_creator_hash = 0
+        for i in range(len(ladder_list)):
+            is_creator_hash += ladder_list[i][1] * 2**i
+
+        self.hash_value = hash(tuple(index_list + [is_creator_hash]))
+
+    def __hash__(self):
+        return self.hash_value
+
+    def __eq__(self, other):
+        return self.hash_value == other.hash_value
+
+    def copy(self):
+        return BosonicTerm(self.ladder_list.copy())
+
+    def dagger(self):
+        return BosonicTerm([(index, not is_creator) for index, is_creator in self.ladder_list[::-1]])
+
+    #
+    # Printing
+    #
+
+    def __str__(self):
+        # Convert the sympy expression to a string and return it
+        expr = self.to_expr()
+        return str(expr)
+
+    def __repr__(self):
+        return str(self)
+
+    def to_expr(self):
+        """Returns a SymPy expression representing the BosonicTerm.
+
+        Returns
+        -------
+        expr : sympy.expr
+            A SymPy expression representing the BosonicTerm.
+
+        """
+
+        def to_ladder(value, index):
+            if value:
+                return c_(index)
+            else:
+                return a_(index)
+
+        expr = 1
+        for index, value in self.ladder_list[::-1]:
+            expr *= to_ladder(value, str(index))
+
+        return expr
+
+    #
+    # Arithmetic
+    #
+
+    def __mul__(self, other):
+        result_ladder_list = other.ladder_list + self.ladder_list
+        return BosonicTerm(result_ladder_list)
+
+    def order(self):
+        """Not that important, since relevant Hamiltonians (e.g., electronic structure) consist of ordered terms.
+        What is needed for trotterization?
+
+        Bosonic commutation relations:
+
+        [a_i,a_j^dagger] = a_i*a_j^dagger - a_j^dagger*a_i = delta_{ij}
+        [a_i^dagger,a_j^dagger] = [a_i,a_j] = 0
+
+
+        Order ladder terms such that
+            1) Raising operators preceed lowering operators
+            2) Operators are ordered in descending order of fermionic modes
+
+        Example: a_5^dagger a_2^dagger a_3 a_1
+
+        """
+        pass
+
+    def sort(self):
+        # Sort ladder operators (ladder operator semantics are order in-dependent)
+        sorting_list = [-index for index, is_creator in self.ladder_list]
+        perm = np.argsort(sorting_list, kind="stable")
+        ladder_list = [self.ladder_list[i] for i in perm]
+
+        return BosonicTerm(ladder_list)
+
+    def bosonic_swap(self, permutation):
+
+        permutation = [permutation.index(i) for i in range(len(permutation))]
+        new_ladder_list = [(permutation[i], is_creator) for i, is_creator in self.ladder_list]
+
+        return BosonicTerm(new_ladder_list)
+
+    def unipolars_intersect(self, other):
+        """Checks if two terms have intersecting unipolar factos.
+        Unipolar factors are factors that are not of the form a(i)*c(i),
+        i.e. the index i appears only once.
+        """
+        return len(set(self.get_unipolars()).intersection(other.get_unipolars())) != 0
+
+    def unipolars_agree(self, other):
+        """Checks if two terms have intersecting unipolar factos.
+        Unipolar factors are factors that are not of the form a(i)*c(i),
+        i.e. the index i appears only once.
+        """
+        return set(self.get_unipolars()) == set(other.get_unipolars())
+
+    def get_unipolars(self):
+        if hasattr(self, "unipolars"):
+            return list(self.unipolars)
+        else:
+            index_list = [index for index, is_creator in self.ladder_list]
+            index_list.sort()
+
+            i = 0
+            while i < len(index_list) - 1:
+                if index_list[i] == index_list[i + 1]:
+                    index_list.pop(i)
+                    index_list.pop(i)
+                    continue
+                i += 1
+
+            self.unipolars = index_list[::-1]
+            return list(self.unipolars)
+
+    def to_qubit_term(self, truncation=8, binary_encoding="gray_code"):
+        """Maps a bosonic term to a qubit term. 
+        Since bosonic operators act on an infinite-dimensional space, a truncation to a finite
+        number of bosonic occupation numbers is necessary (provided by the "truncation" argument).
+        For their embedding into qubits, an arbitrary binary encoding can be chosen,
+        but the Gray encoding appears tailor-made for the structure of ladder operators.
+        """
+        if not np.isclose(np.log2(truncation)%1, 0):
+            raise Warning("truncation is not a power of 2, could be chosen larger with same amount of qubits.")
+        if binary_encoding == "gray_code":
+            encoder = gray_code
+        else:
+            raise Exception(f"Don't know binary encoding type {binary_encoding}")
+        
+        indices_present = set([x[0] for x in ladder_list])
+        
+        n_qubits = int(np.log2(truncation)) + 1
+        
+        binary_rep = encoder(n_qubits)
+        
+        res = 1
+        
+        for ind in indices_present:
+            ladder_ops = [x[1] for x in self.ladder_list if x[0] == ind]
+            #bring term into matrix form
+            M = np.identity(truncation)
+            for l in ladder_ops:
+                if l:
+                    M = c_matrix(truncation) @ M
+                else:
+                    M = a_matrix(truncation) @ M
+
+            temp = 0
+            for i in range(truncation):
+                for j in range(truncation):
+                    if not np.isclose(M[i][j], 0.):
+                        for k in range(n_qubits):
+                            c1, c2 = binary_rep[i][k], binary_rep[j][k]
+                            qb_ind = ind*n_qubits+k
+                            if (c1, c2) == (0, 0):
+                                temp += M[i][j] * P0(qb_ind)
+                            elif (c1, c2) == (1, 1):
+                                temp += M[i][j] * P1(qb_ind)
+                            elif (c1, c2) == (0, 1):
+                                temp += M[i][j] * A(qb_ind)
+                            elif (c1, c2) == (1, 0):
+                                temp += M[i][j] * C(qb_ind)
+            
+            res *= temp
+      
+        return res
+  
+#Bosonic annihilation operator in matrix representation    
+def a_matrix(N):
+    return np.diag(
+            np.sqrt(np.arange(1, N)), 
+            k=1
+        ).astype(complex)
+
+#Bosonic creation operator in matrix representation            
+def c_matrix(N):
+    return np.diag(
+            np.sqrt(np.arange(1, N)),
+            k=-1
+        ).astype(complex)
+
+#Compute the Gray code
+def gray_code(n):
+    code = []
+    for i in range(n):
+        temp = []
+        block1 = (2**i)*[0]+(2**i)*[1]
+        block2 = (2**i)*[1]+(2**i)*[0]
+        for j in range(2**(n-i-1)):
+            if j%2==0:
+                temp += block1
+            else:
+                temp += block2
+        code.append(temp)
+
+    return np.transpose(np.asarray(code)).tolist()

--- a/src/qrisp/operators/bosonic/bosonic_term.py
+++ b/src/qrisp/operators/bosonic/bosonic_term.py
@@ -245,9 +245,9 @@ def gray_code(n):
     code = []
     for i in range(n):
         temp = []
-        block1 = (2**i) * [0] + (2**i) * [1]
-        block2 = (2**i) * [1] + (2**i) * [0]
-        for j in range(2 ** (n - i - 1)):
+        block1 = (2 ** (n - i - 1)) * [0] + (2 ** (n - i - 1)) * [1]
+        block2 = (2 ** (n - i - 1)) * [1] + (2 ** (n - i - 1)) * [0]
+        for j in range(2**i):
             if j % 2 == 0:
                 temp += block1
             else:
@@ -261,7 +261,7 @@ def gray_code(n):
 def standard_binary(n):
     code = []
     for i in range(2**n):
-        code.append([int(x) for x in bin(i)[:1:-1].ljust(n, "0")])
+        code.append([int(x) for x in bin(i)[2:].rjust(n, "0")])
     return code
 
 

--- a/src/qrisp/operators/bosonic/bosonic_term.py
+++ b/src/qrisp/operators/bosonic/bosonic_term.py
@@ -21,7 +21,7 @@
 import numpy as np
 import warnings
 
-from qrisp.operators.fermionic.visualization import a_, c_
+from qrisp.operators.bosonic.visualization import a_, c_
 from qrisp.operators.qubit import A, C, Z, P0, P1
 
 
@@ -98,7 +98,7 @@ class BosonicTerm:
         return BosonicTerm(result_ladder_list)
 
     def order(self):
-        """Not that important, since relevant Hamiltonians (e.g., electronic structure) consist of ordered terms.
+        """Not that important, since relevant Hamiltonians consist of ordered terms.
         What is needed for trotterization?
 
         Bosonic commutation relations:
@@ -109,7 +109,7 @@ class BosonicTerm:
 
         Order ladder terms such that
             1) Raising operators preceed lowering operators
-            2) Operators are ordered in descending order of fermionic modes
+            2) Operators are ordered in descending order of bosonic modes
 
         Example: a_5^dagger a_2^dagger a_3 a_1
 
@@ -164,13 +164,23 @@ class BosonicTerm:
             return list(self.unipolars)
 
     def to_qubit_term(self, truncation=8, binary_encoding="gray_code"):
-        """Maps a bosonic term to a qubit term. 
+        """Maps a bosonic term to a qubit term.
         Since bosonic operators act on an infinite-dimensional space, a truncation to a finite
         number of bosonic occupation numbers is necessary (provided by the "truncation" argument).
         For their embedding into qubits, an arbitrary binary encoding can be chosen,
         but the Gray encoding appears tailor-made for the structure of ladder operators.
+        Apart from the Gray encoding, a standard binary and a one-hot encoding are provided.
+        https://www.nature.com/articles/s41534-020-0278-0 contains more details on their respective advantages and disadvantages.
+
+        Parameters
+        ----------
+        truncation: int, optional
+            The number of bosonic occupation numbers one wants to describe.
+            Note that 0 also counts as an occupation number, so occupation numbers from 0 to truncation-1 are represented.
+        binary_encoding: str, optional
+            How to embed the bosonic matrix into qubits. Possible values are "gray_code", "standard_binary" and "one_hot".
         """
-        if not np.isclose(np.log2(truncation)%1, 0) and binary_encoding != "one_hot":
+        if not np.isclose(np.log2(truncation) % 1, 0) and binary_encoding != "one_hot":
             warnings.warn("truncation is not a power of 2, could be chosen larger with same amount of qubits.")
         if binary_encoding == "gray_code":
             encoder = gray_code
@@ -180,28 +190,23 @@ class BosonicTerm:
             encoder = one_hot
         else:
             raise Exception(f"Don't know binary encoding type {binary_encoding}")
-            
-        gate_mapping = {
-                (0, 0): P0,
-                (1, 1): P1,
-                (0, 1): A,
-                (1, 0): C
-            }
-        
+
+        gate_mapping = {(0, 0): P0, (1, 1): P1, (0, 1): A, (1, 0): C}
+
         indices_present = set([x[0] for x in self.ladder_list])
-        
+
         if binary_encoding != "one_hot":
             n_qubits = int(np.ceil(np.log2(truncation)))
         else:
             n_qubits = truncation
-        
+
         binary_rep = encoder(n_qubits)
-        
+
         res = 1
-        
+
         for ind in indices_present:
             ladder_ops = [x[1] for x in self.ladder_list if x[0] == ind]
-            #bring term into matrix form
+            # bring term into matrix form
             M = np.identity(truncation)
             for l in ladder_ops:
                 if l:
@@ -212,58 +217,57 @@ class BosonicTerm:
             temp = 0
             for i in range(truncation):
                 for j in range(truncation):
-                    if not np.isclose(M[i][j], 0.):
+                    if not np.isclose(M[i][j], 0.0):
                         temp2 = 1
                         for k in range(n_qubits):
                             c1, c2 = binary_rep[i][k], binary_rep[j][k]
-                            qb_ind = ind*n_qubits + k
+                            qb_ind = ind * n_qubits + k
                             temp2 *= gate_mapping[(c1, c2)](qb_ind)
                         temp += M[i][j] * temp2
-            
+
             res *= temp
-      
+
         return res
-  
-#Bosonic annihilation operator in matrix representation    
+
+
+# Bosonic annihilation operator in matrix representation
 def a_matrix(N):
-    return np.diag(
-            np.sqrt(np.arange(1, N)), 
-            k=1
-        ).astype(complex)
+    return np.diag(np.sqrt(np.arange(1, N)), k=1).astype(complex)
 
-#Bosonic creation operator in matrix representation            
+
+# Bosonic creation operator in matrix representation
 def c_matrix(N):
-    return np.diag(
-            np.sqrt(np.arange(1, N)),
-            k=-1
-        ).astype(complex)
+    return np.diag(np.sqrt(np.arange(1, N)), k=-1).astype(complex)
 
-#Return the Gray code
+
+# Return the Gray code
 def gray_code(n):
     code = []
     for i in range(n):
         temp = []
-        block1 = (2**i)*[0]+(2**i)*[1]
-        block2 = (2**i)*[1]+(2**i)*[0]
-        for j in range(2**(n-i-1)):
-            if j%2==0:
+        block1 = (2**i) * [0] + (2**i) * [1]
+        block2 = (2**i) * [1] + (2**i) * [0]
+        for j in range(2 ** (n - i - 1)):
+            if j % 2 == 0:
                 temp += block1
             else:
                 temp += block2
         code.append(temp)
 
     return np.transpose(np.asarray(code)).tolist()
-    
-#Return standard binary
+
+
+# Return standard binary
 def standard_binary(n):
     code = []
     for i in range(2**n):
-        code.append([int(x) for x in bin(i)[:1:-1].ljust(n,'0')])
+        code.append([int(x) for x in bin(i)[:1:-1].ljust(n, "0")])
     return code
 
-#Return one-hot encoding
+
+# Return one-hot encoding
 def one_hot(n):
     code = []
     for i in range(n):
-        code.append(i*[0] + [1] + (n-i-1)*[0]) 
+        code.append(i * [0] + [1] + (n - i - 1) * [0])
     return code

--- a/src/qrisp/operators/bosonic/bosonic_term.py
+++ b/src/qrisp/operators/bosonic/bosonic_term.py
@@ -118,7 +118,7 @@ class BosonicTerm:
         pass
 
     def sort(self):
-        # Sort ladder operators (ladder operator semantics are order in-dependent)
+        # Sort ladder operators (ladder operator semantics are order independent)
         sorting_list = [-index for index, is_creator in self.ladder_list]
         perm = np.argsort(sorting_list, kind="stable")
         ladder_list = [self.ladder_list[i] for i in perm]

--- a/src/qrisp/operators/bosonic/bosonic_term.py
+++ b/src/qrisp/operators/bosonic/bosonic_term.py
@@ -1,4 +1,5 @@
 """********************************************************************************
+
 * Copyright (c) 2024 the Qrisp authors
 *
 * This program and the accompanying materials are made available under the
@@ -13,28 +14,42 @@
 *
 * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
 ********************************************************************************
+
 """
 
 #
 # BosonicTerm
 #
-import numpy as np
 import warnings
+from itertools import product
 from typing import Self
 
+import numpy as np
+
 from qrisp.operators.bosonic.visualization import a_, c_
-from qrisp.operators.qubit import A, C, Z, P0, P1
+from qrisp.operators.qubit import P0, P1, A, C
 
 
 class BosonicTerm:
-    r"""This class implements single bosonic terms, which are the constituents of `BosonicOperators`.
-    Such terms are internally represented by a list of 2-tuples, which store the modes onto which the ladder operators act and whether they are creation or annihilation operators.
-    For details on the conversion of bosonic operators to qubit operators and examples, see the documentation of the `BosonicOperator` class.
+    r"""Implementation of single bosonic terms, which are the constituents of `BosonicOperators`.
+
+    Such terms are internally represented by a list of 2-tuples, which store the modes
+    onto which the ladder operators act and whether they are creation or annihilation operators.
+    For details on the conversion of bosonic operators to qubit operators and examples,
+    see the documentation of the `BosonicOperator` class.
 
     """
 
     def __init__(self, ladder_list=[]):
+        """Create bosonic term from ladder list.
 
+        Parameters
+        ----------
+        ladder_list : list
+            list of (int, bool) tuples containing the index of a ladder operator
+            and whether it is a creator.
+
+        """
         self.ladder_list = ladder_list
 
         # Compute the hash value such that
@@ -49,15 +64,19 @@ class BosonicTerm:
         self.hash_value = hash(tuple(index_list + [is_creator_hash]))
 
     def __hash__(self):
+        """Return hash value."""
         return self.hash_value
 
     def __eq__(self, other: Self):
+        """Check if two terms are identical."""
         return self.hash_value == other.hash_value
 
     def copy(self):
+        """Copy term."""
         return BosonicTerm(self.ladder_list.copy())
 
     def dagger(self):
+        """Return daggered version of term."""
         return BosonicTerm([(index, not is_creator) for index, is_creator in self.ladder_list[::-1]])
 
     #
@@ -65,15 +84,16 @@ class BosonicTerm:
     #
 
     def __str__(self):
-        # Convert the sympy expression to a string and return it
+        """Convert the sympy expression to a string and return it."""
         expr = self.to_expr()
         return str(expr)
 
     def __repr__(self):
+        """Convert the sympy expression to a string and return it."""
         return str(self)
 
     def to_expr(self):
-        """Returns a SymPy expression representing the BosonicTerm.
+        """Return a SymPy expression representing the BosonicTerm.
 
         Returns
         -------
@@ -99,11 +119,12 @@ class BosonicTerm:
     #
 
     def __mul__(self, other: Self):
+        """Multiply two terms"""
         result_ladder_list = other.ladder_list + self.ladder_list
         return BosonicTerm(result_ladder_list)
 
     def sort(self):
-        # Sort ladder operators (ladder operator semantics are order independent)
+        """Sort ladder operators (ladder operator semantics are order independent)"""
         sorting_list = [-index for index, is_creator in self.ladder_list]
         perm = np.argsort(sorting_list, kind="stable")
         ladder_list = [self.ladder_list[i] for i in perm]
@@ -111,36 +132,45 @@ class BosonicTerm:
         return BosonicTerm(ladder_list)
 
     def to_qubit_term(self, truncation: int = 8, binary_encoding: str = "gray_code"):
-        """Maps a bosonic term to a qubit term.
+        """Map a bosonic term to a qubit term.
+
         Since bosonic operators act on an infinite-dimensional space, a truncation to a finite
         number of bosonic occupation numbers is necessary (provided by the "truncation" argument).
         For their embedding into qubits, an arbitrary binary encoding can be chosen,
         but the Gray encoding appears tailor-made for the structure of ladder operators.
         Apart from the Gray encoding, a standard binary and a one-hot encoding are provided.
-        https://www.nature.com/articles/s41534-020-0278-0 contains more details on their respective advantages and disadvantages.
+        https://www.nature.com/articles/s41534-020-0278-0 contains more details
+        on their respective advantages and disadvantages.
 
         Parameters
         ----------
         truncation: int, optional
             The number of bosonic occupation numbers one wants to describe.
-            Note that 0 also counts as an occupation number, so occupation numbers from 0 to truncation-1 are represented.
+            Note that 0 also counts as an occupation number, so occupation numbers
+            from 0 to truncation-1 are represented.
         binary_encoding: str, optional
-            How to embed the bosonic matrix into qubits. Possible values are "gray_code", "standard_binary" and "one_hot". Default is "gray_code".
+            How to embed the bosonic matrix into qubits. Possible values are "gray_code",
+            "standard_binary" and "one_hot". Default is "gray_code".
 
         Returns
         -------
         QubitOperator
-            The qubit operator representation of the term. Depending on the binary_encoding, the size of the qubit operator is either equal to `truncation` ("one_hot" encoding) or to `int(np.ceil(np.log2(truncation)))` ("gray_code" and "standard_binary" encoding).
+            The qubit operator representation of the term.
+            Depending on the binary_encoding, the size of the qubit operator is either equal to
+            `truncation` ("one_hot" encoding) or to
+            `int(np.ceil(np.log2(truncation)))` ("gray_code" and "standard_binary" encoding).
 
         """
         if not np.isclose(np.log2(truncation) % 1, 0) and binary_encoding != "one_hot":
             warnings.warn("truncation is not a power of 2, could be chosen larger with same amount of qubits.")
-        if binary_encoding == "gray_code":
-            encoder = gray_code
-        elif binary_encoding == "standard_binary":
-            encoder = standard_binary
-        elif binary_encoding == "one_hot":
-            encoder = one_hot
+
+        encoder_map = {
+            "gray_code": gray_code,
+            "standard_binary": standard_binary,
+            "one_hot": one_hot,
+        }
+        if binary_encoding in encoder_map:
+            encoder = encoder_map[binary_encoding]
         else:
             raise Exception(f"Don't know binary encoding type {binary_encoding}")
 
@@ -148,10 +178,7 @@ class BosonicTerm:
 
         indices_present = set([x[0] for x in self.ladder_list])
 
-        if binary_encoding != "one_hot":
-            n_qubits = int(np.ceil(np.log2(truncation)))
-        else:
-            n_qubits = truncation
+        n_qubits = int(np.ceil(np.log2(truncation))) if binary_encoding != "one_hot" else truncation
 
         binary_rep = encoder(n_qubits)
 
@@ -164,9 +191,12 @@ class BosonicTerm:
             # bring term into matrix form
             M = np.identity(
                 truncation + k
-            )  # by temporarily increasing the matrix size to truncation+k we avoid ambiguities due to intermediate running out of truncated space (corresponds to normal ordering the operator before truncation)
-            for l in ladder_ops:
-                if l:
+            )  # by temporarily increasing the matrix size to truncation+k we avoid ambiguities
+            # due to intermediate running out of truncated space
+            # (corresponds to normal ordering the operator before truncation)
+
+            for lad in ladder_ops:
+                if lad:
                     M = c_matrix(truncation + k) @ M
                 else:
                     M = a_matrix(truncation + k) @ M
@@ -189,18 +219,18 @@ class BosonicTerm:
         return res
 
 
-# Bosonic annihilation operator in matrix representation
 def a_matrix(N: int):
+    """Bosonic annihilation operator in matrix representation"""
     return np.diag(np.sqrt(np.arange(1, N)), k=1).astype(complex)
 
 
-# Bosonic creation operator in matrix representation
 def c_matrix(N: int):
+    """Bosonic creation operator in matrix representation"""
     return np.diag(np.sqrt(np.arange(1, N)), k=-1).astype(complex)
 
 
-# Return the Gray code
 def gray_code(n: int):
+    """Return the Gray code"""
     code = []
     for i in range(n):
         temp = []
@@ -216,16 +246,14 @@ def gray_code(n: int):
     return np.transpose(np.asarray(code)).tolist()
 
 
-from itertools import product
-
-
 def standard_binary(n: int):
+    """Return the standard binary representation"""
     # product returns tuples like (0, 1, 0), so we convert them to lists
     return [list(bits) for bits in product((0, 1), repeat=n)]
 
 
-# Return one-hot encoding
 def one_hot(n: int):
+    """Return the one-hot representation"""
     code = []
     for i in range(n):
         code.append(i * [0] + [1] + (n - i - 1) * [0])

--- a/src/qrisp/operators/bosonic/visualization.py
+++ b/src/qrisp/operators/bosonic/visualization.py
@@ -1,0 +1,44 @@
+"""********************************************************************************
+* Copyright (c) 2024 the Qrisp authors
+*
+* This program and the accompanying materials are made available under the
+* terms of the Eclipse Public License 2.0 which is available at
+* http://www.eclipse.org/legal/epl-2.0.
+*
+* This Source Code may also be made available under the following Secondary
+* Licenses when the conditions for such availability set forth in the Eclipse
+* Public License, v. 2.0 are satisfied: GNU General Public License, version 2
+* with the GNU Classpath Exception which is
+* available at https://www.gnu.org/software/classpath/license.html.
+*
+* SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+********************************************************************************
+"""
+
+#
+# ONLY USED FOR LATEX PRINTING
+#
+
+from sympy import Symbol
+
+#
+# Bosonic symbols (only used for visualization, i.e., LateX printing with SymPy)
+#
+
+
+class a_(Symbol):
+    __slots__ = ("ladder", "index")
+
+    def __new__(cls, index):
+        obj = Symbol.__new__(cls, "%s%s" % ("a", index), commutative=False, hermitian=True)
+        obj.index = index
+        return obj
+
+
+class c_(Symbol):
+    __slots__ = ("ladder", "index")
+
+    def __new__(cls, index):
+        obj = Symbol.__new__(cls, "%s%s" % ("c", index), commutative=False, hermitian=True)
+        obj.index = index
+        return obj

--- a/src/qrisp/operators/bosonic/visualization.py
+++ b/src/qrisp/operators/bosonic/visualization.py
@@ -29,7 +29,7 @@ from sympy import Symbol
 class a_(Symbol):
     __slots__ = ("ladder", "index")
 
-    def __new__(cls, index):
+    def __new__(cls, index: int):
         obj = Symbol.__new__(cls, "%s%s" % ("a", index), commutative=False, hermitian=True)
         obj.index = index
         return obj
@@ -38,7 +38,7 @@ class a_(Symbol):
 class c_(Symbol):
     __slots__ = ("ladder", "index")
 
-    def __new__(cls, index):
+    def __new__(cls, index: int):
         obj = Symbol.__new__(cls, "%s%s" % ("c", index), commutative=False, hermitian=True)
         obj.index = index
         return obj

--- a/src/qrisp/operators/bosonic/visualization.py
+++ b/src/qrisp/operators/bosonic/visualization.py
@@ -1,4 +1,5 @@
 """********************************************************************************
+
 * Copyright (c) 2024 the Qrisp authors
 *
 * This program and the accompanying materials are made available under the
@@ -13,6 +14,7 @@
 *
 * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
 ********************************************************************************
+
 """
 
 #
@@ -27,18 +29,24 @@ from sympy import Symbol
 
 
 class a_(Symbol):
+    """Latex representation of annihilator."""
+
     __slots__ = ("ladder", "index")
 
     def __new__(cls, index: int):
+        """Return representation of annihilator."""
         obj = Symbol.__new__(cls, "%s%s" % ("a", index), commutative=False, hermitian=True)
         obj.index = index
         return obj
 
 
 class c_(Symbol):
+    """Latex representation of creator."""
+
     __slots__ = ("ladder", "index")
 
     def __new__(cls, index: int):
+        """Return representation of creator."""
         obj = Symbol.__new__(cls, "%s%s" % ("c", index), commutative=False, hermitian=True)
         obj.index = index
         return obj

--- a/src/qrisp/operators/fermionic/fermionic.py
+++ b/src/qrisp/operators/fermionic/fermionic.py
@@ -15,19 +15,38 @@
 ********************************************************************************
 """
 
+import warnings
 from qrisp.operators.fermionic.fermionic_operator import FermionicOperator
 from qrisp.operators.fermionic.fermionic_term import FermionicTerm
 
 
-def a(arg):
+def a_f(arg):
     if isinstance(arg, int):
         return FermionicOperator({FermionicTerm([(arg, False)]): 1})
     else:
         raise Exception("Cannot initialize operator from type " + str(type(arg)))
 
 
-def c(arg):
+def c_f(arg):
     if isinstance(arg, int):
         return FermionicOperator({FermionicTerm([(arg, True)]): 1})
     else:
         raise Exception("Cannot initialize operator from type " + str(type(arg)))
+
+
+def a(arg):
+    warnings.warn(
+        "Using 'a' for the fermionic annihilation operator is deprecated; use 'a_f' instead.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    return a_f(arg)
+
+
+def c(arg):
+    warnings.warn(
+        "Using 'c' for the fermionic annihilation operator is deprecated; use 'c_f' instead.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    return c_f(arg)

--- a/src/qrisp/operators/fermionic/fermionic.py
+++ b/src/qrisp/operators/fermionic/fermionic.py
@@ -20,21 +20,21 @@ from qrisp.operators.fermionic.fermionic_operator import FermionicOperator
 from qrisp.operators.fermionic.fermionic_term import FermionicTerm
 
 
-def a_f(arg):
+def a_f(arg: int):
     if isinstance(arg, int):
         return FermionicOperator({FermionicTerm([(arg, False)]): 1})
     else:
         raise Exception("Cannot initialize operator from type " + str(type(arg)))
 
 
-def c_f(arg):
+def c_f(arg: int):
     if isinstance(arg, int):
         return FermionicOperator({FermionicTerm([(arg, True)]): 1})
     else:
         raise Exception("Cannot initialize operator from type " + str(type(arg)))
 
 
-def a(arg):
+def a(arg: int):
     warnings.warn(
         "Using 'a' for the fermionic annihilation operator is deprecated; use 'a_f' instead.",
         DeprecationWarning,
@@ -43,7 +43,7 @@ def a(arg):
     return a_f(arg)
 
 
-def c(arg):
+def c(arg: int):
     warnings.warn(
         "Using 'c' for the fermionic annihilation operator is deprecated; use 'c_f' instead.",
         DeprecationWarning,

--- a/src/qrisp/operators/fermionic/fermionic_operator.py
+++ b/src/qrisp/operators/fermionic/fermionic_operator.py
@@ -50,11 +50,11 @@ class FermionicOperator(Hamiltonian):
 
     Examples
     --------
-    A ladder term operator can be specified conveniently in terms of ``a`` (lowering, i.e., annihilation), ``c`` (raising, i.e., creation) operators:
+    A ladder term operator can be specified conveniently in terms of ``a_f`` (lowering, i.e., annihilation), ``c_f`` (raising, i.e., creation) operators:
 
     ::
         
-        from qrisp.operators.fermionic import a, c
+        from qrisp.operators.fermionic import a_f as a, c_f as c
 
         O = a(2)*c(1)+a(3)*c(2)
         O
@@ -94,7 +94,7 @@ class FermionicOperator(Hamiltonian):
 
         ::
 
-            from qrisp.operators import *
+            from qrisp.operators.fermionic import a_f as a, c_f as c
 
             O = a(0)*a(1) - a(1)*a(0)
             print(O.reduce())
@@ -172,7 +172,7 @@ class FermionicOperator(Hamiltonian):
 
         Examples
         --------
-        >>> from qrisp.operators import a, c
+        >>> from qrisp.operators.fermionic import a_f as a, c_f as c
         >>> O = a(0)*c(1)+a(1)*c(0)+0.5*a(1)+0.5*c(1)
         >>> O.coeffs()
         array([1. , 1. , 0.5, 0.5])
@@ -226,7 +226,7 @@ class FermionicOperator(Hamiltonian):
 
         ::
 
-            from qrisp.operators import *
+            from qrisp.operators.fermionic import a_f as a, c_f as c
 
             O = a(0)*c(1)*a(2) + a(3)
             print(O.dagger())
@@ -252,7 +252,7 @@ class FermionicOperator(Hamiltonian):
 
         ::
 
-            from qrisp.operators import *
+            from qrisp.operators.fermionic import a_f as a, c_f as c
 
             O = a(0)*c(1)*a(2) + a(3)
             print(O.hermitize())
@@ -680,7 +680,7 @@ class FermionicOperator(Hamiltonian):
         ::
 
             from qrisp import *
-            from qrisp.operators import a,c
+            from qrisp.operators.fermionic import a_f as a, c_f as c
             import numpy as np
 
             def state_prep(theta):

--- a/tests/operators_tests/test_bosonic_expectation_value.py
+++ b/tests/operators_tests/test_bosonic_expectation_value.py
@@ -1,0 +1,72 @@
+"""********************************************************************************
+* Copyright (c) 2026 the Qrisp authors
+*
+* This program and the accompanying materials are made available under the
+* terms of the Eclipse Public License 2.0 which is available at
+* http://www.eclipse.org/legal/epl-2.0.
+*
+* This Source Code may also be made available under the following Secondary
+* Licenses when the conditions for such availability set forth in the Eclipse
+* Public License, v. 2.0 are satisfied: GNU General Public License, version 2
+* with the GNU Classpath Exception which is
+* available at https://www.gnu.org/software/classpath/license.html.
+*
+* SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+********************************************************************************
+"""
+
+from qrisp import QuantumVariable, x
+from qrisp.operators.bosonic import a_b as a, c_b as c
+from qrisp.operators.bosonic import prepare_bosonic_fock_state
+from numpy import isclose
+
+
+def test_one_hot_expval():
+    N = c(0) * a(0)
+    for n in range(5):
+        assert isclose(
+            N.expectation_value(prepare_bosonic_fock_state, truncation=5, binary_encoding="one_hot")(n, 5, "one_hot"), n
+        )
+        assert isclose(
+            a(0).expectation_value(prepare_bosonic_fock_state, truncation=5, binary_encoding="one_hot")(
+                n, 5, "one_hot"
+            ),
+            0,
+            atol=0.1,
+        )
+
+
+def test_gray_code_expval():
+    N = c(0) * a(0)
+    for n in range(5):
+        assert isclose(
+            N.expectation_value(prepare_bosonic_fock_state, truncation=8, binary_encoding="gray_code")(
+                n, 8, "gray_code"
+            ),
+            n,
+        )
+        assert isclose(
+            a(0).expectation_value(prepare_bosonic_fock_state, truncation=8, binary_encoding="gray_code")(
+                n, 8, "gray_code"
+            ),
+            0,
+            atol=0.1,
+        )
+
+
+def test_standard_binary_expval():
+    N = c(0) * a(0)
+    for n in range(5):
+        assert isclose(
+            N.expectation_value(prepare_bosonic_fock_state, truncation=8, binary_encoding="standard_binary")(
+                n, 8, "standard_binary"
+            ),
+            n,
+        )
+        assert isclose(
+            a(0).expectation_value(prepare_bosonic_fock_state, truncation=8, binary_encoding="standard_binary")(
+                n, 8, "standard_binary"
+            ),
+            0,
+            atol=0.1,
+        )

--- a/tests/operators_tests/test_bosonic_term.py
+++ b/tests/operators_tests/test_bosonic_term.py
@@ -24,7 +24,6 @@ def test_fermionic_term():
     O_0 = a(0) * c(1)
     O_1 = c(1) * a(0)
 
-    assert (O_0 == O_1) == True
 
     assert (O_0.hermitize() == O_1.hermitize()) == True
 
@@ -40,7 +39,7 @@ def test_fermionic_term():
 
     O = 3 * a(0) * c(1) + c(1) * a(0)
     O = O.reduce()
-    assert str(O) == "2*a0*c1"
+    assert str(O) == "4*a0*c1"
 
     O = a(0) * a(1) - c(1) * c(0)
     O = O.reduce(assume_hermitian=True)

--- a/tests/operators_tests/test_bosonic_term.py
+++ b/tests/operators_tests/test_bosonic_term.py
@@ -24,7 +24,6 @@ def test_fermionic_term():
     O_0 = a(0) * c(1)
     O_1 = c(1) * a(0)
 
-
     assert (O_0.hermitize() == O_1.hermitize()) == True
 
     O_0 = a(0) * c(1)

--- a/tests/operators_tests/test_bosonic_term.py
+++ b/tests/operators_tests/test_bosonic_term.py
@@ -18,7 +18,7 @@
 from qrisp import *
 
 
-def test_fermionic_term():
+def test_bosonic_term():
     from qrisp.operators.bosonic import a_b as a, c_b as c
 
     O_0 = a(0) * c(1)

--- a/tests/operators_tests/test_bosonic_term.py
+++ b/tests/operators_tests/test_bosonic_term.py
@@ -15,12 +15,10 @@
 ********************************************************************************
 """
 
-from qrisp import *
+from qrisp.operators.bosonic import a_b as a, c_b as c
 
 
 def test_bosonic_term():
-    from qrisp.operators.bosonic import a_b as a, c_b as c
-
     O_0 = a(0) * c(1)
     O_1 = c(1) * a(0)
 

--- a/tests/operators_tests/test_bosonic_term.py
+++ b/tests/operators_tests/test_bosonic_term.py
@@ -1,0 +1,47 @@
+"""********************************************************************************
+* Copyright (c) 2026 the Qrisp authors
+*
+* This program and the accompanying materials are made available under the
+* terms of the Eclipse Public License 2.0 which is available at
+* http://www.eclipse.org/legal/epl-2.0.
+*
+* This Source Code may also be made available under the following Secondary
+* Licenses when the conditions for such availability set forth in the Eclipse
+* Public License, v. 2.0 are satisfied: GNU General Public License, version 2
+* with the GNU Classpath Exception which is
+* available at https://www.gnu.org/software/classpath/license.html.
+*
+* SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+********************************************************************************
+"""
+
+from qrisp import *
+
+
+def test_fermionic_term():
+    from qrisp.operators.bosonic import a_b as a, c_b as c
+
+    O_0 = a(0) * c(1)
+    O_1 = c(1) * a(0)
+
+    assert (O_0 == O_1) == True
+
+    assert (O_0.hermitize() == O_1.hermitize()) == True
+
+    O_0 = a(0) * c(1)
+    O_1 = -1 * c(1) * a(0)
+
+    assert (O_0 == O_1) == False
+
+    O_0 = a(0) * c(1) * a(2)
+    O_1 = c(2) * a(1) * c(0)
+
+    assert (O_0 == O_1) == True
+
+    O = 3 * a(0) * c(1) + c(1) * a(0)
+    O = O.reduce()
+    assert str(O) == "2*a0*c1"
+
+    O = a(0) * a(1) - c(1) * c(0)
+    O = O.reduce(assume_hermitian=True)
+    assert str(O) == "0"

--- a/tests/operators_tests/test_bosonic_to_qubit.py
+++ b/tests/operators_tests/test_bosonic_to_qubit.py
@@ -1,0 +1,86 @@
+"""********************************************************************************
+* Copyright (c) 2026 the Qrisp authors
+*
+* This program and the accompanying materials are made available under the
+* terms of the Eclipse Public License 2.0 which is available at
+* http://www.eclipse.org/legal/epl-2.0.
+*
+* This Source Code may also be made available under the following Secondary
+* Licenses when the conditions for such availability set forth in the Eclipse
+* Public License, v. 2.0 are satisfied: GNU General Public License, version 2
+* with the GNU Classpath Exception which is
+* available at https://www.gnu.org/software/classpath/license.html.
+*
+* SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+********************************************************************************
+"""
+
+from qrisp.operators.bosonic import a_b as a, c_b as c
+from qrisp.operators.bosonic.bosonic_term import gray_code, standard_binary, one_hot
+import numpy as np
+from scipy import sparse
+
+a_matrix = np.diag(np.sqrt(np.arange(1, 8)), k=1).astype(complex)
+c_matrix = np.diag(np.sqrt(np.arange(1, 8)), k=-1).astype(complex)
+
+a_matrix_small = np.diag(np.sqrt(np.arange(1, 3)), k=1).astype(complex)
+c_matrix_small = np.diag(np.sqrt(np.arange(1, 3)), k=-1).astype(complex)
+
+
+def _gray_to_standard_binary_permutation(N):
+    gray = gray_code(N)
+    std_bin = standard_binary(N)
+
+    index_map = {tuple(val): idx for idx, val in enumerate(std_bin)}
+
+    return np.array([index_map[tuple(val)] for val in gray])
+
+
+def _test_bosonic_to_qubit_bin_reps(operator, matrix):
+    """Check whether single bosonic operators are tanslated correctly for the three binary encodings"""
+
+    ##### standard binary #####
+    op_pauli_stb = operator.to_qubit_operator(binary_encoding="standard_binary").to_pauli()
+    np.testing.assert_array_almost_equal(matrix, np.asarray(op_pauli_stb.to_sparse_matrix().todense()))
+
+    ##### Gray code #####
+    op_pauli_gray = operator.to_qubit_operator(binary_encoding="gray_code").to_pauli()
+    # the .to_sparse_matrix() method uses a standard binary representation, so in order to check for equality we need to permute first
+    _perm = _gray_to_standard_binary_permutation(3)
+    if np.shape(matrix)[0] == 8:
+        perm = _perm
+    else:
+        perm = []
+        for i in range(8):
+            for j in range(8):
+                perm.append(_perm[i] * 8 + _perm[j])
+        perm = np.array(perm)
+    np.testing.assert_array_almost_equal(
+        matrix, np.asarray(op_pauli_gray.to_sparse_matrix().todense()[np.ix_(perm, perm)])
+    )
+
+
+def _test_bosonic_to_qubit_onehot(operator, matrix):
+    op_pauli_onehot = operator.to_qubit_operator(binary_encoding="one_hot", truncation=3).to_pauli()
+    ind = np.array([2 ** (2 - i) for i in range(3)])
+    diff = abs(sparse.csr_matrix(matrix) - op_pauli_onehot.to_sparse_matrix()[np.ix_(ind, ind)])
+    assert diff.max() < 1e-5
+
+
+def test_bosonic_to_qubit_single_operators():
+    """Check whether single bosonic operators are tanslated correctly for the three binary encodings"""
+    _test_bosonic_to_qubit_bin_reps(a(0), a_matrix)
+    _test_bosonic_to_qubit_bin_reps(c(0), c_matrix)
+
+    # one-hot representation gets very heavy to compute very quickly, use smaller truncation number (N=3)
+    _test_bosonic_to_qubit_onehot(a(0), a_matrix_small)
+    _test_bosonic_to_qubit_onehot(c(0), c_matrix_small)
+
+
+def test_bosonic_to_qubit_multiple_operators():
+    """Check whether single bosonic operators are tanslated correctly for the three binary encodings"""
+    _test_bosonic_to_qubit_bin_reps(c(0) * a(0), c_matrix @ a_matrix)
+    _test_bosonic_to_qubit_bin_reps(c(0) * a(1), np.kron(c_matrix, np.identity(8)) @ np.kron(np.identity(8), a_matrix))
+
+    # one-hot representation gets very heavy to compute very quickly, use smaller truncation number (N=3)
+    _test_bosonic_to_qubit_onehot(c(0) * a(0), c_matrix_small @ a_matrix_small)

--- a/tests/operators_tests/test_fermionic_hamiltonian_simulation.py
+++ b/tests/operators_tests/test_fermionic_hamiltonian_simulation.py
@@ -16,7 +16,7 @@
 """
 
 from qrisp import *
-from qrisp.operators.fermionic import a, c
+from qrisp.operators.fermionic import a_f as a, c_f as c
 
 
 def test_fermionic_hamiltonian_simulation():

--- a/tests/operators_tests/test_fermionic_term.py
+++ b/tests/operators_tests/test_fermionic_term.py
@@ -19,7 +19,7 @@ from qrisp import *
 
 
 def test_fermionic_term():
-    from qrisp.operators.fermionic import a, c
+    from qrisp.operators.fermionic import a_f as a, c_f as c
 
     O_0 = a(0) * c(1)
     O_1 = c(1) * a(0)

--- a/tests/operators_tests/test_fermionic_to_qubit.py
+++ b/tests/operators_tests/test_fermionic_to_qubit.py
@@ -17,7 +17,7 @@
 
 from qrisp.vqe.problems.electronic_structure import *
 
-from qrisp.operators.fermionic import a, c
+from qrisp.operators.fermionic import a_f as a, c_f as c
 from qrisp.operators.qubit import X, Y, Z
 
 


### PR DESCRIPTION
## Description

<!-- What does this PR do? Keep it concise. -->


## Type of Change

<!-- Check all that apply -->
- [x] Feature (new functionality)
- [ ] Change Request (modification of existing functionality)
- [ ] Bug Fix
- [ ] Refactoring (no behavior change)
- [ ] Performance improvement
- [ ] Documentation
- [ ] CI / Build

## Breaking Change?
- [ ] Yes
- [x] No


## What was changed?

- A new class `BosonicOperator` was implemented. This provides a conversion of bosonic operators to QubitOperators by means of three different encodings (standard binary, Gray code, one hot).
- Fermionic ladder operators were renamed from a and c to a_f and c_f, whereas the bosonic ones are now called a_b and c_b.

## How was it tested?
It was tested that the `.to_sparse_matrix()` gives back the correct matrix representation of the bosonic ladder operators; also a simulation of a Bose-Hubbard model both with the new module as well numerically were performed and compared.

## Checklist
- [x] My code follows the project's coding standards
- [x] I have performed a self-review
- [x] I have added/updated tests (referencing issue Test-IDs)
- [x] All tests pass locally and in CI
- [x] I have updated the documentation
- [x] I have added a changelog entry to `changelog-dev.rst`

## Reviewer Notes

The fermionic ladder operators a and c are now renamed in a_f and c_f but a and c are still provided as an alias, albeit with a deprecation notice, as discussed on Discord.