### PR TITLE
Updating Documentation of the Jasp module

### DIFF
--- a/documentation/source/general/changelog/changelog-dev.rst
+++ b/documentation/source/general/changelog/changelog-dev.rst
@@ -163,6 +163,15 @@ Development
   after a module docstring)
   (`PR #811 <https://github.com/eclipse-qrisp/Qrisp/pull/811>`_).
 
+* Added ``E501`` (line too long) and ``D205`` (missing blank line after
+  docstring summary) to the ``ruff`` ignore list in ``pyproject.toml``. The
+  120-character limit was generating excessive ``reviewdog`` noise on PRs
+  without providing much value, and the standard license header docstring
+  present at the top of nearly every source file in the repository always
+  triggers ``D205``, so any PR touching code near the top of a file risked
+  unrelated ``reviewdog`` complaints about the header
+  (`PR #805 <https://github.com/eclipse-qrisp/Qrisp/pull/805>`_).
+
 Dependency Upgrades
 -------------------
 

--- a/documentation/source/general/changelog/changelog-dev.rst
+++ b/documentation/source/general/changelog/changelog-dev.rst
@@ -89,10 +89,9 @@ Compatibility
 New Tutorials/ Updated Documentation
 -------------------------------------
 
-- Fixed outdated or inaccurate docstrings and examples
-  across the Jasp module (control flow, sampling, simulators, optimization
-  tools, ``BigInteger``, ``Jaspr`` MLIR/QIR export, and the "Ported
-  Features" page)
+- Fixed outdated or inaccurate docstrings and examples across the Jasp
+  module (control flow, sampling, simulators, optimization tools,
+  ``BigInteger``, and ``Jaspr`` MLIR/QIR export)
   (`PR #805 <https://github.com/eclipse-qrisp/Qrisp/pull/805>`_).
 
 .. Add new tutorials above this line

--- a/documentation/source/general/changelog/changelog-dev.rst
+++ b/documentation/source/general/changelog/changelog-dev.rst
@@ -89,6 +89,12 @@ Compatibility
 New Tutorials/ Updated Documentation
 -------------------------------------
 
+- Fixed outdated or inaccurate docstrings and examples
+  across the Jasp module (control flow, sampling, simulators, optimization
+  tools, ``BigInteger``, ``Jaspr`` MLIR/QIR export, and the "Ported
+  Features" page)
+  (`PR #805 <https://github.com/eclipse-qrisp/Qrisp/pull/805>`_).
+
 .. Add new tutorials above this line
 
 API Changes

--- a/documentation/source/general/changelog/changelog-dev.rst
+++ b/documentation/source/general/changelog/changelog-dev.rst
@@ -163,15 +163,6 @@ Development
   after a module docstring)
   (`PR #811 <https://github.com/eclipse-qrisp/Qrisp/pull/811>`_).
 
-* Added ``E501`` (line too long) and ``D205`` (missing blank line after
-  docstring summary) to the ``ruff`` ignore list in ``pyproject.toml``. The
-  120-character limit was generating excessive ``reviewdog`` noise on PRs
-  without providing much value, and the standard license header docstring
-  present at the top of nearly every source file in the repository always
-  triggers ``D205``, so any PR touching code near the top of a file risked
-  unrelated ``reviewdog`` complaints about the header
-  (`PR #805 <https://github.com/eclipse-qrisp/Qrisp/pull/805>`_).
-
 Dependency Upgrades
 -------------------
 

--- a/documentation/source/reference/Jasp/Control Flow/ClControl.rst
+++ b/documentation/source/reference/Jasp/Control Flow/ClControl.rst
@@ -4,6 +4,6 @@ Classical Control
 =================
 
 .. currentmodule:: qrisp.environments
-.. autofunction:: ClControlEnvironment
+.. autoclass:: ClControlEnvironment
 
 

--- a/documentation/source/reference/Jasp/Expectation Value.rst
+++ b/documentation/source/reference/Jasp/Expectation Value.rst
@@ -17,22 +17,22 @@ For example, we prepare the state
 
 .. math::
 
-    \ket{\psi_{\theta}} = (\cos(\theta)\ket{0}+\sin(\theta)\ket{1})^{\otimes 2}
+    \ket{\psi_{\theta}} = (\cos(\theta/2)\ket{0}+\sin(\theta/2)\ket{1})^{\otimes 2}
 
 ::
-            
+
     from qrisp import *
-    from qrisp.operators import X,Y,Z
+    from qrisp.operators import Z
     import numpy as np
 
     def state_prep(theta):
         qv = QuantumFloat(2)
 
         ry(theta,qv)
-    
+
         return qv
 
-And compute the expectation value of the Hamiltonion $H=Z_0Z_1$ for the state $\ket{\psi_{\theta}}$
+And compute the expectation value of the Hamiltonian $H=Z_0Z_1$ for the state $\ket{\psi_{\theta}}$
 
 ::
 

--- a/documentation/source/reference/Jasp/Resource Estimation.rst
+++ b/documentation/source/reference/Jasp/Resource Estimation.rst
@@ -28,4 +28,6 @@ Circuit depth
 Number of qubits
 ----------------
 
+.. _num_qubits:
+
 .. autofunction:: num_qubits

--- a/documentation/source/reference/Jasp/Scalable Integer Type.rst
+++ b/documentation/source/reference/Jasp/Scalable Integer Type.rst
@@ -80,10 +80,10 @@ This enables expressions like:
 
 .. code-block:: python
 
-    a = BigInteger.create(42)
-    b = BigInteger.create(100)
+    a = BigInteger.create(42, size=2)
+    b = BigInteger.create(100, size=2)
 
-    print((a + b)())     # 142.0
-    print((b - a)())     # 58.0
-    print((a < b))       # True   
-    print((a << 2)())    # 168.0
+    print((a + b)())     # 142
+    print((b - a)())     # 58
+    print((a < b))       # True
+    print((a << 2)())    # 168

--- a/documentation/source/reference/Jasp/index.rst
+++ b/documentation/source/reference/Jasp/index.rst
@@ -64,10 +64,10 @@ This gives the output
 .. code-block::
 
     { lambda ; a:f32[3]. let
-    b:f32[3] = add a 2.0
-    c:f32[3] = sin b
-    d:f32[3] = mul b c
-    in (d,) }
+        b:f32[3] = add a 2.0:f32[]
+        c:f32[3] = sin b
+        d:f32[3] = mul b c
+      in (d,) }
 
 Jax not only allows us to represent (classical) computations in a more simplified and easier-to-process form but also provides a `matured ecosystem <https://www.educative.io/courses/intro-jax-deep-learning/awesome-jax-libraries>`_ of libraries. On top of that, Jax exposes the means to `create new primitives <https://docs.jax.dev/en/latest/jax-primitives.html>`_, which allows quantum developers to use the Jax infrastructure for their purposes.
 
@@ -124,7 +124,7 @@ jasprs can be simulated using the built-in real-time simulator. You achieve this
 How is this different from the regular Qrisp features? The essential point is that because jaspr objects are embedded into the Jaxpr IR, they allow more advanced compilation tools to process the algorithm. In our case it is possible to convert jaspr objects to the `Catalyst <https://docs.pennylane.ai/projects/catalyst/en/stable/index.html>`__ representation, which targets `established classical compilation infrastructure <https://mlir.llvm.org/>`_ to lower the (hybrid) algorithm into `QIR <https://www.qir-alliance.org/>`_.
 If you are interested in how the QIR representation looks like, try calling
 
->>> jaspr.to_qir(8)
+>>> jaspr.to_qir()
 
 .. toctree::
    :maxdepth: 2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -115,7 +115,6 @@ select = ["I", "E", "W", "D", "PL", "F"]
 
 ignore = [
     "D203",  # inconsistent with D211 (no-blank-line-before-class)
-    "D205",  # blank-line-required-between-summary-and-description (false-positives on the standard license header docstring present in ~400 files)
     "D209",  # new-line-after-last-paragraph
     "D212",  # inconsistent with D213 (multi-line-summary-first-line)
     "D213",  # inconsistent with D212 (multi-line-summary-first-line)
@@ -127,7 +126,6 @@ ignore = [
     "D416",  # section-name-should-end-with-colon
     "PLC0415",  # import not at top of file (lazy/function-level imports to avoid circular imports)
     "E402",  # module-level import not at top of file (imports after a module docstring)
-    "E501",  # line too long
 ]
 
 [tool.coverage.run]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -115,6 +115,7 @@ select = ["I", "E", "W", "D", "PL", "F"]
 
 ignore = [
     "D203",  # inconsistent with D211 (no-blank-line-before-class)
+    "D205",  # blank-line-required-between-summary-and-description (false-positives on the standard license header docstring present in ~400 files)
     "D209",  # new-line-after-last-paragraph
     "D212",  # inconsistent with D213 (multi-line-summary-first-line)
     "D213",  # inconsistent with D212 (multi-line-summary-first-line)
@@ -126,6 +127,7 @@ ignore = [
     "D416",  # section-name-should-end-with-colon
     "PLC0415",  # import not at top of file (lazy/function-level imports to avoid circular imports)
     "E402",  # module-level import not at top of file (imports after a module docstring)
+    "E501",  # line too long
 ]
 
 [tool.coverage.run]

--- a/src/qrisp/algorithms/gqsp/hamiltonian_simulation.py
+++ b/src/qrisp/algorithms/gqsp/hamiltonian_simulation.py
@@ -236,8 +236,7 @@ def hamiltonian_simulation(
 
 @jax.jit
 def jax_jv(m: "ArrayLike", x: "ArrayLike", M: int = 1000):
-    r"""Pure JAX implementation of the Bessel function of the first kind, J_m(x),
-    for integer orders m.
+    r"""Pure JAX implementation of the Bessel function of the first kind, J_m(x), for integer orders m.
 
     This function evaluates the integral representation of the Bessel function
     using the numerical Midpoint rule, which is highly stable and avoids

--- a/src/qrisp/algorithms/gqsp/hamiltonian_simulation.py
+++ b/src/qrisp/algorithms/gqsp/hamiltonian_simulation.py
@@ -236,8 +236,7 @@ def hamiltonian_simulation(
 
 @jax.jit
 def jax_jv(m: "ArrayLike", x: "ArrayLike", M: int = 1000):
-    r"""
-    Pure JAX implementation of the Bessel function of the first kind, J_m(x),
+    r"""Pure JAX implementation of the Bessel function of the first kind, J_m(x),
     for integer orders m.
 
     This function evaluates the integral representation of the Bessel function
@@ -256,6 +255,7 @@ def jax_jv(m: "ArrayLike", x: "ArrayLike", M: int = 1000):
         Argument to evaluate.
     M : int, optional
         Number of integration steps. M=250 is perfectly accurate up to x ≈ 100.
+
     """
     m = jnp.asarray(m)
     x = jnp.asarray(x)

--- a/src/qrisp/circuit/pass_management/pass_manager.py
+++ b/src/qrisp/circuit/pass_management/pass_manager.py
@@ -35,7 +35,7 @@ class PassManager:
     ``CircuitPass(my_func)``.
 
     Example:
-    --------
+    -------
     Build a pipeline with ``+=``, then inspect, insert, and remove passes::
 
         >>> from qrisp import PassManager

--- a/src/qrisp/jasp/evaluation_tools/boolean_simulation.py
+++ b/src/qrisp/jasp/evaluation_tools/boolean_simulation.py
@@ -63,7 +63,7 @@ def boolean_simulation(
     bit_array_padding: int = 2**16,
     callback_threshold: int | None = None,
 ) -> Callable:
-    """Decorator to simulate Jasp functions containing only classical logic (like X, CX, CCX etc.).
+    r"""Decorator to simulate Jasp functions containing only classical logic (like X, CX, CCX etc.).
 
     This decorator transforms the function into a JAX expression without any
     quantum primitives and leverages the JAX compilation pipeline to compile

--- a/src/qrisp/jasp/evaluation_tools/boolean_simulation.py
+++ b/src/qrisp/jasp/evaluation_tools/boolean_simulation.py
@@ -35,9 +35,9 @@
 #    code, it can be used to benchmark the classical logic portion of algorithms.
 #
 # Supported Operations:
-# - X, SWAP gates (unconditional bit operations)
-# - Controlled variants: CX, CCX, CSWAP, multi-controlled X, etc.
-# - Phase gates (Z, S, T, RZ, P): These are no-ops in classical simulation
+# - X, Y, SWAP gates (unconditional bit operations)
+# - Controlled variants: CX, CY, CCX, CSWAP, multi-controlled X/Y, etc.
+# - Phase gates (Z, S, T, S_dg, T_dg, RZ, P): These are no-ops in classical simulation
 # - Measurement: Returns the current classical bit values
 #
 # Unsupported Operations:
@@ -87,7 +87,7 @@ def boolean_simulation(
         sized arrays but Jasp supports dynamically sized QuantumVariables, the
         array has to be "padded". The padding therefore indicates an upper boundary
         for how many qubits are required to execute ``func``. A large padding
-        slows down the simulation but prevents overflow errors.The default is
+        slows down the simulation but prevents overflow errors. The default is
         ``2**16``. The minimum value is 64. This threshold describes the maximum
         OVERALL amount of qubits that can appear in the simulation. The maximum
         amount per QuantumVariable/per QuantumArray is tied to this number
@@ -141,7 +141,7 @@ def boolean_simulation(
             return measure(c)
 
     This script evaluates the multiplication of the two inputs 150 times and adds
-    them into the same QuantumFloat. The respected result is therefore ``i*j*150``.
+    them into the same QuantumFloat. The expected result is therefore ``i*j*150``.
 
     >>> main(1,2)
     Array(300., dtype=float64)
@@ -201,7 +201,8 @@ def boolean_simulation(
     >>> main(1,2)
     Array(8.92323439e+08, dtype=float64)
 
-    A faulty result because the script needs more than 64 qubits.
+    A faulty result (instead of the expected one) because the script
+    needs more than 64 qubits.
 
     Increasing the padding ensures that enough qubits are available at the cost
     of simulation speed.
@@ -221,7 +222,7 @@ def boolean_simulation(
     target_func: Callable = func[0]
 
     if bit_array_padding < 64:
-        raise Exception("Tried to initialize boolean_simulation with less than 512 bits")
+        raise Exception("Tried to initialize boolean_simulation with less than 64 bits")
 
     @jit
     def return_function(*args: Any) -> Any:

--- a/src/qrisp/jasp/evaluation_tools/buffered_quantum_state.py
+++ b/src/qrisp/jasp/evaluation_tools/buffered_quantum_state.py
@@ -99,7 +99,6 @@ class BufferedQuantumState:
 
     def apply_buffer(self) -> None:
         """Flush every buffered gate into the backend quantum state."""
-
         if self.simulator == "qrisp":
             assert isinstance(self.quantum_state, QuantumState)
             self.quantum_state = advance_quantum_state(
@@ -145,7 +144,6 @@ class BufferedQuantumState:
 
     def reset(self, qubit: Sequence[Qubit]) -> None:
         """Reset a qubit to the |0> state via measurement and a conditional flip."""
-
         if qubit[0] not in self.qubit_to_index_dict:
             return
 

--- a/src/qrisp/jasp/evaluation_tools/catalyst_qjit.py
+++ b/src/qrisp/jasp/evaluation_tools/catalyst_qjit.py
@@ -21,8 +21,8 @@ from qrisp.jasp.jasp_expression import make_jaspr
 
 
 def qjit(function=None, device=None):
-    """Decorator to leverage the jasp + Catalyst infrastructure to compile the given
-    function to QIR and run it on the Catalyst QIR runtime.
+    """Decorator to leverage the jasp + Catalyst infrastructure to compile the given function to QIR and run it on the Catalyst QIR runtime.
+
     Requires the Catalyst package to be installed (``pip install qrisp[catalyst]``).
 
     Parameters

--- a/src/qrisp/jasp/evaluation_tools/catalyst_qjit.py
+++ b/src/qrisp/jasp/evaluation_tools/catalyst_qjit.py
@@ -21,7 +21,7 @@ from qrisp.jasp.jasp_expression import make_jaspr
 
 
 def qjit(function=None, device=None):
-    """Decorator to leverage the jasp + Catalyst infrastructure to compile the given function to QIR and run it on the Catalyst QIR runtime.
+    """Decorator that compiles the given function to QIR and runs it on the Catalyst QIR runtime via jasp + Catalyst.
 
     Requires the Catalyst package to be installed (``pip install qrisp[catalyst]``).
 

--- a/src/qrisp/jasp/evaluation_tools/catalyst_qjit.py
+++ b/src/qrisp/jasp/evaluation_tools/catalyst_qjit.py
@@ -85,11 +85,11 @@ def qjit(function=None, device=None):
     We execute the function a couple of times to demonstrate the randomness
 
     >>> test_fun(4)
-    [array(5.25, dtype=float64)]
+    Array(5.25, dtype=float64)
     >>> test_fun(5)
-    [array(3., dtype=float64)]
+    Array(3., dtype=float64)
     >>> test_fun(5)
-    [array(7.25, dtype=float64)]
+    Array(7.25, dtype=float64)
 
 
     For executing on "lightning.gpu" we specify the device:

--- a/src/qrisp/jasp/evaluation_tools/jaspification.py
+++ b/src/qrisp/jasp/evaluation_tools/jaspification.py
@@ -432,7 +432,7 @@ def compile_cl_func(jaxpr: Jaxpr, function_name: str) -> tuple[Callable, list[bo
 
 
 def _jaspr_has_name(jaxpr, target_name):
-    """Return True if *target_name* appears as a ``jit`` call name in *jaxpr* or its nested sub-jaxprs, skipping ``user_func`` subtrees."""
+    """Return True if *target_name* is a ``jit`` call name in *jaxpr* or a sub-jaxpr, skipping ``user_func``."""
     for eqn in jaxpr.jaxpr.eqns:
         if eqn.primitive.name == "jit":
             if eqn.params.get("name") == target_name:

--- a/src/qrisp/jasp/evaluation_tools/jaspification.py
+++ b/src/qrisp/jasp/evaluation_tools/jaspification.py
@@ -228,7 +228,7 @@ def stimulate(func: Callable) -> Callable:
             return measure(qf)
 
         print(main())
-        # Yields either 0.0 or 31.0
+        # Yields either 0 or 31
 
     """
 

--- a/src/qrisp/jasp/evaluation_tools/jaspification.py
+++ b/src/qrisp/jasp/evaluation_tools/jaspification.py
@@ -432,7 +432,8 @@ def compile_cl_func(jaxpr: Jaxpr, function_name: str) -> tuple[Callable, list[bo
 
 def _jaspr_has_name(jaxpr, target_name):
     """Return True if *target_name* appears as a ``jit`` call name in *jaxpr*
-    or its nested sub-jaxprs, skipping ``user_func`` subtrees."""
+    or its nested sub-jaxprs, skipping ``user_func`` subtrees.
+    """
     for eqn in jaxpr.jaxpr.eqns:
         if eqn.primitive.name == "jit":
             if eqn.params.get("name") == target_name:

--- a/src/qrisp/jasp/evaluation_tools/jaspification.py
+++ b/src/qrisp/jasp/evaluation_tools/jaspification.py
@@ -61,7 +61,7 @@ def jaspify(func: Callable | bool | None = None, terminal_sampling: bool = False
     terminal_sampling : bool, optional
         Whether to leverage the terminal sampling strategy. Significantly fast
         for all sampling tasks but can yield incorrect results in some situations.
-        Check out :ref:`terminal_sampling` form more details. The default is False.
+        Check out :ref:`terminal_sampling` for more details. The default is False.
 
     Returns
     -------
@@ -228,7 +228,7 @@ def stimulate(func: Callable) -> Callable:
             return measure(qf)
 
         print(main())
-        # Yields either 0 or 31
+        # Yields either 0.0 or 31.0
 
     """
 

--- a/src/qrisp/jasp/evaluation_tools/jaspification.py
+++ b/src/qrisp/jasp/evaluation_tools/jaspification.py
@@ -44,6 +44,7 @@ from qrisp.jasp.primitives import (
 
 def jaspify(func: Callable | bool | None = None, terminal_sampling: bool = False) -> Callable:
     """This simulator is the established Qrisp simulator linked to the Jasp infrastructure.
+
     Among a variety of simulation tricks, the simulator can leverage state sparsity,
     allowing simulations with up to hundreds of qubits!
 
@@ -431,9 +432,7 @@ def compile_cl_func(jaxpr: Jaxpr, function_name: str) -> tuple[Callable, list[bo
 
 
 def _jaspr_has_name(jaxpr, target_name):
-    """Return True if *target_name* appears as a ``jit`` call name in *jaxpr*
-    or its nested sub-jaxprs, skipping ``user_func`` subtrees.
-    """
+    """Return True if *target_name* appears as a ``jit`` call name in *jaxpr* or its nested sub-jaxprs, skipping ``user_func`` subtrees."""
     for eqn in jaxpr.jaxpr.eqns:
         if eqn.primitive.name == "jit":
             if eqn.params.get("name") == target_name:

--- a/src/qrisp/jasp/evaluation_tools/profiler.py
+++ b/src/qrisp/jasp/evaluation_tools/profiler.py
@@ -112,6 +112,7 @@ def _normalize_meas_behavior(meas_behavior: str | Callable) -> Callable:
 
 def count_ops(meas_behavior: str | Callable, callback_threshold: int | None = None) -> Callable:
     """Decorator to determine resources of large scale quantum computations.
+
     This decorator compiles the given Jasp-compatible function into a classical
     function computing the amount of each gates required. The decorated function
     will return a dictionary containing the operation counts.

--- a/src/qrisp/jasp/evaluation_tools/profiler.py
+++ b/src/qrisp/jasp/evaluation_tools/profiler.py
@@ -179,12 +179,12 @@ def count_ops(meas_behavior: str | Callable, callback_threshold: int | None = No
             return measure(c)
 
         print(main(5))
-        # {'s': 45, 'x': 22, 't_dg': 98, 'cx': 510, 't': 96, 'h': 139, 'measure': 55}
+        # {'t': 100, 's': 50, 't_dg': 100, 'h': 139, 'x': 22, 'cx': 577, 'measure': 49}
         print(main(5000))
-        # {'t': 751506, 'h': 1127254, 'x': 2002, 's': 375750, 't_dg': 751508, 'cx': 4629255, 'measure': 752500}
+        # {'t': 75025000, 's': 37512500, 't_dg': 75025000, 'h': 112527499, 'x': 20002, 'cx': 500089987, 'measure': 37512499}
 
     Note that even though the second computation contains more than 800 million gates,
-    determining the resources takes less than 200ms, highlighting the scalability
+    determining the resources takes well under a second, highlighting the scalability
     features of the Jasp infrastructure.
 
     **Modifying the measurement behavior via a random number generator**
@@ -238,7 +238,7 @@ def count_ops(meas_behavior: str | Callable, callback_threshold: int | None = No
     measurements.
 
     For some algorithms (such as :ref:`RUS`) sampling the measurement result
-    from a simple distribution won't cut it because the required ressource can
+    from a simple distribution won't cut it because the required resources can
     be heavily influenced by measurement outcomes. For this matter it is also
     possible to perform a full simulation. Note that this simulation is no
     longer deterministic.
@@ -258,9 +258,9 @@ def count_ops(meas_behavior: str | Callable, callback_threshold: int | None = No
             return measure(qv)
 
         print(main(0))
-        {'measure': 4, 'x': 2}
+        # {'measure': 4, 'x': 2}
         print(main(1))
-        {'measure': 4}
+        # {'measure': 4}
 
     """
 
@@ -388,7 +388,7 @@ def depth(
 
     .. warning::
 
-        The depth metric an experimental feature and may not behave as expected in certain edge cases.
+        The depth metric is an experimental feature and may not behave as expected in certain edge cases.
 
         -   The memory management operations ``reset`` and ``delete`` are currently ignored.
             Qubits freed by these calls still count toward the ``max_qubits`` limit.

--- a/src/qrisp/jasp/evaluation_tools/profiler.py
+++ b/src/qrisp/jasp/evaluation_tools/profiler.py
@@ -182,7 +182,8 @@ def count_ops(meas_behavior: str | Callable, callback_threshold: int | None = No
         print(main(5))
         # {'t': 100, 's': 50, 't_dg': 100, 'h': 139, 'x': 22, 'cx': 577, 'measure': 49}
         print(main(5000))
-        # {'t': 75025000, 's': 37512500, 't_dg': 75025000, 'h': 112527499, 'x': 20002, 'cx': 500089987, 'measure': 37512499}
+        # {'t': 75025000, 's': 37512500, 't_dg': 75025000, 'h': 112527499,
+        #  'x': 20002, 'cx': 500089987, 'measure': 37512499}
 
     Note that even though the second computation contains more than 800 million gates,
     determining the resources takes well under a second, highlighting the scalability

--- a/src/qrisp/jasp/evaluation_tools/terminal_sampling.py
+++ b/src/qrisp/jasp/evaluation_tools/terminal_sampling.py
@@ -19,7 +19,7 @@ from qrisp.jasp.jasp_expression import make_jaspr
 
 
 def terminal_sampling(func=None, shots=0):
-    """The ``terminal_sampling`` decorator performs a hybrid simulation and afterwards samples from the resulting quantum state.
+    """The ``terminal_sampling`` decorator runs a hybrid simulation and samples from the resulting quantum state.
 
     The idea behind this function is that it is very cheap for a classical simulator
     to sample from a given quantum state without simulating the whole state from

--- a/src/qrisp/jasp/evaluation_tools/terminal_sampling.py
+++ b/src/qrisp/jasp/evaluation_tools/terminal_sampling.py
@@ -19,8 +19,8 @@ from qrisp.jasp.jasp_expression import make_jaspr
 
 
 def terminal_sampling(func=None, shots=0):
-    """The ``terminal_sampling`` decorator performs a hybrid simulation and afterwards
-    samples from the resulting quantum state.
+    """The ``terminal_sampling`` decorator performs a hybrid simulation and afterwards samples from the resulting quantum state.
+
     The idea behind this function is that it is very cheap for a classical simulator
     to sample from a given quantum state without simulating the whole state from
     scratch. For quantum simulators that simulate pure quantum computations

--- a/src/qrisp/jasp/evaluation_tools/terminal_sampling.py
+++ b/src/qrisp/jasp/evaluation_tools/terminal_sampling.py
@@ -29,7 +29,7 @@ def terminal_sampling(func=None, shots=0):
     because mid-circuit measurements can alter the classical computation.
 
     In general, generating N samples from a hybrid program requires N executions
-    of said programm. If it is however known that the quantum state is the same
+    of said program. If it is however known that the quantum state is the same
     regardless of mid-circuit measurement outcomes, we can use the terminal sampling
     function. If this condition is not met, the ``terminal_sampling`` function
     will not return a valid distribution. A demonstration for this is given in the
@@ -43,6 +43,11 @@ def terminal_sampling(func=None, shots=0):
         are **not** supported — use :func:`~qrisp.jasp.sample` with
         ``@jaspify(terminal_sampling=False)`` (the default) for those.
 
+        Additionally, terminal sampling currently cannot be combined with the
+        ``stim`` simulator backend (i.e. calling the lower-level
+        ``simulate_jaspr`` with both ``simulator="stim"`` and
+        ``terminal_sampling=True`` raises an exception).
+
     To use the terminal sampling decorator, a Jasp-compatible sampling kernel
     returning some QuantumVariables has to be given as a parameter.
 
@@ -51,8 +56,9 @@ def terminal_sampling(func=None, shots=0):
     func : callable
         A Jasp-compatible sampling kernel returning QuantumVariables.
     shots : int, optional
-        An integer specifying the amount of shots. The default is None, which
-        will result in probabilities being returned.
+        An integer specifying the amount of shots. The default is ``0``,
+        which results in the exact probabilities being returned instead of
+        shot-sampled counts.
 
     Returns
     -------
@@ -90,12 +96,12 @@ def terminal_sampling(func=None, shots=0):
 
     **Example of invalid use**
 
-    In this example we demonstrate a hybrid program that can not be properly sample
+    In this example we demonstrate a hybrid program that can not be properly sampled
     via ``terminal_sampling``. The key ingredient here is a realtime component.
 
     ::
 
-        from qrisp import QuantumBool, measure, control
+        from qrisp import QuantumBool, QuantumFloat, h, measure, control
 
         @terminal_sampling
         def main():

--- a/src/qrisp/jasp/interpreter_tools/interpreters/control_flow_interpretation.py
+++ b/src/qrisp/jasp/interpreter_tools/interpreters/control_flow_interpretation.py
@@ -1,4 +1,5 @@
 """********************************************************************************
+
 * Copyright (c) 2026 the Qrisp authors
 *
 * This program and the accompanying materials are made available under the

--- a/src/qrisp/jasp/interpreter_tools/interpreters/control_flow_interpretation.py
+++ b/src/qrisp/jasp/interpreter_tools/interpreters/control_flow_interpretation.py
@@ -1,5 +1,4 @@
-"""
-********************************************************************************
+"""********************************************************************************
 * Copyright (c) 2026 the Qrisp authors
 *
 * This program and the accompanying materials are made available under the
@@ -32,8 +31,7 @@ from qrisp.jasp.interpreter_tools import (
 
 
 def evaluate_cond_eqn(cond_eqn: JaxprEqn, context_dic: ContextDict, eqn_evaluator: Callable = exec_eqn) -> None:
-    """
-    Evaluates a JAX condition equation within the context of the JASP interpreter.
+    """Evaluates a JAX condition equation within the context of the JASP interpreter.
 
     This function handles the branching logic of jax.lax.cond or similar primitives.
     It determines which branch to execute based on the condition variable.
@@ -47,8 +45,8 @@ def evaluate_cond_eqn(cond_eqn: JaxprEqn, context_dic: ContextDict, eqn_evaluato
     Raises:
         Exception: If the condition variable depends on a Qrisp ProcessedMeasurement (real-time feedback),
                    which cannot be resolved during circuit generation/interpretation.
-    """
 
+    """
     # Extract the invalues from the context dic
     invalues = extract_invalues(cond_eqn, context_dic)
 
@@ -76,8 +74,7 @@ def evaluate_while_loop(
     eqn_evaluator: Callable = exec_eqn,
     break_after_first_iter: bool = False,
 ) -> None:
-    """
-    Evaluates a JAX while loop equation within the context of the JASP interpreter.
+    """Evaluates a JAX while loop equation within the context of the JASP interpreter.
 
     This handles `jax.lax.while_loop`, performing iterations as long as the condition function
     returns True.
@@ -90,8 +87,8 @@ def evaluate_while_loop(
 
     Raises:
         Exception: If the loop condition depends on a Qrisp ProcessedMeasurement.
-    """
 
+    """
     # Deferred import: qc_extraction_interpreter (where ProcessedMeasurement is
     # defined) is loaded after control_flow_interpretation within
     # interpreter_tools.interpreters, so this can't be a top-level import.
@@ -142,8 +139,7 @@ def evaluate_while_loop(
 
 
 def evaluate_scan(scan_eq: JaxprEqn, context_dic: ContextDict, eqn_evaluator: Callable = exec_eqn) -> None:
-    """
-    Evaluates a JAX scan equation within the context of the JASP interpreter.
+    """Evaluates a JAX scan equation within the context of the JASP interpreter.
 
     This handles `jax.lax.scan` (and `jax.lax.map` which lowers to scan). It iterates
     over input arrays, applying a function that carries state, and stacks the outputs.
@@ -152,8 +148,8 @@ def evaluate_scan(scan_eq: JaxprEqn, context_dic: ContextDict, eqn_evaluator: Ca
         scan_eq (jax.core.JaxprEqn): The equation representing the scan operation.
         context_dic (dict): Dictionary mapping variables to their values.
         eqn_evaluator (function, optional): Function to evaluate the scanned body equation.
-    """
 
+    """
     invalues = extract_invalues(scan_eq, context_dic)
 
     f = eval_jaxpr(scan_eq.params["jaxpr"], eqn_evaluator=eqn_evaluator)

--- a/src/qrisp/jasp/interpreter_tools/interpreters/traced_control_flow_interpretation.py
+++ b/src/qrisp/jasp/interpreter_tools/interpreters/traced_control_flow_interpretation.py
@@ -1,5 +1,4 @@
-"""
-********************************************************************************
+"""********************************************************************************
 * Copyright (c) 2026 the Qrisp authors
 *
 * This program and the accompanying materials are made available under the

--- a/src/qrisp/jasp/interpreter_tools/interpreters/traced_control_flow_interpretation.py
+++ b/src/qrisp/jasp/interpreter_tools/interpreters/traced_control_flow_interpretation.py
@@ -1,4 +1,5 @@
 """********************************************************************************
+
 * Copyright (c) 2026 the Qrisp authors
 *
 * This program and the accompanying materials are made available under the

--- a/src/qrisp/jasp/jasp_expression/centerclass.py
+++ b/src/qrisp/jasp/jasp_expression/centerclass.py
@@ -1,5 +1,4 @@
-"""
-********************************************************************************
+"""********************************************************************************
 * Copyright (c) 2026 the Qrisp authors
 *
 * This program and the accompanying materials are made available under the
@@ -37,8 +36,7 @@ from qrisp.jasp.primitives import AbstractQuantumState
 
 
 class Jaspr(ClosedJaxpr):
-    """
-    The ``Jaspr`` class enables an efficient representation of a wide variety
+    """The ``Jaspr`` class enables an efficient representation of a wide variety
     of (hybrid) algorithms. For many applications, the representation is agnostic
     to the scale of the problem, implying function calls with 10 or 10000 qubits
     can be represented by the same object. The actual unfolding to a circuit-level
@@ -246,8 +244,7 @@ class Jaspr(ClosedJaxpr):
         return res
 
     def inverse(self) -> "Jaspr":
-        """
-        Returns the inverse Jaspr (if applicable). For Jaspr that contain realtime
+        """Returns the inverse Jaspr (if applicable). For Jaspr that contain realtime
         computations or measurements, the inverse does not exist.
 
         Returns
@@ -257,7 +254,6 @@ class Jaspr(ClosedJaxpr):
 
         Examples
         --------
-
         We create a simple script and inspect the daggered version:
 
         ::
@@ -283,12 +279,12 @@ class Jaspr(ClosedJaxpr):
             #     g:QuantumState = jasp.quantum_gate[gate=t_dg] f d
             #     h:QuantumState = jasp.quantum_gate[gate=cx] e f g
             #   in (c, h) }
+
         """
         return invert_jaspr(self)
 
     def control(self, num_ctrl: int, ctrl_state: int | str = -1) -> "Jaspr":
-        """
-        Returns the controlled version of the Jaspr. The control qubits are added
+        """Returns the controlled version of the Jaspr. The control qubits are added
         to the signature of the Jaspr as the arguments after the QuantumState.
 
         Parameters
@@ -305,7 +301,6 @@ class Jaspr(ClosedJaxpr):
 
         Examples
         --------
-
         We create a simple script and inspect the controlled version:
 
         ::
@@ -357,8 +352,7 @@ class Jaspr(ClosedJaxpr):
         return ControlledJaspr.from_cache(self, ctrl_state)
 
     def to_qc(self, *args):
-        """
-        Converts the Jaspr into a :ref:`QuantumCircuit` if applicable. Circuit
+        """Converts the Jaspr into a :ref:`QuantumCircuit` if applicable. Circuit
         conversion of algorithms involving realtime computations is not possible.
 
         Any computations that perform classical postprocessing of measurements
@@ -382,7 +376,6 @@ class Jaspr(ClosedJaxpr):
 
         Examples
         --------
-
         We create a simple script and inspect the QuantumCircuit:
 
         ::
@@ -437,8 +430,7 @@ class Jaspr(ClosedJaxpr):
         return jaspr_to_qc(self, *args)
 
     def extract_post_processing(self, *args) -> Callable:
-        """
-        Extracts the post-processing logic from this Jaspr and returns a function
+        """Extracts the post-processing logic from this Jaspr and returns a function
         that performs the post-processing on measurement results.
 
         This method is useful for separating the quantum circuit from the classical
@@ -467,7 +459,6 @@ class Jaspr(ClosedJaxpr):
 
         Examples
         --------
-
         We create a Jaspr that performs post-processing on measurement results:
 
         ::
@@ -513,6 +504,7 @@ class Jaspr(ClosedJaxpr):
         Note that the static arguments (in this case `1`) must be the same as those
         used for circuit extraction, since they affect the structure of both the
         quantum circuit and the post-processing logic.
+
         """
         from qrisp.jasp.interpreter_tools.interpreters import extract_post_processing
 
@@ -523,8 +515,7 @@ class Jaspr(ClosedJaxpr):
         return eval_jaxpr(self, eqn_evaluator=eqn_evaluator)(*args)
 
     def flatten_environments(self) -> "Jaspr":
-        """
-        Flattens all environments by applying the corresponding compilation
+        """Flattens all environments by applying the corresponding compilation
         routines such that no more ``q_env`` primitives are left.
 
         Returns
@@ -534,7 +525,6 @@ class Jaspr(ClosedJaxpr):
 
         Examples
         --------
-
         Create a Jaspr with ``flatten_envs=False`` so that the
         :ref:`InversionEnvironment` is still visible as a ``jasp.q_env`` primitive:
 
@@ -687,8 +677,7 @@ class Jaspr(ClosedJaxpr):
         return res
 
     def qjit(self, *args, function_name: str = "jaspr_function", device=None) -> Any:
-        """
-        Leverages the Catalyst pipeline to compile a QIR representation of
+        """Leverages the Catalyst pipeline to compile a QIR representation of
         this function and executes that function using the Catalyst QIR runtime.
         Requires the Catalyst package to be installed (``pip install qrisp[catalyst]``).
 
@@ -727,8 +716,7 @@ class Jaspr(ClosedJaxpr):
     @classmethod
     @qrisp_lru_compilation_cache
     def from_cache(cls, closed_jaxpr: ClosedJaxpr) -> "Jaspr":
-        """
-        Construct a :class:`Jaspr` from a :class:`~jax.extend.core.ClosedJaxpr`,
+        """Construct a :class:`Jaspr` from a :class:`~jax.extend.core.ClosedJaxpr`,
         caching the result so that repeated calls with the same argument are free.
 
         :func:`remove_redundant_allocations` is run on the newly created instance to
@@ -743,6 +731,7 @@ class Jaspr(ClosedJaxpr):
         -------
         Jaspr
             The corresponding :class:`Jaspr` instance.
+
         """
         res = Jaspr(jaxpr=closed_jaxpr.jaxpr, consts=closed_jaxpr.consts)
         remove_redundant_allocations(res)
@@ -760,8 +749,7 @@ class Jaspr(ClosedJaxpr):
         )
 
     def to_qir(self) -> str:
-        """
-        Compiles the Jaspr to QIR using the `Catalyst framework <https://docs.pennylane.ai/projects/catalyst/en/stable/index.html>`__.
+        """Compiles the Jaspr to QIR using the `Catalyst framework <https://docs.pennylane.ai/projects/catalyst/en/stable/index.html>`__.
         Requires the Catalyst package to be installed (``pip install qrisp[catalyst]``).
 
         Returns
@@ -771,7 +759,6 @@ class Jaspr(ClosedJaxpr):
 
         Examples
         --------
-
         We create a simple script and inspect the QIR string:
 
         ::
@@ -791,7 +778,8 @@ class Jaspr(ClosedJaxpr):
             jaspr = make_jaspr(example_function)(2)
             print(jaspr.to_qir())
 
-        Yields:
+        Yields
+        ------
 
         .. code-block:: none
 
@@ -881,8 +869,7 @@ class Jaspr(ClosedJaxpr):
         return jaspr_to_qir(self.flatten_environments())
 
     def to_mlir(self, lower_stablehlo: bool = False) -> Any:
-        """
-        Compiles the Jaspr to an xDSL module using the Jasp Dialect.
+        """Compiles the Jaspr to an xDSL module using the Jasp Dialect.
         Requires the xDSL package to be installed (``pip install qrisp[xdsl]``).
 
         .. note::
@@ -916,7 +903,6 @@ class Jaspr(ClosedJaxpr):
 
         Examples
         --------
-
         We create a simple script and inspect the MLIR string:
 
         ::
@@ -983,8 +969,7 @@ class Jaspr(ClosedJaxpr):
         return jaspr_to_mlir(self, lower_stablehlo)
 
     def to_catalyst_mlir(self) -> str | None:
-        """
-        Compiles the Jaspr to MLIR using the `Catalyst dialect <https://docs.pennylane.ai/projects/catalyst/en/stable/index.html>`__.
+        """Compiles the Jaspr to MLIR using the `Catalyst dialect <https://docs.pennylane.ai/projects/catalyst/en/stable/index.html>`__.
         Requires the Catalyst package to be installed (``pip install qrisp[catalyst]``).
 
         Returns
@@ -994,7 +979,6 @@ class Jaspr(ClosedJaxpr):
 
         Examples
         --------
-
         We create a simple script and inspect the MLIR string:
 
         ::
@@ -1073,8 +1057,7 @@ class Jaspr(ClosedJaxpr):
         return jaspr_to_mlir(self.flatten_environments())
 
     def to_qasm(self, *args) -> str:
-        """
-        Compiles the Jaspr into an OpenQASM 2 string. Real-time control is possible
+        """Compiles the Jaspr into an OpenQASM 2 string. Real-time control is possible
         as long as no computations on the measurement results are performed.
 
         Parameters
@@ -1089,7 +1072,6 @@ class Jaspr(ClosedJaxpr):
 
         Examples
         --------
-
         We create a simple script and inspect the QASM 2 string:
 
         ::
@@ -1171,8 +1153,7 @@ class Jaspr(ClosedJaxpr):
         return qrisp_qc.qasm()
 
     def to_catalyst_jaxpr(self) -> Any:
-        """
-        Compiles the jaspr to the corresponding `Catalyst jaxpr <https://docs.pennylane.ai/projects/catalyst/en/stable/index.html>`__.
+        """Compiles the jaspr to the corresponding `Catalyst jaxpr <https://docs.pennylane.ai/projects/catalyst/en/stable/index.html>`__.
         Requires the Catalyst package to be installed (``pip install qrisp[catalyst]``).
 
         Returns
@@ -1182,7 +1163,6 @@ class Jaspr(ClosedJaxpr):
 
         Examples
         --------
-
         We create a simple script and inspect the Catalyst Jaxpr:
 
         ::
@@ -1265,8 +1245,7 @@ def make_jaxpr_mod(
     return_shape: bool = False,
     abstracted_axes: Any = None,
 ) -> Callable:
-    """
-    Creates a function that produces the jaxpr of a traced function.
+    """Creates a function that produces the jaxpr of a traced function.
 
     This is a modified version of JAX's ``make_jaxpr`` that supports
     ``return_shape=True`` even when the function returns custom abstract
@@ -1312,6 +1291,7 @@ def make_jaxpr_mod(
     ...     return {"a": x + 1, "b": x * 2}
     >>> jaxpr, out_tree = make_jaxpr_mod(f, return_shape=True)(1.0)
     >>> # out_tree can be used with tree_unflatten to reconstruct the dict
+
     """
 
     def jaxpr_creator(*args, **kwargs):
@@ -1342,8 +1322,7 @@ def make_jaspr(
     return_shape: bool = False,
     **jax_kwargs,
 ) -> Callable:
-    """
-    Creates a function that returns the Jaspr representation of a quantum function.
+    """Creates a function that returns the Jaspr representation of a quantum function.
 
     This function is analogous to JAX's ``make_jaxpr``, but produces a Jaspr
     (a Jaxpr enhanced with quantum primitives) from a Qrisp quantum function.
@@ -1375,7 +1354,6 @@ def make_jaspr(
 
     Examples
     --------
-
     **Basic quantum circuit with measurement**
 
     Create a Jaspr for a simple Bell state circuit:
@@ -1528,8 +1506,7 @@ def check_aval_equivalence(invars_1, invars_2) -> bool:
 
 
 def remove_redundant_allocations(closed_jaxpr: ClosedJaxpr) -> None:
-    """
-    Optimise a Jaspr in-place by removing redundant qubit allocations.
+    """Optimise a Jaspr in-place by removing redundant qubit allocations.
 
     A ``jasp.create_qubits`` equation is considered redundant when its output
     ``QubitArray`` is not returned by the function *and* every use of that array
@@ -1551,8 +1528,8 @@ def remove_redundant_allocations(closed_jaxpr: ClosedJaxpr) -> None:
     closed_jaxpr : ClosedJaxpr
         The Jaspr (or ClosedJaxpr) to optimise.  Modified in-place; nothing is
         returned.
-    """
 
+    """
     jaxpr = closed_jaxpr.jaxpr
     eqns = jaxpr.eqns
 

--- a/src/qrisp/jasp/jasp_expression/centerclass.py
+++ b/src/qrisp/jasp/jasp_expression/centerclass.py
@@ -36,8 +36,9 @@ from qrisp.jasp.primitives import AbstractQuantumState
 
 
 class Jaspr(ClosedJaxpr):
-    """The ``Jaspr`` class enables an efficient representation of a wide variety
-    of (hybrid) algorithms. For many applications, the representation is agnostic
+    """The ``Jaspr`` class enables an efficient representation of a wide variety of (hybrid) algorithms.
+
+    For many applications, the representation is agnostic
     to the scale of the problem, implying function calls with 10 or 10000 qubits
     can be represented by the same object. The actual unfolding to a circuit-level
     description is outsourced to
@@ -244,7 +245,9 @@ class Jaspr(ClosedJaxpr):
         return res
 
     def inverse(self) -> "Jaspr":
-        """Returns the inverse Jaspr (if applicable). For Jaspr that contain realtime
+        """Returns the inverse Jaspr (if applicable).
+
+        For Jaspr that contain realtime
         computations or measurements, the inverse does not exist.
 
         Returns
@@ -284,7 +287,9 @@ class Jaspr(ClosedJaxpr):
         return invert_jaspr(self)
 
     def control(self, num_ctrl: int, ctrl_state: int | str = -1) -> "Jaspr":
-        """Returns the controlled version of the Jaspr. The control qubits are added
+        """Returns the controlled version of the Jaspr.
+
+        The control qubits are added
         to the signature of the Jaspr as the arguments after the QuantumState.
 
         Parameters
@@ -352,7 +357,9 @@ class Jaspr(ClosedJaxpr):
         return ControlledJaspr.from_cache(self, ctrl_state)
 
     def to_qc(self, *args):
-        """Converts the Jaspr into a :ref:`QuantumCircuit` if applicable. Circuit
+        """Converts the Jaspr into a :ref:`QuantumCircuit` if applicable.
+
+        Circuit
         conversion of algorithms involving realtime computations is not possible.
 
         Any computations that perform classical postprocessing of measurements
@@ -430,8 +437,7 @@ class Jaspr(ClosedJaxpr):
         return jaspr_to_qc(self, *args)
 
     def extract_post_processing(self, *args) -> Callable:
-        """Extracts the post-processing logic from this Jaspr and returns a function
-        that performs the post-processing on measurement results.
+        """Extracts the post-processing logic from this Jaspr and returns a function that performs the post-processing on measurement results.
 
         This method is useful for separating the quantum circuit from the classical
         post-processing of measurement results. The quantum circuit can be executed
@@ -515,8 +521,7 @@ class Jaspr(ClosedJaxpr):
         return eval_jaxpr(self, eqn_evaluator=eqn_evaluator)(*args)
 
     def flatten_environments(self) -> "Jaspr":
-        """Flattens all environments by applying the corresponding compilation
-        routines such that no more ``q_env`` primitives are left.
+        """Flattens all environments by applying the corresponding compilation routines such that no more ``q_env`` primitives are left.
 
         Returns
         -------
@@ -677,8 +682,8 @@ class Jaspr(ClosedJaxpr):
         return res
 
     def qjit(self, *args, function_name: str = "jaspr_function", device=None) -> Any:
-        """Leverages the Catalyst pipeline to compile a QIR representation of
-        this function and executes that function using the Catalyst QIR runtime.
+        """Leverages the Catalyst pipeline to compile a QIR representation of this function and executes that function using the Catalyst QIR runtime.
+
         Requires the Catalyst package to be installed (``pip install qrisp[catalyst]``).
 
         Parameters
@@ -716,8 +721,7 @@ class Jaspr(ClosedJaxpr):
     @classmethod
     @qrisp_lru_compilation_cache
     def from_cache(cls, closed_jaxpr: ClosedJaxpr) -> "Jaspr":
-        """Construct a :class:`Jaspr` from a :class:`~jax.extend.core.ClosedJaxpr`,
-        caching the result so that repeated calls with the same argument are free.
+        """Construct a :class:`Jaspr` from a :class:`~jax.extend.core.ClosedJaxpr`, caching the result so that repeated calls with the same argument are free.
 
         :func:`remove_redundant_allocations` is run on the newly created instance to
         clean up any trivially unused qubit allocations produced during tracing.
@@ -749,7 +753,8 @@ class Jaspr(ClosedJaxpr):
         )
 
     def to_qir(self) -> str:
-        """Compiles the Jaspr to QIR using the `Catalyst framework <https://docs.pennylane.ai/projects/catalyst/en/stable/index.html>`__.
+        r"""Compiles the Jaspr to QIR using the `Catalyst framework <https://docs.pennylane.ai/projects/catalyst/en/stable/index.html>`__.
+
         Requires the Catalyst package to be installed (``pip install qrisp[catalyst]``).
 
         Returns
@@ -870,6 +875,7 @@ class Jaspr(ClosedJaxpr):
 
     def to_mlir(self, lower_stablehlo: bool = False) -> Any:
         """Compiles the Jaspr to an xDSL module using the Jasp Dialect.
+
         Requires the xDSL package to be installed (``pip install qrisp[xdsl]``).
 
         .. note::

--- a/src/qrisp/jasp/jasp_expression/centerclass.py
+++ b/src/qrisp/jasp/jasp_expression/centerclass.py
@@ -402,9 +402,9 @@ class Jaspr(ClosedJaxpr):
             qb_list, qc = jaspr.to_qc(2)
             print(qc)
             # Yields
-            # qb_59: ──■───────
+            # qb_0: ──■───────
             #        ┌─┴─┐┌───┐
-            # qb_60: ┤ X ├┤ T ├
+            # qb_1: ┤ X ├┤ T ├
             #        └───┘└───┘
 
         To demonstrate the behavior under measurement post-processing, we build
@@ -797,12 +797,10 @@ class Jaspr(ClosedJaxpr):
 
             ; ModuleID = 'LLVMDialectModule'
             source_filename = "LLVMDialectModule"
-            target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
-            target triple = "x86_64-unknown-linux-gnu"
 
             @"{'mcmc': False, 'num_burnin': 0, 'kernel_name': None}" = internal constant [54 x i8] c"{'mcmc': False, 'num_burnin': 0, 'kernel_name': None}\00"
             @LightningSimulator = internal constant [19 x i8] c"LightningSimulator\00"
-            @"/home/positr0nium/miniconda3/envs/qrisp/lib/python3.10/site-packages/pennylane_lightning/liblightning_qubit_catalyst.so" = internal constant [...] c"...\00"
+            @... = internal constant [...] c"...\00"
             @__constant_30xi64 = private constant [30 x i64] [i64 30, i64 29, ..., i64 1], align 64
             @__constant_xi64 = private constant i64 0, align 64
 
@@ -827,7 +825,7 @@ class Jaspr(ClosedJaxpr):
             declare ptr @_mlir_memref_to_llvm_alloc(i64)
 
             define { ptr, ptr, i64 } @jit_jaspr_function(ptr %0, ptr %1, i64 %2) {
-              call void @__catalyst__rt__device_init(ptr @"/home/positr0nium/miniconda3/envs/qrisp/lib/python3.10/site-packages/pennylane_lightning/liblightning_qubit_catalyst.so", ptr @LightningSimulator, ptr @"{'mcmc': False, 'num_burnin': 0, 'kernel_name': None}", i64 0, i1 true)
+              call void @__catalyst__rt__device_init(...)
               %4 = call ptr @__catalyst__rt__qubit_allocate_array(i64 20)
               ... (bookkeeping: allocates and threads a 1024-entry dynamic
                    qubit-index stack through a couple of loops, using the
@@ -1023,7 +1021,7 @@ class Jaspr(ClosedJaxpr):
                 %cst = stablehlo.constant dense<1.000000e+00> : tensor<f64>
                 %c_4 = stablehlo.constant dense<0> : tensor<i64>
                 %c0_i64 = arith.constant 0 : i64
-                quantum.device shots(%c0_i64) ["/home/positr0nium/miniconda3/envs/qrisp/lib/python3.10/site-packages/pennylane_lightning/liblightning_qubit_catalyst.so", "LightningSimulator", "{'mcmc': False, 'num_burnin': 0, 'kernel_name': None}"] {auto_qubit_management}
+                quantum.device shots(%c0_i64) [..., "LightningSimulator", "{'mcmc': False, 'num_burnin': 0, 'kernel_name': None}"] {auto_qubit_management}
                 %0 = quantum.alloc( 20) : !quantum.reg
                 ... (bookkeeping: a %c_3-seeded ``stablehlo.while`` populates a
                      30-entry index stack via calls to @_pop/@_append, resolving

--- a/src/qrisp/jasp/jasp_expression/centerclass.py
+++ b/src/qrisp/jasp/jasp_expression/centerclass.py
@@ -402,10 +402,10 @@ class Jaspr(ClosedJaxpr):
             qb_list, qc = jaspr.to_qc(2)
             print(qc)
             # Yields
-            # qb_0: ──■───────
-            #       ┌─┴─┐┌───┐
-            # qb_1: ┤ X ├┤ T ├
-            #       └───┘└───┘
+            # qb_59: ──■───────
+            #        ┌─┴─┐┌───┐
+            # qb_60: ┤ X ├┤ T ├
+            #        └───┘└───┘
 
         To demonstrate the behavior under measurement post-processing, we build
         a similar script:
@@ -797,241 +797,85 @@ class Jaspr(ClosedJaxpr):
 
             ; ModuleID = 'LLVMDialectModule'
             source_filename = "LLVMDialectModule"
+            target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
+            target triple = "x86_64-unknown-linux-gnu"
 
-            @"{'shots': 0, 'mcmc': False, 'num_burnin': 0, 'kernel_name': None}" = internal constant [66 x i8] c"{'shots': 0, 'mcmc': False, 'num_burnin': 0, 'kernel_name': None}\00"
-            @lightning.qubit = internal constant [16 x i8] c"lightning.qubit\00"
-            @"/home/positr0nium/miniconda3/envs/qrisp/lib/python3.10/site-packages/catalyst/utils/../lib/librtd_lightning.so" = internal constant [111 x i8] c"/home/positr0nium/miniconda3/envs/qrisp/lib/python3.10/site-packages/catalyst/utils/../lib/librtd_lightning.so\00"
+            @"{'mcmc': False, 'num_burnin': 0, 'kernel_name': None}" = internal constant [54 x i8] c"{'mcmc': False, 'num_burnin': 0, 'kernel_name': None}\00"
+            @LightningSimulator = internal constant [19 x i8] c"LightningSimulator\00"
+            @"/home/positr0nium/miniconda3/envs/qrisp/lib/python3.10/site-packages/pennylane_lightning/liblightning_qubit_catalyst.so" = internal constant [...] c"...\00"
+            @__constant_30xi64 = private constant [30 x i64] [i64 30, i64 29, ..., i64 1], align 64
+            @__constant_xi64 = private constant i64 0, align 64
 
-            declare void @__catalyst__rt__finalize() local_unnamed_addr
+            declare void @__catalyst__rt__finalize()
 
-            declare void @__catalyst__rt__initialize() local_unnamed_addr
+            declare void @__catalyst__rt__initialize(ptr)
 
-            declare ptr @__catalyst__qis__Measure(ptr, i32) local_unnamed_addr
+            declare ptr @__catalyst__qis__Measure(ptr, i32)
 
-            declare void @__catalyst__qis__T(ptr, ptr) local_unnamed_addr
+            declare void @__catalyst__qis__T(ptr, ptr)
 
-            declare void @__catalyst__qis__CNOT(ptr, ptr, ptr) local_unnamed_addr
+            declare void @__catalyst__qis__CNOT(ptr, ptr, ptr)
 
-            declare ptr @__catalyst__rt__array_get_element_ptr_1d(ptr, i64) local_unnamed_addr
+            declare ptr @__catalyst__rt__array_get_element_ptr_1d(ptr, i64)
 
-            declare ptr @__catalyst__rt__qubit_allocate_array(i64) local_unnamed_addr
+            declare ptr @__catalyst__rt__qubit_allocate_array(i64)
 
-            declare void @__catalyst__rt__device_init(ptr, ptr, ptr) local_unnamed_addr
+            declare void @__catalyst__rt__device_init(ptr, ptr, ptr, i64, i1)
 
-            declare void @_mlir_memref_to_llvm_free(ptr) local_unnamed_addr
+            declare void @_mlir_memref_to_llvm_free(ptr)
 
-            declare ptr @_mlir_memref_to_llvm_alloc(i64) local_unnamed_addr
+            declare ptr @_mlir_memref_to_llvm_alloc(i64)
 
-            define { ptr, ptr, i64 } @jit_jaspr_function(ptr nocapture readnone %0, ptr nocapture readonly %1, i64 %2) local_unnamed_addr {
-              tail call void @__catalyst__rt__device_init(ptr nonnull @"/home/positr0nium/miniconda3/envs/qrisp/lib/python3.10/site-packages/catalyst/utils/../lib/librtd_lightning.so", ptr nonnull @lightning.qubit, ptr nonnull @"{'shots': 0, 'mcmc': False, 'num_burnin': 0, 'kernel_name': None}")
-              %4 = tail call ptr @__catalyst__rt__qubit_allocate_array(i64 20)
-              %5 = tail call ptr @__catalyst__rt__array_get_element_ptr_1d(ptr %4, i64 0)
-              %6 = load ptr, ptr %5, align 8
-              %7 = tail call ptr @__catalyst__rt__array_get_element_ptr_1d(ptr %4, i64 1)
-              %8 = load ptr, ptr %7, align 8
-              tail call void @__catalyst__qis__CNOT(ptr %6, ptr %8, ptr null)
-              %9 = tail call ptr @__catalyst__rt__array_get_element_ptr_1d(ptr %4, i64 1)
-              %10 = load ptr, ptr %9, align 8
-              tail call void @__catalyst__qis__T(ptr %10, ptr null)
-              %11 = tail call ptr @_mlir_memref_to_llvm_alloc(i64 65)
-              %12 = ptrtoint ptr %11 to i64
-              %13 = add i64 %12, 63
-              %14 = and i64 %13, -64
-              %15 = inttoptr i64 %14 to ptr
-              %16 = tail call ptr @_mlir_memref_to_llvm_alloc(i64 65)
-              %17 = ptrtoint ptr %16 to i64
-              %18 = add i64 %17, 63
-              %19 = and i64 %18, -64
-              %20 = inttoptr i64 %19 to ptr
-              %21 = tail call ptr @_mlir_memref_to_llvm_alloc(i64 72)
-              %22 = ptrtoint ptr %21 to i64
-              %23 = add i64 %22, 63
-              %24 = and i64 %23, -64
-              %25 = inttoptr i64 %24 to ptr
-              %26 = tail call ptr @_mlir_memref_to_llvm_alloc(i64 72)
-              %27 = ptrtoint ptr %26 to i64
-              %28 = add i64 %27, 63
-              %29 = and i64 %28, -64
-              %30 = inttoptr i64 %29 to ptr
-              %31 = tail call ptr @_mlir_memref_to_llvm_alloc(i64 72)
-              %32 = ptrtoint ptr %31 to i64
-              %33 = add i64 %32, 63
-              %34 = and i64 %33, -64
-              %35 = inttoptr i64 %34 to ptr
-              %36 = tail call ptr @_mlir_memref_to_llvm_alloc(i64 72)
-              %37 = ptrtoint ptr %36 to i64
-              %38 = add i64 %37, 63
-              %39 = and i64 %38, -64
-              %40 = inttoptr i64 %39 to ptr
-              %41 = tail call ptr @_mlir_memref_to_llvm_alloc(i64 8)
-              store i64 0, ptr %41, align 1
-              %42 = tail call ptr @_mlir_memref_to_llvm_alloc(i64 8)
-              store i64 0, ptr %42, align 1
-              %43 = load i64, ptr %1, align 4
-              %44 = icmp slt i64 %43, 1
-              store i1 %44, ptr %15, align 64
-              %45 = tail call ptr @_mlir_memref_to_llvm_alloc(i64 8)
-              %46 = load i64, ptr %42, align 1
-              store i64 %46, ptr %45, align 1
-              tail call void @_mlir_memref_to_llvm_free(ptr nonnull %42)
-              %47 = tail call ptr @_mlir_memref_to_llvm_alloc(i64 8)
-              %48 = load i64, ptr %41, align 1
-              store i64 %48, ptr %47, align 1
-              tail call void @_mlir_memref_to_llvm_free(ptr nonnull %41)
-              br i1 %44, label %.lr.ph, label %._crit_edge
-
-            .lr.ph:                                           ; preds = %3, %.lr.ph
-              %49 = phi ptr [ %87, %.lr.ph ], [ %47, %3 ]
-              %50 = phi ptr [ %85, %.lr.ph ], [ %45, %3 ]
-              %51 = load i64, ptr %50, align 4
-              %52 = tail call ptr @__catalyst__rt__array_get_element_ptr_1d(ptr %4, i64 %51)
-              %53 = load ptr, ptr %52, align 8
-              %54 = tail call ptr @__catalyst__qis__Measure(ptr %53, i32 -1)
-              %55 = load i1, ptr %54, align 1
-              store i1 %55, ptr %20, align 64
-              %56 = load i64, ptr %50, align 4
-              store i64 %56, ptr %25, align 64
-              %57 = shl i64 2, %56
-              %58 = icmp ult i64 %56, 64
-              %59 = select i1 %58, i64 %57, i64 0
-              store i64 %59, ptr %30, align 64
-              %60 = load i1, ptr %20, align 64
-              %61 = zext i1 %60 to i64
-              store i64 %61, ptr %35, align 64
-              %62 = load i64, ptr %30, align 64
-              %63 = select i1 %60, i64 %62, i64 0
-              store i64 %63, ptr %40, align 64
-              %64 = tail call ptr @_mlir_memref_to_llvm_alloc(i64 72)
-              %65 = ptrtoint ptr %64 to i64
-              %66 = add i64 %65, 63
-              %67 = and i64 %66, -64
-              %68 = inttoptr i64 %67 to ptr
-              %69 = load i64, ptr %49, align 4
-              %70 = load i64, ptr %40, align 64
-              %71 = add i64 %70, %69
-              store i64 %71, ptr %68, align 64
-              tail call void @_mlir_memref_to_llvm_free(ptr nonnull %49)
-              %72 = tail call ptr @_mlir_memref_to_llvm_alloc(i64 72)
-              %73 = ptrtoint ptr %72 to i64
-              %74 = add i64 %73, 63
-              %75 = and i64 %74, -64
-              %76 = inttoptr i64 %75 to ptr
-              %77 = load i64, ptr %50, align 4
-              %78 = add i64 %77, 1
-              store i64 %78, ptr %76, align 64
-              tail call void @_mlir_memref_to_llvm_free(ptr nonnull %50)
-              %79 = tail call ptr @_mlir_memref_to_llvm_alloc(i64 8)
-              %80 = load i64, ptr %68, align 64
-              store i64 %80, ptr %79, align 1
-              tail call void @_mlir_memref_to_llvm_free(ptr %64)
-              %81 = tail call ptr @_mlir_memref_to_llvm_alloc(i64 8)
-              %82 = load i64, ptr %76, align 64
-              store i64 %82, ptr %81, align 1
-              tail call void @_mlir_memref_to_llvm_free(ptr %72)
-              %.pre = load i64, ptr %81, align 4
-              %83 = load i64, ptr %1, align 4
-              %84 = icmp sge i64 %.pre, %83
-              store i1 %84, ptr %15, align 64
-              %85 = tail call ptr @_mlir_memref_to_llvm_alloc(i64 8)
-              %86 = load i64, ptr %81, align 1
-              store i64 %86, ptr %85, align 1
-              tail call void @_mlir_memref_to_llvm_free(ptr nonnull %81)
-              %87 = tail call ptr @_mlir_memref_to_llvm_alloc(i64 8)
-              %88 = load i64, ptr %79, align 1
-              store i64 %88, ptr %87, align 1
-              tail call void @_mlir_memref_to_llvm_free(ptr nonnull %79)
-              br i1 %84, label %.lr.ph, label %._crit_edge
-
-            ._crit_edge:                                      ; preds = %.lr.ph, %3
-              %.lcssa20 = phi ptr [ %45, %3 ], [ %85, %.lr.ph ]
-              %.lcssa = phi ptr [ %47, %3 ], [ %87, %.lr.ph ]
-              tail call void @_mlir_memref_to_llvm_free(ptr nonnull %.lcssa20)
-              tail call void @_mlir_memref_to_llvm_free(ptr %36)
-              tail call void @_mlir_memref_to_llvm_free(ptr %31)
-              tail call void @_mlir_memref_to_llvm_free(ptr %26)
-              tail call void @_mlir_memref_to_llvm_free(ptr %21)
-              tail call void @_mlir_memref_to_llvm_free(ptr %16)
-              tail call void @_mlir_memref_to_llvm_free(ptr %11)
-              %89 = tail call ptr @_mlir_memref_to_llvm_alloc(i64 68)
-              %90 = ptrtoint ptr %89 to i64
-              %91 = add i64 %90, 63
-              %92 = and i64 %91, -64
-              %93 = inttoptr i64 %92 to ptr
-              %94 = load i64, ptr %.lcssa, align 4
-              %95 = trunc i64 %94 to i32
-              store i32 %95, ptr %93, align 64
-              tail call void @_mlir_memref_to_llvm_free(ptr nonnull %.lcssa)
-              %96 = tail call ptr @_mlir_memref_to_llvm_alloc(i64 68)
-              %97 = ptrtoint ptr %96 to i64
-              %98 = add i64 %97, 63
-              %99 = and i64 %98, -64
-              %100 = inttoptr i64 %99 to ptr
-              %101 = load i32, ptr %93, align 64
-              %102 = add i32 %101, 1
-              store i32 %102, ptr %100, align 64
-              tail call void @_mlir_memref_to_llvm_free(ptr %89)
-              %103 = icmp eq ptr %96, inttoptr (i64 3735928559 to ptr)
-              br i1 %103, label %104, label %107
-
-            104:                                              ; preds = %._crit_edge
-              %105 = tail call ptr @_mlir_memref_to_llvm_alloc(i64 4)
-              %106 = load i32, ptr %100, align 64
-              store i32 %106, ptr %105, align 1
-              br label %107
-
-            107:                                              ; preds = %104, %._crit_edge
-              %.pn16 = phi ptr [ %105, %104 ], [ %96, %._crit_edge ]
-              %.pn14 = phi ptr [ %105, %104 ], [ %100, %._crit_edge ]
-              %.pn13 = insertvalue { ptr, ptr, i64 } undef, ptr %.pn16, 0
-              %.pn = insertvalue { ptr, ptr, i64 } %.pn13, ptr %.pn14, 1
-              %108 = insertvalue { ptr, ptr, i64 } %.pn, i64 0, 2
-              ret { ptr, ptr, i64 } %108
+            define { ptr, ptr, i64 } @jit_jaspr_function(ptr %0, ptr %1, i64 %2) {
+              call void @__catalyst__rt__device_init(ptr @"/home/positr0nium/miniconda3/envs/qrisp/lib/python3.10/site-packages/pennylane_lightning/liblightning_qubit_catalyst.so", ptr @LightningSimulator, ptr @"{'mcmc': False, 'num_burnin': 0, 'kernel_name': None}", i64 0, i1 true)
+              %4 = call ptr @__catalyst__rt__qubit_allocate_array(i64 20)
+              ... (bookkeeping: allocates and threads a 1024-entry dynamic
+                   qubit-index stack through a couple of loops, using the
+                   @_append.detensorized / @_pop.detensorized /
+                   @make_tracer.detensorized helper functions defined further
+                   below, to resolve the array offsets %50 and %54 used by
+                   the gate calls right below) ...
+              call void @__catalyst__qis__CNOT(ptr %50, ptr %54, ptr null)
+              call void @__catalyst__qis__T(ptr %54, ptr null)
+              ... (bookkeeping, resolving the offset for the qubit measured
+                   below) ...
+              %73 = call ptr @__catalyst__qis__Measure(ptr %72, i32 -1)
+              ... (post-processing the measurement result into the returned
+                   value) ...
+              ret { ptr, ptr, i64 } %103
             }
 
-            define void @_catalyst_pyface_jit_jaspr_function(ptr nocapture writeonly %0, ptr nocapture readonly %1) local_unnamed_addr {
-              %.unpack = load ptr, ptr %1, align 8
-              %.elt1.i = getelementptr inbounds { ptr, ptr, i64 }, ptr %.unpack, i64 0, i32 1
-              %.unpack2.i = load ptr, ptr %.elt1.i, align 8
-              %3 = tail call { ptr, ptr, i64 } @jit_jaspr_function(ptr poison, ptr %.unpack2.i, i64 poison)
-              %.elt.i = extractvalue { ptr, ptr, i64 } %3, 0
-              store ptr %.elt.i, ptr %0, align 8
-              %.repack5.i = getelementptr inbounds { ptr, ptr, i64 }, ptr %0, i64 0, i32 1
-              %.elt6.i = extractvalue { ptr, ptr, i64 } %3, 1
-              store ptr %.elt6.i, ptr %.repack5.i, align 8
-              %.repack7.i = getelementptr inbounds { ptr, ptr, i64 }, ptr %0, i64 0, i32 2
-              %.elt8.i = extractvalue { ptr, ptr, i64 } %3, 2
-              store i64 %.elt8.i, ptr %.repack7.i, align 8
+            define void @_catalyst_pyface_jit_jaspr_function(ptr %0, ptr %1) {
+              ...
+            }
+
+            define void @_catalyst_ciface_jit_jaspr_function(ptr %0, ptr %1) {
+              ...
+            }
+
+            define void @setup() {
+              call void @__catalyst__rt__initialize(ptr null)
               ret void
             }
 
-            define void @_catalyst_ciface_jit_jaspr_function(ptr nocapture writeonly %0, ptr nocapture readonly %1) local_unnamed_addr {
-              %.elt1 = getelementptr inbounds { ptr, ptr, i64 }, ptr %1, i64 0, i32 1
-              %.unpack2 = load ptr, ptr %.elt1, align 8
-              %3 = tail call { ptr, ptr, i64 } @jit_jaspr_function(ptr poison, ptr %.unpack2, i64 poison)
-              %.elt = extractvalue { ptr, ptr, i64 } %3, 0
-              store ptr %.elt, ptr %0, align 8
-              %.repack5 = getelementptr inbounds { ptr, ptr, i64 }, ptr %0, i64 0, i32 1
-              %.elt6 = extractvalue { ptr, ptr, i64 } %3, 1
-              store ptr %.elt6, ptr %.repack5, align 8
-              %.repack7 = getelementptr inbounds { ptr, ptr, i64 }, ptr %0, i64 0, i32 2
-              %.elt8 = extractvalue { ptr, ptr, i64 } %3, 2
-              store i64 %.elt8, ptr %.repack7, align 8
+            define void @teardown() {
+              call void @__catalyst__rt__finalize()
               ret void
             }
 
-            define void @setup() local_unnamed_addr {
-              tail call void @__catalyst__rt__initialize()
-              ret void
+            define internal { { ptr, ptr, i64, [1 x i64], [1 x i64] }, i64 } @_append.detensorized(...) {
+              ...
             }
 
-            define void @teardown() local_unnamed_addr {
-              tail call void @__catalyst__rt__finalize()
-              ret void
+            define internal { i64, i64 } @_pop.detensorized(...) {
+              ...
             }
 
-            !llvm.module.flags = !{!0}
+            define internal i64 @make_tracer.detensorized(i64 %0) {
+              ...
+            }
 
-            !0 = !{i32 2, !"Debug Info Version", i32 3}
+            declare void @llvm.memcpy.p0.p0.i64(ptr noalias writeonly captures(none), ptr noalias readonly captures(none), i64, i1 immarg) #0
 
         """
         from qrisp.jasp.evaluation_tools.catalyst_interface import jaspr_to_qir
@@ -1097,19 +941,41 @@ class Jaspr(ClosedJaxpr):
         .. code-block:: none
 
             builtin.module @jasp_module {
-              func.func public @main(%arg0 : tensor<i64>, %arg1 : !jasp.QuantumState) -> (tensor<i64>, !jasp.QuantumState) {
-                %0, %1 = "jasp.create_qubits"(%arg0, %arg1) : (tensor<i64>, !jasp.QuantumState) -> (!jasp.QubitArray, !jasp.QuantumState)
+              func.func public @main(%arg13: tensor<i64>, %arg14: !jasp.QuantumState) -> (tensor<i64>, !jasp.QuantumState) {
+                %0, %1 = jasp.create_qubits %arg13, %arg14 : tensor<i64>, !jasp.QuantumState -> !jasp.QubitArray, !jasp.QuantumState
                 %2 = "stablehlo.constant"() <{value = dense<0> : tensor<i64>}> : () -> tensor<i64>
-                %3 = "jasp.get_qubit"(%0, %2) : (!jasp.QubitArray, tensor<i64>) -> !jasp.Qubit
+                %3 = jasp.get_qubit %0, %2 : !jasp.QubitArray, tensor<i64> -> !jasp.Qubit
                 %4 = "stablehlo.constant"() <{value = dense<1> : tensor<i64>}> : () -> tensor<i64>
-                %5 = "jasp.get_qubit"(%0, %4) : (!jasp.QubitArray, tensor<i64>) -> !jasp.Qubit
-                %6 = "jasp.quantum_gate"(%3, %5, %1) {gate_type = "cx"} : (!jasp.Qubit, !jasp.Qubit, !jasp.QuantumState) -> !jasp.QuantumState
-                %7 = "jasp.quantum_gate"(%5, %6) {gate_type = "t"} : (!jasp.Qubit, !jasp.QuantumState) -> !jasp.QuantumState
-                %8, %9 = "jasp.measure"(%0, %7) : (!jasp.QubitArray, !jasp.QuantumState) -> (tensor<i64>, !jasp.QuantumState)
+                %5 = jasp.get_qubit %0, %4 : !jasp.QubitArray, tensor<i64> -> !jasp.Qubit
+                %6 = jasp.quantum_gate "cx" (%3, %5) , %1 : (!jasp.Qubit, !jasp.Qubit) , !jasp.QuantumState -> !jasp.QuantumState
+                %7 = jasp.quantum_gate "t" (%5) , %6 : (!jasp.Qubit) , !jasp.QuantumState -> !jasp.QuantumState
+                %8, %9 = jasp.measure %0, %7 : !jasp.QubitArray, !jasp.QuantumState -> tensor<i64>, !jasp.QuantumState
                 %10 = "stablehlo.add"(%8, %4) : (tensor<i64>, tensor<i64>) -> tensor<i64>
-                %11 = "jasp.reset"(%0, %9) : (!jasp.QubitArray, !jasp.QuantumState) -> !jasp.QuantumState
-                %12 = "jasp.delete_qubits"(%0, %11) : (!jasp.QubitArray, !jasp.QuantumState) -> !jasp.QuantumState
-                func.return %10, %12 : tensor<i64>, !jasp.QuantumState
+                func.return %10, %9 : tensor<i64>, !jasp.QuantumState
+              }
+              func.func private @jasp.create_qubits(%arg11: tensor<i64>, %arg12: !jasp.QuantumState) -> (!jasp.QubitArray, !jasp.QuantumState) {
+                %0, %1 = jasp.create_qubits %arg11, %arg12 : tensor<i64>, !jasp.QuantumState -> !jasp.QubitArray, !jasp.QuantumState
+                func.return %0, %1 : !jasp.QubitArray, !jasp.QuantumState
+              }
+              func.func private @jasp.get_qubit(%arg9: !jasp.QubitArray, %arg10: tensor<i64>) -> !jasp.Qubit {
+                %0 = jasp.get_qubit %arg9, %arg10 : !jasp.QubitArray, tensor<i64> -> !jasp.Qubit
+                func.return %0 : !jasp.Qubit
+              }
+              func.func private @jasp.quantum_gate(%arg6: !jasp.Qubit, %arg7: !jasp.Qubit, %arg8: !jasp.QuantumState) -> !jasp.QuantumState {
+                %0 = jasp.quantum_gate "cx" (%arg6, %arg7) , %arg8 : (!jasp.Qubit, !jasp.Qubit) , !jasp.QuantumState -> !jasp.QuantumState
+                func.return %0 : !jasp.QuantumState
+              }
+              func.func private @jasp.quantum_gate_0(%arg4: !jasp.Qubit, %arg5: !jasp.QuantumState) -> !jasp.QuantumState {
+                %0 = jasp.quantum_gate "t" (%arg4) , %arg5 : (!jasp.Qubit) , !jasp.QuantumState -> !jasp.QuantumState
+                func.return %0 : !jasp.QuantumState
+              }
+              func.func private @jasp.measure(%arg2: !jasp.QubitArray, %arg3: !jasp.QuantumState) -> (tensor<i64>, !jasp.QuantumState) {
+                %0, %1 = jasp.measure %arg2, %arg3 : !jasp.QubitArray, !jasp.QuantumState -> tensor<i64>, !jasp.QuantumState
+                func.return %0, %1 : tensor<i64>, !jasp.QuantumState
+              }
+              func.func private @add(%arg0: tensor<i64>, %arg1: tensor<i64>) -> tensor<i64> {
+                %0 = "stablehlo.add"(%arg0, %arg1) : (tensor<i64>, tensor<i64>) -> tensor<i64>
+                func.return %0 : tensor<i64>
               }
             }
 
@@ -1152,48 +1018,47 @@ class Jaspr(ClosedJaxpr):
 
         .. code-block:: none
 
-                        module @jaspr_function {
-              func.func public @jit_jaspr_function(%arg0: tensor<i64>) -> tensor<i32> attributes {llvm.emit_c_interface} {
-                %0 = stablehlo.constant dense<1> : tensor<i32>
-                %1 = stablehlo.constant dense<2> : tensor<i64>
-                %2 = stablehlo.constant dense<1> : tensor<i64>
-                %3 = stablehlo.constant dense<0> : tensor<i64>
-                quantum.device["/home/positr0nium/miniconda3/envs/qrisp/lib/python3.10/site-packages/catalyst/utils/../lib/librtd_lightning.so", "lightning.qubit", "{'shots': 0, 'mcmc': False, 'num_burnin': 0, 'kernel_name': None}"]
-                %4 = quantum.alloc( 20) : !quantum.reg
-                %5 = quantum.extract %4[ 0] : !quantum.reg -> !quantum.bit
-                %6 = quantum.extract %4[ 1] : !quantum.reg -> !quantum.bit
-                %out_qubits:2 = quantum.custom "CNOT"() %5, %6 : !quantum.bit, !quantum.bit
-                %7 = quantum.insert %4[ 0], %out_qubits#0 : !quantum.reg, !quantum.bit
-                %8 = quantum.insert %7[ 1], %out_qubits#1 : !quantum.reg, !quantum.bit
-                %9 = quantum.extract %8[ 1] : !quantum.reg -> !quantum.bit
-                %out_qubits_0 = quantum.custom "T"() %9 : !quantum.bit
-                %10 = quantum.insert %8[ 1], %out_qubits_0 : !quantum.reg, !quantum.bit
-                %11 = stablehlo.add %3, %arg0 : tensor<i64>
-                %12:3 = scf.while (%arg1 = %3, %arg2 = %3, %arg3 = %10) : (tensor<i64>, tensor<i64>, !quantum.reg) -> (tensor<i64>, tensor<i64>, !quantum.reg) {
-                  %16 = stablehlo.compare  GE, %arg1, %11,  SIGNED : (tensor<i64>, tensor<i64>) -> tensor<i1>
-                  %extracted = tensor.extract %16[] : tensor<i1>
-                  scf.condition(%extracted) %arg1, %arg2, %arg3 : tensor<i64>, tensor<i64>, !quantum.reg
+            module @jaspr_function {
+              func.func public @jit_jaspr_function(%arg0: tensor<i64>) -> tensor<f64> attributes {llvm.emit_c_interface} {
+                %cst = stablehlo.constant dense<1.000000e+00> : tensor<f64>
+                %c_4 = stablehlo.constant dense<0> : tensor<i64>
+                %c0_i64 = arith.constant 0 : i64
+                quantum.device shots(%c0_i64) ["/home/positr0nium/miniconda3/envs/qrisp/lib/python3.10/site-packages/pennylane_lightning/liblightning_qubit_catalyst.so", "LightningSimulator", "{'mcmc': False, 'num_burnin': 0, 'kernel_name': None}"] {auto_qubit_management}
+                %0 = quantum.alloc( 20) : !quantum.reg
+                ... (bookkeeping: a %c_3-seeded ``stablehlo.while`` populates a
+                     30-entry index stack via calls to @_pop/@_append, resolving
+                     the dynamic qubit positions %11 and %19 used below) ...
+                %extracted = tensor.extract %11[] : tensor<i64>
+                %20 = quantum.extract %0[%extracted] : !quantum.reg -> !quantum.bit
+                %extracted_5 = tensor.extract %19[] : tensor<i64>
+                %21 = quantum.extract %0[%extracted_5] : !quantum.reg -> !quantum.bit
+                %out_qubits:2 = quantum.custom "CNOT"() %20, %21 : !quantum.bit, !quantum.bit
+                %extracted_6 = tensor.extract %11[] : tensor<i64>
+                %22 = quantum.insert %0[%extracted_6], %out_qubits#0 : !quantum.reg, !quantum.bit
+                %extracted_7 = tensor.extract %19[] : tensor<i64>
+                %23 = quantum.insert %22[%extracted_7], %out_qubits#1 : !quantum.reg, !quantum.bit
+                %extracted_8 = tensor.extract %19[] : tensor<i64>
+                %24 = quantum.extract %23[%extracted_8] : !quantum.reg -> !quantum.bit
+                %out_qubits_9 = quantum.custom "T"() %24 : !quantum.bit
+                %extracted_10 = tensor.extract %19[] : tensor<i64>
+                %25 = quantum.insert %23[%extracted_10], %out_qubits_9 : !quantum.reg, !quantum.bit
+                %26:3 = scf.while (%arg1 = %c_4, %arg2 = %c_4, %arg3 = %25) : (tensor<i64>, tensor<i64>, !quantum.reg) -> (tensor<i64>, tensor<i64>, !quantum.reg) {
+                  ...
                 } do {
                 ^bb0(%arg1: tensor<i64>, %arg2: tensor<i64>, %arg3: !quantum.reg):
-                  %extracted = tensor.extract %arg1[] : tensor<i64>
-                  %16 = quantum.extract %arg3[%extracted] : !quantum.reg -> !quantum.bit
-                  %mres, %out_qubit = quantum.measure %16 : i1, !quantum.bit
-                  %from_elements = tensor.from_elements %mres : tensor<i1>
-                  %extracted_1 = tensor.extract %arg1[] : tensor<i64>
-                  %17 = quantum.insert %arg3[%extracted_1], %out_qubit : !quantum.reg, !quantum.bit
-                  %18 = stablehlo.subtract %arg1, %3 : tensor<i64>
-                  %19 = stablehlo.shift_left %1, %18 : tensor<i64>
-                  %20 = stablehlo.convert %from_elements : (tensor<i1>) -> tensor<i64>
-                  %21 = stablehlo.multiply %19, %20 : tensor<i64>
-                  %22 = stablehlo.add %arg2, %21 : tensor<i64>
-                  %23 = stablehlo.add %arg1, %2 : tensor<i64>
-                  scf.yield %23, %22, %17 : tensor<i64>, tensor<i64>, !quantum.reg
+                  ...
+                  %mres, %out_qubit = quantum.measure %35 : i1, !quantum.bit
+                  ...
+                  scf.yield %41, %40, %36 : tensor<i64>, tensor<i64>, !quantum.reg
                 }
-                %13 = stablehlo.convert %12#1 : (tensor<i64>) -> tensor<i32>
-                %14 = stablehlo.multiply %13, %0 : tensor<i32>
-                %15 = stablehlo.add %14, %0 : tensor<i32>
-                return %15 : tensor<i32>
+                %27 = stablehlo.convert %26#1 : (tensor<i64>) -> tensor<f64>
+                %28 = stablehlo.multiply %27, %cst : tensor<f64>
+                %29 = stablehlo.add %28, %cst : tensor<f64>
+                return %29 : tensor<f64>
               }
+              func.func private @make_tracer(...) { ... }
+              func.func private @_pop(...) { ... }
+              func.func private @_append(...) { ... }
               func.func @setup() {
                 quantum.init
                 return
@@ -1340,45 +1205,53 @@ class Jaspr(ClosedJaxpr):
 
             print(jaspr.to_catalyst_jaxpr())
             # Yields
-            # { lambda ; a:AbstractQreg() b:i64[] c:i32[]. let
-            #   d:i64[] = convert_element_type[new_dtype=int64 weak_type=True] c
-            #   e:i64[] = add b d
-            #   f:i64[] = add b 0
-            #   g:i64[] = add b 1
-            #   h:AbstractQbit() = qextract a f
-            #   i:AbstractQbit() = qextract a g
-            #   j:AbstractQbit() k:AbstractQbit() = qinst[op=CNOT qubits_len=2] h i
-            #   l:AbstractQreg() = qinsert a f j
-            #   m:AbstractQreg() = qinsert l g k
-            #   n:AbstractQbit() = qextract m g
-            #   o:AbstractQbit() = qinst[op=T qubits_len=1] n
-            #   p:AbstractQreg() = qinsert m g o
-            #   q:i64[] = convert_element_type[new_dtype=int64 weak_type=True] c
-            #   r:i64[] = add b q
-            #   _:i64[] s:i64[] t:AbstractQreg() _:i64[] _:i64[] = while_loop[
-            #     body_jaxpr={ lambda ; u:i64[] v:i64[] w:AbstractQreg() x:i64[] y:i64[]. let
-            #         z:AbstractQbit() = qextract w u
-            #         ba:bool[] bb:AbstractQbit() = qmeasure z
-            #         bc:AbstractQreg() = qinsert w u bb
-            #         bd:i64[] = sub u x
-            #         be:i64[] = shift_left 2 bd
-            #         bf:i64[] = convert_element_type[new_dtype=int64 weak_type=True] ba
-            #         bg:i64[] = mul be bf
-            #         bh:i64[] = add v bg
-            #         bi:i64[] = add u 1
-            #       in (bi, bh, bc, x, y) }
+            # { lambda ; a:i64[] b:AbstractQreg() c:i64[30] d:i64[]. let
+            #   ... (bookkeeping: a `while` loop populates a 30-entry index
+            #        stack `c` via jit-wrapped `_pop`/`_append` helpers,
+            #        producing the dynamic qubit positions `br`/`bz` used
+            #        below; `h`/`i` are the (unused past this point) final
+            #        stack/size outputs) ...
+            #   ca:AbstractQbit() = qextract b br
+            #   cb:AbstractQbit() = qextract b bz
+            #   cc:AbstractQbit() cd:AbstractQbit() = qinst[
+            #     adjoint=False
+            #     ctrl_len=0
+            #     op=CNOT
+            #     params_len=0
+            #     qubits_len=2
+            #   ] ca cb
+            #   ce:AbstractQreg() = qinsert b br cc
+            #   cf:AbstractQreg() = qinsert ce bz cd
+            #   cg:AbstractQbit() = qextract cf bz
+            #   ch:AbstractQbit() = qinst[
+            #     adjoint=False
+            #     ctrl_len=0
+            #     op=T
+            #     params_len=0
+            #     qubits_len=1
+            #   ] cg
+            #   ci:AbstractQreg() = qinsert cf bz ch
+            #   _:i64[] cj:i64[] ck:AbstractQreg() _:i64[1024] _:i64[] = while_loop[
+            #     body_jaxpr={ lambda ; cl:i64[] cm:i64[] cn:AbstractQreg() co:i64[1024] cp:i64[]. let
+            #         ...
+            #         cv:AbstractQbit() = qextract cn cu
+            #         cw:bool[] cx:AbstractQbit() = measure cv
+            #         cy:AbstractQreg() = qinsert cn cu cx
+            #         ...
+            #       in (dd, dc, cy, co, cp) }
             #     body_nconsts=0
-            #     cond_jaxpr={ lambda ; bj:i64[] bk:i64[] bl:AbstractQreg() bm:i64[] bn:i64[]. let
-            #         bo:bool[] = ge bj bn
-            #       in (bo,) }
+            #     cond_jaxpr={ lambda ; de:i64[] df:i64[] dg:AbstractQreg() dh:i64[1024] di:i64[]. let
+            #         dj:bool[] = lt de di
+            #       in (dj,) }
             #     cond_nconsts=0
-            #     nimplicit=0
+            #     num_implicit_inputs=0
             #     preserve_dimensions=True
-            #   ] b 0 p b r
-            #   bp:i32[] = convert_element_type[new_dtype=int64 weak_type=False] s
-            #   bq:i32[] = mul bp 1
-            #   br:i32[] = add bq 1
-            # in (t, e, br) }
+            #   ] 0:i64[] 0:i64[] ci h i
+            #   dk:f64[] = integer_pow[y=0] 2.0:f64[]
+            #   dl:f64[] = convert_element_type[new_dtype=float64 weak_type=False] cj
+            #   dm:f64[] = mul dl dk
+            #   dn:f64[] = add dm 1.0:f64[]
+            # in (dn, ck, c, g) }
 
         """
         from qrisp.jasp.evaluation_tools.catalyst_interface import (

--- a/src/qrisp/jasp/jasp_expression/centerclass.py
+++ b/src/qrisp/jasp/jasp_expression/centerclass.py
@@ -1,4 +1,5 @@
 """********************************************************************************
+
 * Copyright (c) 2026 the Qrisp authors
 *
 * This program and the accompanying materials are made available under the
@@ -437,7 +438,7 @@ class Jaspr(ClosedJaxpr):
         return jaspr_to_qc(self, *args)
 
     def extract_post_processing(self, *args) -> Callable:
-        """Extracts the post-processing logic from this Jaspr and returns a function that performs the post-processing on measurement results.
+        """Extracts the post-processing function that performs measurement post-processing for this Jaspr.
 
         This method is useful for separating the quantum circuit from the classical
         post-processing of measurement results. The quantum circuit can be executed
@@ -521,7 +522,7 @@ class Jaspr(ClosedJaxpr):
         return eval_jaxpr(self, eqn_evaluator=eqn_evaluator)(*args)
 
     def flatten_environments(self) -> "Jaspr":
-        """Flattens all environments by applying the corresponding compilation routines such that no more ``q_env`` primitives are left.
+        """Flattens all environments so that no more ``q_env`` primitives are left.
 
         Returns
         -------
@@ -682,7 +683,7 @@ class Jaspr(ClosedJaxpr):
         return res
 
     def qjit(self, *args, function_name: str = "jaspr_function", device=None) -> Any:
-        """Leverages the Catalyst pipeline to compile a QIR representation of this function and executes that function using the Catalyst QIR runtime.
+        """Compiles this function to QIR via the Catalyst pipeline and executes it on the Catalyst QIR runtime.
 
         Requires the Catalyst package to be installed (``pip install qrisp[catalyst]``).
 
@@ -721,7 +722,7 @@ class Jaspr(ClosedJaxpr):
     @classmethod
     @qrisp_lru_compilation_cache
     def from_cache(cls, closed_jaxpr: ClosedJaxpr) -> "Jaspr":
-        """Construct a :class:`Jaspr` from a :class:`~jax.extend.core.ClosedJaxpr`, caching the result so that repeated calls with the same argument are free.
+        """Construct a :class:`Jaspr` from a :class:`~jax.extend.core.ClosedJaxpr`, caching repeated calls.
 
         :func:`remove_redundant_allocations` is run on the newly created instance to
         clean up any trivially unused qubit allocations produced during tracing.
@@ -791,7 +792,7 @@ class Jaspr(ClosedJaxpr):
             ; ModuleID = 'LLVMDialectModule'
             source_filename = "LLVMDialectModule"
 
-            @"{'mcmc': False, 'num_burnin': 0, 'kernel_name': None}" = internal constant [54 x i8] c"{'mcmc': False, 'num_burnin': 0, 'kernel_name': None}\00"
+            @... = internal constant [54 x i8] c"{'mcmc': False, 'num_burnin': 0, 'kernel_name': None}\00"
             @LightningSimulator = internal constant [19 x i8] c"LightningSimulator\00"
             @... = internal constant [...] c"...\00"
             @__constant_30xi64 = private constant [30 x i64] [i64 30, i64 29, ..., i64 1], align 64
@@ -866,7 +867,7 @@ class Jaspr(ClosedJaxpr):
               ...
             }
 
-            declare void @llvm.memcpy.p0.p0.i64(ptr noalias writeonly captures(none), ptr noalias readonly captures(none), i64, i1 immarg) #0
+            declare void @llvm.memcpy.p0.p0.i64(...) #0
 
         """
         from qrisp.jasp.evaluation_tools.catalyst_interface import jaspr_to_qir
@@ -931,36 +932,46 @@ class Jaspr(ClosedJaxpr):
         .. code-block:: none
 
             builtin.module @jasp_module {
-              func.func public @main(%arg13: tensor<i64>, %arg14: !jasp.QuantumState) -> (tensor<i64>, !jasp.QuantumState) {
-                %0, %1 = jasp.create_qubits %arg13, %arg14 : tensor<i64>, !jasp.QuantumState -> !jasp.QubitArray, !jasp.QuantumState
+              func.func public @main(%arg13: tensor<i64>, %arg14: !jasp.QuantumState)
+                  -> (tensor<i64>, !jasp.QuantumState) {
+                %0, %1 = jasp.create_qubits %arg13, %arg14 : tensor<i64>, !jasp.QuantumState
+                    -> !jasp.QubitArray, !jasp.QuantumState
                 %2 = "stablehlo.constant"() <{value = dense<0> : tensor<i64>}> : () -> tensor<i64>
                 %3 = jasp.get_qubit %0, %2 : !jasp.QubitArray, tensor<i64> -> !jasp.Qubit
                 %4 = "stablehlo.constant"() <{value = dense<1> : tensor<i64>}> : () -> tensor<i64>
                 %5 = jasp.get_qubit %0, %4 : !jasp.QubitArray, tensor<i64> -> !jasp.Qubit
-                %6 = jasp.quantum_gate "cx" (%3, %5) , %1 : (!jasp.Qubit, !jasp.Qubit) , !jasp.QuantumState -> !jasp.QuantumState
+                %6 = jasp.quantum_gate "cx" (%3, %5) , %1 : (!jasp.Qubit, !jasp.Qubit) , !jasp.QuantumState
+                    -> !jasp.QuantumState
                 %7 = jasp.quantum_gate "t" (%5) , %6 : (!jasp.Qubit) , !jasp.QuantumState -> !jasp.QuantumState
                 %8, %9 = jasp.measure %0, %7 : !jasp.QubitArray, !jasp.QuantumState -> tensor<i64>, !jasp.QuantumState
                 %10 = "stablehlo.add"(%8, %4) : (tensor<i64>, tensor<i64>) -> tensor<i64>
                 func.return %10, %9 : tensor<i64>, !jasp.QuantumState
               }
-              func.func private @jasp.create_qubits(%arg11: tensor<i64>, %arg12: !jasp.QuantumState) -> (!jasp.QubitArray, !jasp.QuantumState) {
-                %0, %1 = jasp.create_qubits %arg11, %arg12 : tensor<i64>, !jasp.QuantumState -> !jasp.QubitArray, !jasp.QuantumState
+              func.func private @jasp.create_qubits(%arg11: tensor<i64>, %arg12: !jasp.QuantumState)
+                  -> (!jasp.QubitArray, !jasp.QuantumState) {
+                %0, %1 = jasp.create_qubits %arg11, %arg12 : tensor<i64>, !jasp.QuantumState
+                    -> !jasp.QubitArray, !jasp.QuantumState
                 func.return %0, %1 : !jasp.QubitArray, !jasp.QuantumState
               }
               func.func private @jasp.get_qubit(%arg9: !jasp.QubitArray, %arg10: tensor<i64>) -> !jasp.Qubit {
                 %0 = jasp.get_qubit %arg9, %arg10 : !jasp.QubitArray, tensor<i64> -> !jasp.Qubit
                 func.return %0 : !jasp.Qubit
               }
-              func.func private @jasp.quantum_gate(%arg6: !jasp.Qubit, %arg7: !jasp.Qubit, %arg8: !jasp.QuantumState) -> !jasp.QuantumState {
-                %0 = jasp.quantum_gate "cx" (%arg6, %arg7) , %arg8 : (!jasp.Qubit, !jasp.Qubit) , !jasp.QuantumState -> !jasp.QuantumState
+              func.func private @jasp.quantum_gate(%arg6: !jasp.Qubit, %arg7: !jasp.Qubit, %arg8: !jasp.QuantumState)
+                  -> !jasp.QuantumState {
+                %0 = jasp.quantum_gate "cx" (%arg6, %arg7) , %arg8 : (!jasp.Qubit, !jasp.Qubit) , !jasp.QuantumState
+                    -> !jasp.QuantumState
                 func.return %0 : !jasp.QuantumState
               }
-              func.func private @jasp.quantum_gate_0(%arg4: !jasp.Qubit, %arg5: !jasp.QuantumState) -> !jasp.QuantumState {
+              func.func private @jasp.quantum_gate_0(%arg4: !jasp.Qubit, %arg5: !jasp.QuantumState)
+                  -> !jasp.QuantumState {
                 %0 = jasp.quantum_gate "t" (%arg4) , %arg5 : (!jasp.Qubit) , !jasp.QuantumState -> !jasp.QuantumState
                 func.return %0 : !jasp.QuantumState
               }
-              func.func private @jasp.measure(%arg2: !jasp.QubitArray, %arg3: !jasp.QuantumState) -> (tensor<i64>, !jasp.QuantumState) {
-                %0, %1 = jasp.measure %arg2, %arg3 : !jasp.QubitArray, !jasp.QuantumState -> tensor<i64>, !jasp.QuantumState
+              func.func private @jasp.measure(%arg2: !jasp.QubitArray, %arg3: !jasp.QuantumState)
+                  -> (tensor<i64>, !jasp.QuantumState) {
+                %0, %1 = jasp.measure %arg2, %arg3 : !jasp.QubitArray, !jasp.QuantumState
+                    -> tensor<i64>, !jasp.QuantumState
                 func.return %0, %1 : tensor<i64>, !jasp.QuantumState
               }
               func.func private @add(%arg0: tensor<i64>, %arg1: tensor<i64>) -> tensor<i64> {
@@ -976,6 +987,7 @@ class Jaspr(ClosedJaxpr):
 
     def to_catalyst_mlir(self) -> str | None:
         """Compiles the Jaspr to MLIR using the `Catalyst dialect <https://docs.pennylane.ai/projects/catalyst/en/stable/index.html>`__.
+
         Requires the Catalyst package to be installed (``pip install qrisp[catalyst]``).
 
         Returns
@@ -1007,11 +1019,13 @@ class Jaspr(ClosedJaxpr):
         .. code-block:: none
 
             module @jaspr_function {
-              func.func public @jit_jaspr_function(%arg0: tensor<i64>) -> tensor<f64> attributes {llvm.emit_c_interface} {
+              func.func public @jit_jaspr_function(%arg0: tensor<i64>)
+                  -> tensor<f64> attributes {llvm.emit_c_interface} {
                 %cst = stablehlo.constant dense<1.000000e+00> : tensor<f64>
                 %c_4 = stablehlo.constant dense<0> : tensor<i64>
                 %c0_i64 = arith.constant 0 : i64
-                quantum.device shots(%c0_i64) [..., "LightningSimulator", "{'mcmc': False, 'num_burnin': 0, 'kernel_name': None}"] {auto_qubit_management}
+                quantum.device shots(%c0_i64) [..., "LightningSimulator",
+                    "{'mcmc': False, 'num_burnin': 0, 'kernel_name': None}"] {auto_qubit_management}
                 %0 = quantum.alloc( 20) : !quantum.reg
                 ... (bookkeeping: a %c_3-seeded ``stablehlo.while`` populates a
                      30-entry index stack via calls to @_pop/@_append, resolving
@@ -1030,7 +1044,8 @@ class Jaspr(ClosedJaxpr):
                 %out_qubits_9 = quantum.custom "T"() %24 : !quantum.bit
                 %extracted_10 = tensor.extract %19[] : tensor<i64>
                 %25 = quantum.insert %23[%extracted_10], %out_qubits_9 : !quantum.reg, !quantum.bit
-                %26:3 = scf.while (%arg1 = %c_4, %arg2 = %c_4, %arg3 = %25) : (tensor<i64>, tensor<i64>, !quantum.reg) -> (tensor<i64>, tensor<i64>, !quantum.reg) {
+                %26:3 = scf.while (%arg1 = %c_4, %arg2 = %c_4, %arg3 = %25) : (tensor<i64>, tensor<i64>, !quantum.reg)
+                    -> (tensor<i64>, tensor<i64>, !quantum.reg) {
                   ...
                 } do {
                 ^bb0(%arg1: tensor<i64>, %arg2: tensor<i64>, %arg3: !quantum.reg):
@@ -1063,7 +1078,9 @@ class Jaspr(ClosedJaxpr):
         return jaspr_to_mlir(self.flatten_environments())
 
     def to_qasm(self, *args) -> str:
-        """Compiles the Jaspr into an OpenQASM 2 string. Real-time control is possible
+        """Compiles the Jaspr into an OpenQASM 2 string.
+
+        Real-time control is possible
         as long as no computations on the measurement results are performed.
 
         Parameters
@@ -1160,6 +1177,7 @@ class Jaspr(ClosedJaxpr):
 
     def to_catalyst_jaxpr(self) -> Any:
         """Compiles the jaspr to the corresponding `Catalyst jaxpr <https://docs.pennylane.ai/projects/catalyst/en/stable/index.html>`__.
+
         Requires the Catalyst package to be installed (``pip install qrisp[catalyst]``).
 
         Returns

--- a/src/qrisp/jasp/optimization_tools/cobyla.py
+++ b/src/qrisp/jasp/optimization_tools/cobyla.py
@@ -22,6 +22,7 @@ from jax.scipy.optimize import OptimizeResults
 # https://link.springer.com/chapter/10.1007/978-94-015-8330-5_4
 # Constraints not included in this implementation
 
+
 # TODO: Refactor this function
 def cobyla(fun, x0, args, maxiter=50, cons=[], rhobeg=1.0, rhoend=1e-6, seed=3):
     r"""Minimize a scalar function of one or more variables using the Constrained Optimization By Linear Approximation (COBYLA) algorithm.

--- a/src/qrisp/jasp/optimization_tools/cobyla.py
+++ b/src/qrisp/jasp/optimization_tools/cobyla.py
@@ -22,18 +22,24 @@ from jax.scipy.optimize import OptimizeResults
 # https://link.springer.com/chapter/10.1007/978-94-015-8330-5_4
 # Constraints not included in this implementation
 
-
+# TODO: Refactor this function
 def cobyla(fun, x0, args, maxiter=50, cons=[], rhobeg=1.0, rhoend=1e-6, seed=3):
     r"""Minimize a scalar function of one or more variables using the Constrained Optimization By Linear Approximation (COBYLA) algorithm.
+
+    See :func:`~qrisp.jasp.minimize` for a description of ``fun``, ``x0``, and ``args``.
 
     Parameters
     ----------
         maxiter : int
             Maximum number of iterations to perform. Each iteration requires several function evaluations.
+        cons : list[callable], optional
+            A list of constraint functions.
         rhobeg : float
             Initial simplex size. Determines how far from the initial guess the algorithm first explores.
         rhoend : float
             Ending simplex size. When the simplex contracts to around this scale, the algorithm terminates.
+        seed : int, optional
+            Accepted for API symmetry with :func:`~qrisp.jasp.spsa`, but currently has no effect.
 
     Returns
     -------

--- a/src/qrisp/jasp/optimization_tools/optimize.py
+++ b/src/qrisp/jasp/optimization_tools/optimize.py
@@ -93,16 +93,9 @@ def minimize(fun, x0, args=(), method="COBYLA", options={}):
         results = main()
         print(results.x)
         print(results.fun)
-
-        # Yields something like
+        # Yields e.g.
         # [0.098]
         # 0.0
-
-    The objective function is the probability of measuring the qubit in the $\ket{1}$ state,
-    which is minimized (down to $0$) at $\theta = 0 \mod 2\pi$. Because only ``shots = 100``
-    measurements are used to estimate this probability, the exact values of ``results.x`` and
-    ``results.fun`` fluctuate slightly from run to run due to shot noise, but ``results.x`` should
-    always end up close to $0$ and ``results.fun`` close to $0$.
 
     """
     if method == "SPSA":

--- a/src/qrisp/jasp/optimization_tools/optimize.py
+++ b/src/qrisp/jasp/optimization_tools/optimize.py
@@ -20,7 +20,7 @@ from qrisp.jasp.optimization_tools.spsa import spsa
 
 
 def minimize(fun, x0, args=(), method="COBYLA", options={}):
-    r"""Minimization of scalar functions of one ore more variables via gradient-free solvers.
+    r"""Minimization of scalar functions of one or more variables via gradient-free solvers.
 
     The API for this function matches SciPy with some minor deviations.
 
@@ -34,15 +34,18 @@ def minimize(fun, x0, args=(), method="COBYLA", options={}):
         1-D array with shape ``(n,)`` and ``args`` is a tuple of parameters needed to specify the function.
     x0 : jax.Array
         Initial guess. Array of real elements of size ``(n,)``, where ``n`` is the number of independent variables.
-    args : tuple
+    args : tuple, optional
         Extra arguments passed to the objective function.
     method : str, optional
-        The solver type. Supported are ``SPSA`` and ``COBYLA``.
+        The solver type. Supported are ``SPSA`` and ``COBYLA``. The default is ``COBYLA``.
     options : dict, optional
         A dictionary of solver options. All methods accept the following generic options:
 
         * maxiter : int
             Maximum number of iterations to perform. Depending on the method each iteration may use several function evaluations.
+
+        Additionally, the method-specific keyword arguments of :func:`~qrisp.jasp.cobyla` or :func:`~qrisp.jasp.spsa`
+        may be supplied here, depending on the chosen ``method``.
 
     Returns
     -------
@@ -56,7 +59,7 @@ def minimize(fun, x0, args=(), method="COBYLA", options={}):
 
     .. math::
 
-        \ket{\psi_{\theta}} = \cos(\theta)\ket{0} + \sin(\theta)\ket{1}
+        \ket{\psi_{\theta}} = \cos(\theta/2)\ket{0} + \sin(\theta/2)\ket{1}
 
     ::
 
@@ -76,7 +79,7 @@ def minimize(fun, x0, args=(), method="COBYLA", options={}):
         def objective(theta, state_prep):
             return expectation_value(state_prep, shots=100)(theta)
 
-    Finally, we use ``optimize`` to find the optimal choice of the parameter $\theta_0$ that minimizes the objective function
+    Finally, we use ``minimize`` to find the optimal choice of the parameter $\theta_0$ that minimizes the objective function
 
     ::
 
@@ -85,11 +88,21 @@ def minimize(fun, x0, args=(), method="COBYLA", options={}):
 
             x0 = jnp.array([1.0])
 
-            return minimize(objective,x0,args=(state_prep,))
+            return minimize(objective, x0, args=(state_prep,))
 
         results = main()
         print(results.x)
         print(results.fun)
+
+        # Yields something like
+        # [0.098]
+        # 0.0
+
+    The objective function is the probability of measuring the qubit in the $\ket{1}$ state,
+    which is minimized (down to $0$) at $\theta = 0 \mod 2\pi$. Because only ``shots = 100``
+    measurements are used to estimate this probability, the exact values of ``results.x`` and
+    ``results.fun`` fluctuate slightly from run to run due to shot noise, but ``results.x`` should
+    always end up close to $0$ and ``results.fun`` close to $0$.
 
     """
     if method == "SPSA":

--- a/src/qrisp/jasp/optimization_tools/optimize.py
+++ b/src/qrisp/jasp/optimization_tools/optimize.py
@@ -79,7 +79,8 @@ def minimize(fun, x0, args=(), method="COBYLA", options={}):
         def objective(theta, state_prep):
             return expectation_value(state_prep, shots=100)(theta)
 
-    Finally, we use ``minimize`` to find the optimal choice of the parameter $\theta_0$ that minimizes the objective function
+    Finally, we use ``minimize`` to find the optimal choice of the parameter $\theta_0$
+    that minimizes the objective function
 
     ::
 

--- a/src/qrisp/jasp/optimization_tools/spsa.py
+++ b/src/qrisp/jasp/optimization_tools/spsa.py
@@ -26,6 +26,8 @@ from jax.scipy.optimize import OptimizeResults
 def spsa(fun, x0, args, maxiter=50, a=2.0, c=0.1, alpha=0.702, gamma=0.201, seed=3):
     r"""Minimize a scalar function of one or more variables using the `Simultaneous Perturbation Stochastic Approximation algorithm <https://en.wikipedia.org/wiki/Simultaneous_perturbation_stochastic_approximation>`_.
 
+    See :func:`~qrisp.jasp.minimize` for a description of ``fun``, ``x0``, and ``args``.
+
     This algorithm aims at finding the optimal control $x^*$ minimizing a given loss fuction $f$:
 
     .. math::
@@ -38,7 +40,7 @@ def spsa(fun, x0, args, maxiter=50, a=2.0, c=0.1, alpha=0.702, gamma=0.201, seed
 
         x_{k+1} = x_k - a_kg_k(x_k)
 
-    where $a_k=\dfrac{a}{n^{\alpha}}$ for scaling parameters $a, \alpha>0$.
+    where $a_k=\dfrac{a}{(k+1)^{\alpha}}$ for scaling parameters $a, \alpha>0$.
 
     For each step $x_k$ the gradient is approximated by
 
@@ -46,7 +48,8 @@ def spsa(fun, x0, args, maxiter=50, a=2.0, c=0.1, alpha=0.702, gamma=0.201, seed
 
         (g_k(x_k))_i = \frac{f(x_k+c_k\Delta_k)-f(x_k-c_k\Delta_k)}{2c_k(\Delta_k)_i}
 
-    where $c_k=\dfrac{c}{n^{\gamma}}$ for scaling parameters $c, \gamma>0$, and $\Delta_k$ is a random perturbation vector.
+    where $c_k=\dfrac{c}{(k+1)^{\gamma}}$ for scaling parameters $c, \gamma>0$, and $\Delta_k$ is a random perturbation vector
+    with components independently drawn from $\{-1, +1\}$.
 
     Parameters
     ----------
@@ -54,12 +57,15 @@ def spsa(fun, x0, args, maxiter=50, a=2.0, c=0.1, alpha=0.702, gamma=0.201, seed
             Maximum number of iterations to perform. Each iteration requires 2 function evaluations.
         a : float
             Scaling parameter for update rule.
-        alpha : float
-            Scaling exponent for update rule.
         c : float
             Scaling parameter for gradient estimation.
+        alpha : float
+            Scaling exponent for update rule.
         gamma : float
             Scaling exponent for gradient estimation.
+        seed : int, optional
+            The seed for the pseudo-random number generator used to draw the perturbation vectors
+            $\Delta_k$. The default is ``3``.
 
     Returns
     -------

--- a/src/qrisp/jasp/optimization_tools/spsa.py
+++ b/src/qrisp/jasp/optimization_tools/spsa.py
@@ -48,8 +48,8 @@ def spsa(fun, x0, args, maxiter=50, a=2.0, c=0.1, alpha=0.702, gamma=0.201, seed
 
         (g_k(x_k))_i = \frac{f(x_k+c_k\Delta_k)-f(x_k-c_k\Delta_k)}{2c_k(\Delta_k)_i}
 
-    where $c_k=\dfrac{c}{(k+1)^{\gamma}}$ for scaling parameters $c, \gamma>0$, and $\Delta_k$ is a random perturbation vector
-    with components independently drawn from $\{-1, +1\}$.
+    where $c_k=\dfrac{c}{(k+1)^{\gamma}}$ for scaling parameters $c, \gamma>0$, and $\Delta_k$ is a random
+    perturbation vector with components independently drawn from $\{-1, +1\}$.
 
     Parameters
     ----------

--- a/src/qrisp/jasp/primitives/measurement_primitive.py
+++ b/src/qrisp/jasp/primitives/measurement_primitive.py
@@ -17,7 +17,7 @@
 
 from jax.core import ShapedArray
 
-from qrisp.circuit import Clbit, Qubit, QuantumCircuit
+from qrisp.circuit import Clbit, QuantumCircuit, Qubit
 from qrisp.jasp.primitives.abstract_quantum_register import AbstractQubitArray
 from qrisp.jasp.primitives.abstract_quantum_state import AbstractQuantumState
 from qrisp.jasp.primitives.abstract_qubit import AbstractQubit

--- a/src/qrisp/jasp/program_control/ev.py
+++ b/src/qrisp/jasp/program_control/ev.py
@@ -297,4 +297,5 @@ def expectation_value(state_prep, shots, return_dict=False, post_processor=None)
 class _MultiReturnDetected(Exception):
     """Internal signal raised when the post-processor returns multiple values
     (a tuple) instead of a single scalar.  This triggers a retry of the
-    sampling loop with a multi-dimensional accumulator of the correct shape."""
+    sampling loop with a multi-dimensional accumulator of the correct shape.
+    """

--- a/src/qrisp/jasp/program_control/ev.py
+++ b/src/qrisp/jasp/program_control/ev.py
@@ -295,7 +295,7 @@ def expectation_value(state_prep, shots, return_dict=False, post_processor=None)
 
 
 class _MultiReturnDetected(Exception):
-    """Internal signal raised when the post-processor returns multiple values
-    (a tuple) instead of a single scalar.  This triggers a retry of the
-    sampling loop with a multi-dimensional accumulator of the correct shape.
+    """Internal signal raised when the post-processor returns multiple values (a tuple) instead of a single scalar.
+
+    This triggers a retry of the sampling loop with a multi-dimensional accumulator of the correct shape.
     """

--- a/src/qrisp/jasp/program_control/ev.py
+++ b/src/qrisp/jasp/program_control/ev.py
@@ -46,7 +46,9 @@ from qrisp.jasp.tracing_logic import quantum_kernel
 
 
 def expectation_value(state_prep, shots, return_dict=False, post_processor=None):
-    r"""The ``expectation_value`` function allows to estimate the expectation value
+    r"""Estimates the expectation value from a sampling kernel.
+
+    The ``expectation_value`` function allows to estimate the expectation value
     from a *sampling kernel* — a Python function that receives only classical
     arguments and returns arbitrary values.  Any
     :ref:`QuantumVariables <QuantumVariable>` in the return are automatically

--- a/src/qrisp/jasp/program_control/ev.py
+++ b/src/qrisp/jasp/program_control/ev.py
@@ -127,11 +127,12 @@ def expectation_value(state_prep, shots, return_dict=False, post_processor=None)
             return ev_function(k)
 
         print(main(3))
-        # Yields
+        # Yields e.g.
         # [1.44 1.44]
 
-    The true value 1.5 is not reached because of `shot noise <https://en.wikipedia.org/wiki/Shot_noise>`_.
-    To improve the approximation, feel free to increase the shots!
+    The true value 1.5 is not reached exactly because of `shot noise <https://en.wikipedia.org/wiki/Shot_noise>`_ —
+    the printed value fluctuates around 1.5 from run to run. To improve the
+    approximation, feel free to increase the shots!
 
     To demonstrate the ``post_processor`` keyword we define a simple post processing
     function
@@ -144,21 +145,24 @@ def expectation_value(state_prep, shots, return_dict=False, post_processor=None)
         @jaspify
         def main(k):
 
-            ev_function = expectation_value(state_prep, shots = 50)
+            ev_function = expectation_value(state_prep, shots = 50,
+                                             post_processor = post_processor)
 
             return ev_function(k)
 
         print(main(3))
-        # Yields
-        # 4.338
+        # Yields e.g.
+        # 4.86
 
     This result is expected because the inputs of ``post_processor`` are
-    either (0,0) or (3,3) with 50% probability, so we get
+    either (0,0) or (3,3) with 50% probability, so the expectation value is
 
     .. math::
 
         4.5 = \frac{3\cdot 3 + 0\cdot 0}{2}
 
+    As with the previous example, the printed value fluctuates around this
+    expectation from run to run because of shot noise.
 
     """
     from qrisp.core import QuantumVariable, measure

--- a/src/qrisp/jasp/program_control/jrange_iterator.py
+++ b/src/qrisp/jasp/program_control/jrange_iterator.py
@@ -141,7 +141,6 @@ def jrange(*args):
 
     ::
 
-        from qrisp import QuantumFloat, control, x
         from qrisp import QuantumFloat, control, measure, x
         from qrisp.jasp import jrange, make_jaspr, qache
 
@@ -194,9 +193,11 @@ def jrange(*args):
 
             return measure(qv)
 
-        jaspr = make_jaspr(test_f)(1,1)
+    Because the carry value is only detected while flattening the loop's
+    environment, the exception is already raised while tracing, i.e. during
+    the ``make_jaspr`` call:
 
-    >>> jaspr(5, 8)
+    >>> jaspr = make_jaspr(test_f)(1,1)
     Exception: Found jrange with external carry value
 
     To demonstrate the second kind of illegal behavior, we construct a loop
@@ -224,13 +225,12 @@ def jrange(*args):
 
             return measure(qv)
 
-        jaspr = make_jaspr(test_f)(1,1)
-
     In this script, ``int_encoder`` defines a boolean flag that changes the
     semantics of the iteration behavior. After the first iteration the flag
-    is set to ``False`` such that the alternate behavior is activated.
+    is set to ``False`` such that the alternate behavior is activated. As
+    with the carry-value violation above, this is detected while tracing:
 
-    >>> jaspr(5, 8)
+    >>> jaspr = make_jaspr(test_f)(1,1)
     Exception: Jax semantics changed during jrange iteration
 
     Since the ``step`` argument has been removed as of v0.9, multiply the loop

--- a/src/qrisp/jasp/program_control/jrange_iterator.py
+++ b/src/qrisp/jasp/program_control/jrange_iterator.py
@@ -110,7 +110,9 @@ class JRangeIterator:
 
 
 def jrange(*args):
-    """Performs a loop with a dynamic bound. Similar to the Python native ``range``,
+    """Performs a loop with a dynamic bound.
+
+    Similar to the Python native ``range``,
     this iterator can receive one argument (stop) or two arguments (start, stop).
     Step size is always 1.
 

--- a/src/qrisp/jasp/program_control/prefix_control.py
+++ b/src/qrisp/jasp/program_control/prefix_control.py
@@ -150,8 +150,8 @@ def q_while_loop(cond_fun, body_fun, init_val):
 
 
 def q_fori_loop(lower, upper, body_fun, init_val):
-    """Jasp compatible version of
-    `jax.lax.fori_loop <https://jax.readthedocs.io/en/latest/_autosummary/jax.lax.fori_loop.html#jax.lax.fori_loop>`_.
+    """Jasp compatible version of `jax.lax.fori_loop <https://jax.readthedocs.io/en/latest/_autosummary/jax.lax.fori_loop.html#jax.lax.fori_loop>`_.
+
     The parameters and semantics are the same as for the Jax version.
 
     In particular the following loop is performed

--- a/src/qrisp/jasp/program_control/prefix_control.py
+++ b/src/qrisp/jasp/program_control/prefix_control.py
@@ -187,6 +187,9 @@ def q_fori_loop(lower, upper, body_fun, init_val):
 
     ::
 
+        from qrisp import *
+        from qrisp.jasp import *
+
         @jaspify
         def main(k):
 

--- a/src/qrisp/jasp/program_control/rus.py
+++ b/src/qrisp/jasp/program_control/rus.py
@@ -24,7 +24,9 @@ from qrisp.jasp import (
 
 
 def RUS(*trial_function, **jit_kwargs):
-    r"""Decorator to deploy repeat-until-success (RUS) components. At the core,
+    r"""Decorator to deploy repeat-until-success (RUS) components.
+
+    At the core,
     RUS repeats a given quantum subroutine followed by a qubit measurement until
     the measurement returns the value ``1``. This step is prevalent
     in many important algorithms, among them the

--- a/src/qrisp/jasp/program_control/rus.py
+++ b/src/qrisp/jasp/program_control/rus.py
@@ -58,8 +58,8 @@ def RUS(*trial_function, **jit_kwargs):
     static_argnums : int or list[int], optional
         A list of integers specifying which arguments are considered static in
         the sense of `jax.jit <https://jax.readthedocs.io/en/latest/_autosummary/jax.jit.html>`_.
-        The first argument is indicated by 1, the second by 2, etc. The default
-        is ``[]``.
+        Argument positions are 0-indexed, i.e. the first argument is indicated
+        by 0, the second by 1, etc. The default is ``[]``.
     static_argnames : str or list[str], optional
         A list of strings specifying which arguments are considered static in
         the sense of `jax.jit <https://jax.readthedocs.io/en/latest/_autosummary/jax.jit.html>`_.
@@ -196,9 +196,11 @@ def RUS(*trial_function, **jit_kwargs):
     ::
 
         # Specify the corresponding arguments of the block encoding as "static",
-        # i.e. compile time constants.
+        # i.e. compile time constants. Argument positions are 0-indexed, so
+        # this marks "state_preparation" (position 1) and "case_functions"
+        # (position 2).
 
-        @RUS(static_argnums = [2,3])
+        @RUS(static_argnums = [1,2])
         def block_encoding(return_size, state_preparation, case_functions):
 
             # This QuantumFloat will be returned

--- a/src/qrisp/jasp/program_control/sampling.py
+++ b/src/qrisp/jasp/program_control/sampling.py
@@ -47,7 +47,9 @@ from qrisp.jasp.tracing_logic import check_for_tracing_mode, quantum_kernel
 
 
 def sample(sampling_kernel=None, shots=0, post_processor=None):
-    r"""The ``sample`` function allows to take samples from a quantum computation
+    r"""Takes samples from a quantum computation specified by a sampling kernel.
+
+    The ``sample`` function allows to take samples from a quantum computation
     specified by a *sampling kernel* — a Python function that receives only
     classical arguments and returns arbitrary values.  Any
     :ref:`QuantumVariables <QuantumVariable>` in the return are automatically

--- a/src/qrisp/jasp/program_control/sampling.py
+++ b/src/qrisp/jasp/program_control/sampling.py
@@ -393,4 +393,5 @@ def sample(sampling_kernel=None, shots=0, post_processor=None):
 class _MultiReturnDetected(Exception):
     """Internal signal raised when the post-processor returns multiple values
     (a tuple) instead of a single scalar.  This triggers a retry of the
-    sampling loop with a multi-dimensional accumulator of the correct shape."""
+    sampling loop with a multi-dimensional accumulator of the correct shape.
+    """

--- a/src/qrisp/jasp/program_control/sampling.py
+++ b/src/qrisp/jasp/program_control/sampling.py
@@ -391,7 +391,7 @@ def sample(sampling_kernel=None, shots=0, post_processor=None):
 
 
 class _MultiReturnDetected(Exception):
-    """Internal signal raised when the post-processor returns multiple values
-    (a tuple) instead of a single scalar.  This triggers a retry of the
-    sampling loop with a multi-dimensional accumulator of the correct shape.
+    """Internal signal raised when the post-processor returns multiple values (a tuple) instead of a single scalar.
+
+    This triggers a retry of the sampling loop with a multi-dimensional accumulator of the correct shape.
     """

--- a/src/qrisp/jasp/program_control/sampling.py
+++ b/src/qrisp/jasp/program_control/sampling.py
@@ -152,7 +152,7 @@ def sample(sampling_kernel=None, shots=0, post_processor=None):
 
         print(main(3))
 
-        # Yields
+        # Yields e.g.
         # [[3. 3.]
         #  [0. 0.]
         #  [0. 0.]
@@ -163,6 +163,9 @@ def sample(sampling_kernel=None, shots=0, post_processor=None):
         #  [3. 3.]
         #  [0. 0.]
         #  [0. 0.]]
+        #
+        # Each row is either [0, 0] or [3, 3] with 50% probability each.
+        # The exact order of rows is random and varies between runs.
 
     To demonstrate the post processing feature, we write a simple post
     processing function:
@@ -182,8 +185,11 @@ def sample(sampling_kernel=None, shots=0, post_processor=None):
             return sampling_function(k)
 
         print(main(4))
-        # Yields
+        # Yields e.g.
         # [10. 10.  0.  0.  0.  0.  0.  0. 10. 10.]
+        #
+        # Each entry is either 0 or 10 with 50% probability each. The exact
+        # order of entries is random and varies between runs.
 
     **Sampling kernels returning classical values**
 

--- a/src/qrisp/jasp/tracing_logic/qaching.py
+++ b/src/qrisp/jasp/tracing_logic/qaching.py
@@ -28,7 +28,9 @@ from qrisp.jasp.tracing_logic import (
 
 
 def qache(*func, **kwargs):
-    """This decorator allows you to mark a function as "reusable". Reusable here means
+    """This decorator allows you to mark a function as "reusable".
+
+    Reusable here means
     that the jasp expression of this function will be cached and reused in the next
     calls (if the function is called with the same signature, i.e. arguments of the
     same abstract type/shape, and, if any arguments are marked static via ``kwargs``,
@@ -137,7 +139,8 @@ def qache(*func, **kwargs):
 
     As expected, we see three different function definitions:
 
-    * The first one describes ``inner_function`` called with a :ref:`QuantumVariable`. For this kind of signature only the ``QubitArray`` is required.
+    * The first one describes ``inner_function`` called with a :ref:`QuantumVariable`. For this kind
+      of signature only the ``QubitArray`` is required.
     * The second one describes ``inner_function`` called with :ref:`QuantumFloat`. Additionally to the
       ``QubitArray``, the ``.exponent`` attribute is also passed to the function, because it is a *traced*
       attribute.

--- a/src/qrisp/jasp/tracing_logic/qaching.py
+++ b/src/qrisp/jasp/tracing_logic/qaching.py
@@ -138,8 +138,11 @@ def qache(*func, **kwargs):
     As expected, we see three different function definitions:
 
     * The first one describes ``inner_function`` called with a :ref:`QuantumVariable`. For this kind of signature only the ``QubitArray`` is required.
-    * The second one describes ``inner_function`` called with :ref:`QuantumFloat`. Additionally to the ``QubitArray``, the ``.exponent`` attribute is also passed to the function, because it is a *traced* attribute.
-    * The third block is the anonymous top-level function representing ``main``, which calls the previously defined functions.
+    * The second one describes ``inner_function`` called with :ref:`QuantumFloat`. Additionally to the
+      ``QubitArray``, the ``.exponent`` attribute is also passed to the function, because it is a *traced*
+      attribute.
+    * The third block is the anonymous top-level function representing ``main``, which calls the
+      previously defined functions.
 
     **Illegal functions**
 

--- a/src/qrisp/jasp/tracing_logic/qaching.py
+++ b/src/qrisp/jasp/tracing_logic/qaching.py
@@ -30,7 +30,9 @@ from qrisp.jasp.tracing_logic import (
 def qache(*func, **kwargs):
     """This decorator allows you to mark a function as "reusable". Reusable here means
     that the jasp expression of this function will be cached and reused in the next
-    calls (if the function is called with the same signature).
+    calls (if the function is called with the same signature, i.e. arguments of the
+    same abstract type/shape, and, if any arguments are marked static via ``kwargs``,
+    the same concrete value for those).
 
     A qached function therefore has to be traced by the Python interpreter only once
     and after that the function can be called without any Python-interpreter induced
@@ -53,11 +55,13 @@ def qache(*func, **kwargs):
     ----------
     func : callable
         The function to be qached.
+    kwargs : dict, optional
+        Keyword arguments that are forwarded to `jax.jit <https://docs.jax.dev/en/latest/_autosummary/jax.jit.html>`_.
 
     Returns
     -------
     qached_function : callable
-        A function that will be traced on it's first execution and retrieved from
+        A function that will be traced on its first execution and retrieved from
         the cache in any other call.
 
     Examples
@@ -103,45 +107,39 @@ def qache(*func, **kwargs):
     has been traced twice and recalled from the cache twice. We take a look at the :ref:`jaspr`.
 
     >>> print(jaspr)
-    let inner_function = { lambda ; a:QuantumState b:QubitArray. let
-        c:Qubit = jasp.get_qubit b 0
-        d:QuantumState = jasp.h a c
-        e:Qubit = jasp.get_qubit b 1
-        f:QuantumState = jasp.cx d c e
-        g:QuantumState h:bool[] = jasp.measure f c
+    let inner_function = { lambda ; a:QubitArray b:QuantumState. let
+        c:Qubit = jasp.get_qubit a 0:i64[]
+        d:QuantumState = jasp.quantum_gate[gate=h] c b
+        e:Qubit = jasp.get_qubit a 1:i64[]
+        f:QuantumState = jasp.quantum_gate[gate=cx] c e d
+        g:bool[] h:QuantumState = jasp.measure c f
       in (g, h) } in
-    let inner_function1 = { lambda ; i:QuantumState j:QubitArray k:i32[] l:bool[]. let
-        m:Qubit = jasp.get_qubit j 0
-        n:QuantumState = jasp.h i m
-        o:Qubit = jasp.get_qubit j 1
-        p:QuantumState = jasp.cx n m o
-        q:QuantumState r:bool[] = jasp.measure p m
-      in (q, r) } in
-    { lambda ; s:QuantumState. let
-        t:QuantumState u:QubitArray = jasp.create_qubits s 2
-        v:QuantumState w:QubitArray = jasp.create_qubits t 2
-        x:QuantumState y:bool[] = pjit[name=inner_function jaxpr=inner_function] v
-          u
-        z:QuantumState ba:bool[] = pjit[name=inner_function jaxpr=inner_function1] x
-          w 0 False
-        bb:QuantumState bc:bool[] = pjit[name=inner_function jaxpr=inner_function] z
-          u
-        bd:QuantumState be:bool[] = pjit[
-          name=inner_function
-          jaxpr=inner_function1
-        ] bb w 0 False
-        bf:bool[] = and y ba
+    let inner_function1 = { lambda ; i:QubitArray j:i64[] k:QuantumState. let
+        l:Qubit = jasp.get_qubit i 0:i64[]
+        m:QuantumState = jasp.quantum_gate[gate=h] l k
+        n:Qubit = jasp.get_qubit i 1:i64[]
+        o:QuantumState = jasp.quantum_gate[gate=cx] l n m
+        p:bool[] q:QuantumState = jasp.measure l o
+      in (p, q) } in
+    { lambda ; r:QuantumState. let
+        s:QubitArray t:QuantumState = jasp.create_qubits 2:i64[] r
+        u:QubitArray v:QuantumState = jasp.create_qubits 2:i64[] t
+        w:bool[] x:QuantumState = jit[name=inner_function jaxpr=inner_function] s v
+        y:bool[] z:QuantumState = jit[name=inner_function jaxpr=inner_function1] u 0:i64[]
+          x
+        ba:bool[] bb:QuantumState = jit[name=inner_function jaxpr=inner_function] s z
+        bc:bool[] bd:QuantumState = jit[name=inner_function jaxpr=inner_function1] u
+          0:i64[] bb
+        be:bool[] = and w y
+        bf:bool[] = and be ba
         bg:bool[] = and bf bc
-        bh:bool[] = and bg be
-        bi:QuantumState = jasp.reset bd u
-        bj:QuantumState = jasp.delete_qubits bi u
-      in (bj, bh) }
+      in (bg, bd) }
 
     As expected, we see three different function definitions:
 
     * The first one describes ``inner_function`` called with a :ref:`QuantumVariable`. For this kind of signature only the ``QubitArray`` is required.
-    * The second one describes ``inner_function`` called with :ref:`QuantumFloat`. Additionally to the ``QubitArray``, the ``.exponent`` and ``.signed`` attribute are also passed to the function.
-    * The third function definition is ``outer_function``, which calls the previously defined functions.
+    * The second one describes ``inner_function`` called with :ref:`QuantumFloat`. Additionally to the ``QubitArray``, the ``.exponent`` attribute is also passed to the function, because it is a *traced* attribute.
+    * The third block is the anonymous top-level function representing ``main``, which calls the previously defined functions.
 
     **Illegal functions**
 
@@ -182,7 +180,7 @@ def qache(*func, **kwargs):
             inner_function(qf)
 
         main()
-        # Yields: Exception: Found in-place parameter modification of QuantumVariable qf
+        # Yields: Exception: Found in-place parameter modification of QuantumVariable
 
     """
     if kwargs and len(func) == 0:

--- a/src/qrisp/jasp/tracing_logic/quantum_kernel.py
+++ b/src/qrisp/jasp/tracing_logic/quantum_kernel.py
@@ -31,6 +31,7 @@ from qrisp.jasp.tracing_logic import (
 
 def quantum_kernel(func):
     """This decorator allows you to annotate a subroutine as a "quantum kernel".
+
     Quantum kernels are functions that are restricted in the sense that they
     can not have quantum inputs or outputs, yet their inner working can be quantum.
     What is the benefit in that? The underlying idea why this

--- a/src/qrisp/jasp/tracing_logic/quantum_kernel.py
+++ b/src/qrisp/jasp/tracing_logic/quantum_kernel.py
@@ -35,7 +35,7 @@ def quantum_kernel(func):
     can not have quantum inputs or outputs, yet their inner working can be quantum.
     What is the benefit in that? The underlying idea why this
     can be helpful is that future execution environments might host several
-    QPUs that can operate in parallel, much like many of todays HPC
+    QPUs that can operate in parallel, much like many of today's HPC
     environments can access multiple GPUs.
 
     Annotating a function as a quantum kernel therefore allows the execution
@@ -50,8 +50,8 @@ def quantum_kernel(func):
         If you need to execute a 1000 shots of a certain quantum circuit, but
         you have 4 QPUs available, you can execute the task 4 times faster by
         assigning 250 shots to each QPU.
-        As such the :ref:`sample <sample>` and :ref:`expectation_value <expectation_value>` function
-        automatically wraps the state preparation and measurement into a
+        As such the :ref:`sample <sample>` and :ref:`expectation_value <expectation_value>` 
+        functions automatically wrap the state preparation and measurement into a
         dedicated quantum kernel.
 
 
@@ -59,19 +59,19 @@ def quantum_kernel(func):
     ----------
     func : callable
         A function that receives only classical values as inputs and returns
-        classical values as outpus. The function's body can however perform
+        classical values as outputs. The function's body can however perform
         quantum logic.
 
     Returns
     -------
     quantum_kernel : callable
         A function that performs the task of the input but the compiler can
-        identify it as a closed quantum procedure without any external entaglement.
+        identify it as a closed quantum procedure without any external entanglement.
 
     Examples
     --------
-    We demonstrate a naive implementation of an expectation value please use
-    :ref:`expectation_value` if you required this functionality. For this
+    We demonstrate a naive implementation of an expectation value. Please use
+    :ref:`expectation_value` if you require this functionality. For this
     we define a state preparation procedure and call it from a kernelized
     function.
 

--- a/src/qrisp/jasp/tracing_logic/quantum_kernel.py
+++ b/src/qrisp/jasp/tracing_logic/quantum_kernel.py
@@ -50,7 +50,7 @@ def quantum_kernel(func):
         If you need to execute a 1000 shots of a certain quantum circuit, but
         you have 4 QPUs available, you can execute the task 4 times faster by
         assigning 250 shots to each QPU.
-        As such the :ref:`sample <sample>` and :ref:`expectation_value <expectation_value>` 
+        As such the :ref:`sample <sample>` and :ref:`expectation_value <expectation_value>`
         functions automatically wrap the state preparation and measurement into a
         dedicated quantum kernel.
 

--- a/src/qrisp/jasp/tracing_logic/tracing_quantum_session.py
+++ b/src/qrisp/jasp/tracing_logic/tracing_quantum_session.py
@@ -20,7 +20,7 @@ from __future__ import annotations
 import weakref
 from collections.abc import Iterator, Sequence
 from contextlib import contextmanager
-from typing import Any, TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import jax
 from jax.core import Tracer
@@ -34,7 +34,7 @@ from qrisp.typing import ClbitLike, FloatLike
 
 if TYPE_CHECKING:
     from jax._src.core import JaxprEqn
-    from qrisp.core import QuantumArray
+
 
 greek_letters = symbols(
     "alpha beta gamma delta epsilon zeta eta theta iota kappa"
@@ -98,6 +98,7 @@ class TracingQuantumSession:
         ----------
         abs_qst : AbstractQuantumState
             The abstract quantum state to start recording into.
+
         """
         self.abs_qst_stack.append(self.abs_qst)
         self.qubit_cache_stack.append(self.qubit_cache)
@@ -115,6 +116,7 @@ class TracingQuantumSession:
         -------
         AbstractQuantumState or None
             The abstract quantum state that was active in the concluded scope.
+
         """
         temp = self.abs_qst
         self.abs_qst = self.abs_qst_stack.pop()
@@ -155,6 +157,7 @@ class TracingQuantumSession:
         Exception
             If the abstract quantum state has gone out of scope, or if classical
             bits are provided, or if mixed qubit types or incompatible shapes are used.
+
         """
         self._check_in_scope()
 
@@ -216,6 +219,7 @@ class TracingQuantumSession:
         size : int or jax.core.Tracer or None
             Number of qubits to allocate. If ``None``, no allocation is performed
             (the variable already has qubits assigned).
+
         """
         self._check_in_scope()
 
@@ -241,6 +245,7 @@ class TracingQuantumSession:
         -------
         DynamicQubitArray
             A dynamic array backed by the newly allocated qubits.
+
         """
         qb_array_tracer, self.abs_qst = create_qubits(amount, self.abs_qst)
         return DynamicQubitArray(qb_array_tracer)
@@ -261,6 +266,7 @@ class TracingQuantumSession:
         Exception
             If *verify* is ``True``, if the abstract quantum state is out of scope,
             or if *qv* is not registered in this session.
+
         """
         self._check_in_scope()
 
@@ -285,6 +291,7 @@ class TracingQuantumSession:
             The qubit array to deallocate.
         verify : bool, optional
             Unused in tracing mode; present for interface compatibility. Default is ``False``.
+
         """
         self.abs_qst = delete_qubits_p.bind(qubits.tracer, self.abs_qst)
 
@@ -317,6 +324,7 @@ def get_last_equation(i: int = -1) -> JaxprEqn:
     i : int, optional
         Index into the current frame's equation list. The default is ``-1``
         (the most recently recorded equation).
+
     """
     return jax._src.core.trace_ctx.trace.frame.tracing_eqns[i]()
 
@@ -328,6 +336,7 @@ def check_live(tracer: Tracer | None) -> bool:
     ----------
     tracer : JAX tracer or None
         The tracer to check. ``None`` is treated as always live.
+
     """
     if tracer is None:
         return True

--- a/tests/algorithms_tests/qsp_tests/test_gqsp_simulation.py
+++ b/tests/algorithms_tests/qsp_tests/test_gqsp_simulation.py
@@ -81,6 +81,7 @@ def test_gqsp_hamiltonian_simulation_nested_block_encoding():
 
 def test_gqsp_hamiltonian_simulation_long_time():
     """Test the GQSP Hamiltonian simulation via qubitization with long time evolution.
+
     Ensures that calculation of coefficients for Jacobi-Anger expansion remains numerically stable.
     """
     L = 4

--- a/tests/algorithms_tests/qsp_tests/test_gqsp_simulation.py
+++ b/tests/algorithms_tests/qsp_tests/test_gqsp_simulation.py
@@ -48,7 +48,6 @@ def test_gqsp_hamiltonian_simulation_nested_block_encoding():
     Compares the amplitudes obtained form Hamiltonian simulation applied to BE_poly with those obtained from the direct Hamiltonian simulation applied to BE2.
     Ensures that the amplitudes are consistent and the success probability is high.
     """
-
     L = 4
     H = create_ising_hamiltonian(L, 0.25, 0.5)
     H2 = 0.9 * H + 0.8 * H * H * H
@@ -82,8 +81,8 @@ def test_gqsp_hamiltonian_simulation_nested_block_encoding():
 
 def test_gqsp_hamiltonian_simulation_long_time():
     """Test the GQSP Hamiltonian simulation via qubitization with long time evolution.
-    Ensures that calculation of coefficients for Jacobi-Anger expansion remains numerically stable."""
-
+    Ensures that calculation of coefficients for Jacobi-Anger expansion remains numerically stable.
+    """
     L = 4
     H = create_ising_hamiltonian(L, 0.25, 0.5)
     BE = BlockEncoding.from_operator(H)
@@ -118,7 +117,6 @@ def test_gqsp_hamiltonian_simulation_long_time():
 @pytest.mark.parametrize("t", [1.0, 5.0, 10.0])
 def test_jax_jv(N_terms, t):
     """Test the JAX implementation of the Bessel function of the first kind (jv) against SciPy's implementation."""
-
     m_array = jnp.arange(0, N_terms + 1)
 
     # Run the pure JAX version

--- a/tests/algorithms_tests/qsp_tests/test_transformations.py
+++ b/tests/algorithms_tests/qsp_tests/test_transformations.py
@@ -15,13 +15,13 @@
 ********************************************************************************
 """
 
-import pytest
 import numpy as np
+import pytest
+from qrisp.gqsp import GQET, GQSVT, QET, QSVT
 
-from qrisp import multi_measurement, prepare, terminal_sampling, QuantumFloat
+from qrisp import QuantumFloat, multi_measurement, prepare, terminal_sampling
 from qrisp.block_encodings import BlockEncoding
-from qrisp.gqsp import GQET, QET, QSVT, GQSVT
-from qrisp.operators import X, Y, Z
+from qrisp.operators import X, Z
 
 
 def post_selection(res_dict, N):
@@ -42,7 +42,6 @@ def test_non_hermitian_block_encoding(alg, mode):
     Note: GQET relies on qubitization for a non-Hermitian block-encoding unitary (Issue #681).
     The test verifies that GQET produces the same results as the other three algorithms when applied to a non-Hermitian block-encoding of a Hermitian matrix.
     """
-
     N = 8
     I = np.eye(N)
     A = 2 * I + np.eye(N, k=1) + np.eye(N, k=-1)
@@ -105,7 +104,6 @@ def test_nested_polynomial_application(alg, mode):
     Note: We use an odd fixed parity polynomial applied to a Hermitian matrix which ensures compatibility and consistency with all four transformations.
     Note: GQET relies on qubitization for a non-Hermitian block-encoding unitary in the second application (Issue #681).
     """
-
     if alg == QET and mode == "static":
         pytest.skip("(Issue #680).")
 

--- a/tests/jax_tests/test_jaspify.py
+++ b/tests/jax_tests/test_jaspify.py
@@ -357,7 +357,7 @@ def test_jaspify_pytree():
 
 
 def test_jaspify_raises_when_returning_quantum_variable():
-    """jaspify must reject a function that returns a QuantumVariable, not silently accept it."""
+    """Jaspify must reject a function that returns a QuantumVariable, not silently accept it."""
 
     @jaspify
     def main():

--- a/tests/jax_tests/test_sampling.py
+++ b/tests/jax_tests/test_sampling.py
@@ -310,7 +310,8 @@ def _pp_sum(x, y):
 
 class TestClassicalAndMixedReturns:
     """Tests for sample() and expectation_value() with classical and mixed
-    (quantum + classical) returns, and terminal-sampling rejection."""
+    (quantum + classical) returns, and terminal-sampling rejection.
+    """
 
     import jax.numpy as jnp
     import pytest

--- a/tests/jax_tests/test_sampling.py
+++ b/tests/jax_tests/test_sampling.py
@@ -309,9 +309,7 @@ def _pp_sum(x, y):
 
 
 class TestClassicalAndMixedReturns:
-    """Tests for sample() and expectation_value() with classical and mixed
-    (quantum + classical) returns, and terminal-sampling rejection.
-    """
+    """Tests for sample() and expectation_value() with classical/mixed returns and terminal-sampling rejection."""
 
     import jax.numpy as jnp
     import pytest

--- a/tests/jax_tests/test_stim_simulation.py
+++ b/tests/jax_tests/test_stim_simulation.py
@@ -199,7 +199,7 @@ def test_stim_dispatch_controlled_gates():
 
 
 def test_stimulate_raises_when_returning_quantum_variable():
-    """stimulate must reject a function that returns a QuantumVariable, not silently accept it."""
+    """Stimulate must reject a function that returns a QuantumVariable, not silently accept it."""
 
     @stimulate
     def main():

--- a/tests/jax_tests/test_tracing_quantum_session.py
+++ b/tests/jax_tests/test_tracing_quantum_session.py
@@ -19,13 +19,11 @@ import types
 
 import pytest
 
-
 from qrisp import *
 from qrisp.jasp import *
 from qrisp.jasp.tracing_logic.tracing_quantum_session import (
     _instance,
 )
-
 
 # ---------------------------------------------------------------------------
 # Shared helpers and fixtures


### PR DESCRIPTION
## Description

While preparing a tutorial on Jasp for Quantum Week in Toronto, I noticed several outdated and inaccurate docstrings/examples and wanted to fix them before giving the session.

## Related Issues

Closes #
Related to #

## Type of Change

- [ ] Feature (new functionality)
- [ ] Change Request (modification of existing functionality)
- [ ] Bug Fix
- [ ] Refactoring (no behavior change)
- [ ] Performance improvement
- [x] Documentation
- [ ] CI / Build

## Breaking Change?
- [ ] Yes
- [x] No

## What was changed?

- Fixed stale/incorrect docstrings and examples across the Jasp module: control flow (`jrange`, `RUS`, prefix control), sampling, `expectation_value`, optimization tools (`minimize`/`cobyla`/`spsa`), caching (`qache`), `quantum_kernel`, `boolean_simulation`, `terminal_sampling`, `catalyst.qjit`, `BigInteger`, and several `Jaspr` export methods (`to_mlir`, `to_catalyst_mlir`, `to_catalyst_jaxpr`).
- Two of these were genuine bugs in the example code, not just stale text: `RUS`'s `static_argnums` docs said 1-indexed (it's 0-indexed); `expectation_value`'s `post_processor` example never actually passed `post_processor=`.
- Fixed a `ruff format` violation in `cobyla.py`.
- Added a changelog entry.

## How was it tested?

No tracked issue / Test-IDs. Verified by actually running the corrected examples rather than just reading them; `ruff format --check` and the Sphinx doc build both pass cleanly.

## Screenshots / Output (if applicable)

N/A

## Checklist
- [x] My code follows the project's coding standards
- [x] I have performed a self-review
- [ ] I have added/updated tests — docs-only change, verified by execution instead
- [x] All tests pass locally
- [x] I have updated the documentation
- [x] I have added a changelog entry to `changelog-dev.rst`
- [x] Breaking changes are documented with migration path *(N/A)*

## Reviewer Notes

Docs/comments only — no runtime logic changed except the `cobyla.py` whitespace fix.