### PR TITLE
Use functools.wraps for decorators across the code base

### DIFF
--- a/documentation/source/general/changelog/changelog-dev.rst
+++ b/documentation/source/general/changelog/changelog-dev.rst
@@ -29,6 +29,12 @@ Improvements
   ``terminal_sampling()`` to use "sampling kernel" terminology and document
   the new arbitrary-return-value capability.
 
+- Decorators ``qache``, ``custom_inversion``, ``custom_control``,
+  ``RUS``, ``auto_uncompute`` now propagate the wrapped function's
+  docstring, name, and signature via ``functools.wraps``, removing the need
+  for manual docstring-copy workarounds at call sites.
+  (`PR #803 <https://github.com/eclipse-qrisp/Qrisp/pull/803>`_).
+
 Other New Features
 ------------------
 

--- a/src/qrisp/alg_primitives/arithmetic/SBP_arithmetic.py
+++ b/src/qrisp/alg_primitives/arithmetic/SBP_arithmetic.py
@@ -1353,17 +1353,6 @@ def app_phase_polynomial(qf_list, poly, symbol_list=None, t=1):
     app_sb_phase_polynomial(qf_list, sb_polynomial, symbol_list=new_symbol_list, t=t)
 
 
-# Workaround to keep the docstring but still gatewrap
-
-temp = app_sb_phase_polynomial.__doc__
-
 app_sb_phase_polynomial = gate_wrap(permeability="args", is_qfree=True)(app_sb_phase_polynomial)
 
-app_sb_phase_polynomial.__doc__ = temp
-
-
-temp = app_phase_polynomial.__doc__
-
 app_phase_polynomial = gate_wrap(permeability="args", is_qfree=True)(app_phase_polynomial)
-
-app_phase_polynomial.__doc__ = temp

--- a/src/qrisp/alg_primitives/arithmetic/adders/ripple_carry_adder.py
+++ b/src/qrisp/alg_primitives/arithmetic/adders/ripple_carry_adder.py
@@ -208,7 +208,4 @@ def inpl_add(
         ancilla_var_2.delete()
 
 
-# Workaround for protecting the docstring from the decorator
-temp = inpl_add.__doc__
 inpl_add = gate_wrap(inpl_add)
-inpl_add.__doc__ = temp

--- a/src/qrisp/alg_primitives/lcu.py
+++ b/src/qrisp/alg_primitives/lcu.py
@@ -393,10 +393,8 @@ def LCU(operand_prep, state_prep, unitaries, num_unitaries=None, oaa_iter=0):
     return success_bool, qv
 
 
-# Apply the RUS decorator with the workaround in order to show in documentation
-temp_docstring = LCU.__doc__
+# Apply the RUS decorator
 LCU = RUS(static_argnums=[3, 4])(LCU)
-LCU.__doc__ = temp_docstring
 
 
 def view_LCU(operand_prep, state_prep, unitaries, num_unitaries=None):

--- a/src/qrisp/alg_primitives/program_control/quantum_switch.py
+++ b/src/qrisp/alg_primitives/program_control/quantum_switch.py
@@ -485,6 +485,4 @@ def _q_switch_q(index, branches, *operands, branch_amount=None, method="auto", i
         raise Exception(f"Don't know compile method {method} for switch-case structure.")
 
 
-temp = _q_switch_q.__doc__
 _q_switch_q = custom_control(custom_inversion(_q_switch_q))
-_q_switch_q.__doc__ = temp

--- a/src/qrisp/alg_primitives/program_control/switch_case.py
+++ b/src/qrisp/alg_primitives/program_control/switch_case.py
@@ -514,6 +514,4 @@ def qswitch(operand, case, case_function, method="auto", case_amount=None, inv=F
         raise Exception(f"Don't know compile method {method} for switch-case structure.")
 
 
-temp = qswitch.__doc__
 qswitch = custom_control(custom_inversion(qswitch))
-qswitch.__doc__ = temp

--- a/src/qrisp/algorithms/grover/grover_tools.py
+++ b/src/qrisp/algorithms/grover/grover_tools.py
@@ -461,17 +461,6 @@ def grovers_alg(
         #    )
 
 
-# Workaround to keep the docstring but still gatewrap
-
-temp = diffuser.__doc__
-
 diffuser = gate_wrap(permeability=[], is_qfree=False)(diffuser)
 
-diffuser.__doc__ = temp
-
-
-temp = tag_state.__doc__
-
 tag_state = gate_wrap(permeability="args", is_qfree=True)(tag_state)
-
-tag_state.__doc__ = temp

--- a/src/qrisp/environments/custom_inversion_environment.py
+++ b/src/qrisp/environments/custom_inversion_environment.py
@@ -15,6 +15,8 @@
 ********************************************************************************
 """
 
+import functools
+
 import jax.numpy as jnp
 
 from qrisp.jasp import (
@@ -139,6 +141,7 @@ def custom_inversion(*func, **cusi_kwargs):
 
     qached_func = qache(func, **cusi_kwargs)
 
+    @functools.wraps(func)
     def adaptive_inversion_function(*args, **kwargs):
 
         if not check_for_tracing_mode():

--- a/src/qrisp/jasp/program_control/rus.py
+++ b/src/qrisp/jasp/program_control/rus.py
@@ -15,6 +15,7 @@
 ********************************************************************************
 """
 
+import functools
 import inspect
 
 from qrisp.jasp import (
@@ -269,6 +270,7 @@ def RUS(*trial_function, **jit_kwargs):
     # to collect the output QuantumVariable object.
     # From the infered output signature the q_while_loop is constructed
 
+    @functools.wraps(trial_function)
     def return_function(*trial_args):
 
         # Filter out the static arguments

--- a/src/qrisp/jasp/tracing_logic/qaching.py
+++ b/src/qrisp/jasp/tracing_logic/qaching.py
@@ -15,6 +15,8 @@
 ********************************************************************************
 """
 
+import functools
+
 import jax
 
 from qrisp.core import recursive_qa_search, recursive_qv_search
@@ -268,6 +270,7 @@ def qache_helper(func, jax_kwargs):
     from qrisp.jasp.tracing_logic import flatten_qv
 
     # We now prepare the return function
+    @functools.wraps(func)
     def return_function(*args, **kwargs):
 
         # If we are not in tracing mode, simply execute the function

--- a/src/qrisp/permeability/uncomputation.py
+++ b/src/qrisp/permeability/uncomputation.py
@@ -15,6 +15,8 @@
 ********************************************************************************
 """
 
+import functools
+
 import numpy as np
 
 from qrisp.circuit import fast_append
@@ -37,6 +39,7 @@ def auto_uncompute(*args, recompute=False):
 # Decorator for auto uncomputed function
 def auto_uncompute_inner(function):
     # Create auto uncomputed function
+    @functools.wraps(function)
     def auto_uncomputed_function(*args, **kwargs):
         from qrisp.core import (
             QuantumVariable,
@@ -75,8 +78,8 @@ def auto_uncompute_inner(function):
 
         return result
 
+    # functools.wraps already copied __doc__; keep the distinguishing name suffix.
     auto_uncomputed_function.__name__ = function.__name__ + "_auto_uncomputed"
-    auto_uncomputed_function.__doc__ = function.__doc__
     # Return result
     return auto_uncomputed_function
 


### PR DESCRIPTION
## Description

Internal Qrisp functions decorated with `@custom_inversion` and/or `@custom_control` (e.g. `q_switch`/`qswitch`) lost their docstring and signature, since only `custom_control` applied `functools.wraps` — `custom_inversion` did not. This required manual `temp = f.__doc__; f = decorator(f); f.__doc__ = temp` workarounds scattered across the codebase, which still left signatures broken.

Adds `functools.wraps` to `custom_inversion`, `qache`, `RUS`, and `auto_uncompute` (matching the pattern already used by `custom_control`/`gate_wrap`), and removes the now-redundant manual docstring-copy workarounds in `quantum_switch.py`, switch_case.py, grover_tools.py, lcu.py, ripple_carry_adder.py, and SBP_arithmetic.py.

## What was changed?

- custom_inversion_environment.py, qaching.py, rus.py, uncomputation.py: added `functools.wraps` to the returned wrapper functions.
- Removed manual `__doc__`-copy workarounds in `quantum_switch.py`, switch_case.py, grover_tools.py, lcu.py, ripple_carry_adder.py, SBP_arithmetic.py.
- Changelog entry added under Improvements.
