### PR TITLE
Updating the docstring of `Job.status()`

### DIFF
--- a/documentation/source/general/changelog/changelog-dev.rst
+++ b/documentation/source/general/changelog/changelog-dev.rst
@@ -25,6 +25,14 @@ New Features
 Improvements
 ------------
 
+- :class:`~qrisp.interface.QiskitJob` and :class:`~qrisp.interface.AQTJob`
+  now skip the live provider query and return the cached status once a job
+  is done, cancelled, or errored. The :class:`~qrisp.interface.Job` base
+  class docstring for ``status()``/``refresh()`` now consistently describes
+  this as an optional optimization implementations may take advantage of,
+  rather than a guarantee
+  (`PR #806 <https://github.com/eclipse-qrisp/Qrisp/pull/806>`_).
+
 - Updated docstrings for ``sample()``, ``expectation_value()``, and
   ``terminal_sampling()`` to use "sampling kernel" terminology and document
   the new arbitrary-return-value capability.

--- a/src/qrisp/interface/job.py
+++ b/src/qrisp/interface/job.py
@@ -263,12 +263,13 @@ class Job(ABC):
         This value is initialised to :attr:`~JobStatus.INITIALIZING` and is
         updated at the following points:
 
-        * :meth:`status`: every live query updates the cache as a side effect.
+        * :meth:`status`: updates the cache as a side effect, performing a
+          live query unless the job has already reached a terminal state.
         * :meth:`result`: transitions to ``DONE``, ``CANCELLED``, or
           ``ERROR`` when the job reaches a terminal state.
-        * :meth:`refresh`: explicitly fetches the live status and caches it
-          (semantically identical to calling :meth:`status`, but signals intent
-          clearly when the sole purpose is to refresh the cache).
+        * :meth:`refresh`: caches the current status (semantically identical
+          to calling :meth:`status`, but signals intent clearly when the
+          sole purpose is to refresh the cache).
         """
         return self._last_known_status
 
@@ -352,10 +353,11 @@ class Job(ABC):
     def status(self) -> JobStatus:
         """Query and return the current :class:`JobStatus` of the job.
 
-        This is a *live query*: every call fetches the most up-to-date
-        status available, which for remote backends may involve a network
-        call. As a side effect, concrete implementations should store the
-        result in ``_last_known_status`` before returning, so that
+        For a job that has not yet reached a terminal state, this performs
+        a *live query*: it fetches the most up-to-date status available,
+        which for remote backends may involve a network call. As a side
+        effect, concrete implementations should store the result in
+        ``_last_known_status`` before returning, so that
         :attr:`last_known_status` always reflects the most recently
         observed state.
 
@@ -405,17 +407,17 @@ class Job(ABC):
         return self.status() in JOB_FINAL_STATES
 
     def refresh(self) -> JobStatus:
-        """Fetch the latest status from the backend and return it.
+        """Update and return the job's status via :meth:`status`.
 
-        Delegates to :meth:`status`, which already updates
-        :attr:`last_known_status` as a side effect.  This method exists as
-        a named alias that makes the intent explicit: the caller wants to
-        refresh the cached status, not merely query it.
+        This method exists as a named alias that makes the intent
+        explicit: the caller wants to refresh the cached status, not
+        merely read it. As with :meth:`status`, no new live query is
+        performed if the job has already reached a terminal state.
 
         Returns
         -------
         JobStatus
-            The freshly fetched status.
+            The current status, matching what :meth:`status` returns.
 
         """
         return self.status()

--- a/src/qrisp/interface/job.py
+++ b/src/qrisp/interface/job.py
@@ -263,8 +263,9 @@ class Job(ABC):
         This value is initialised to :attr:`~JobStatus.INITIALIZING` and is
         updated at the following points:
 
-        * :meth:`status`: updates the cache as a side effect, performing a
-          live query unless the job has already reached a terminal state.
+        * :meth:`status`: performs a live query and updates the cache as
+          a side effect. Implementations may skip the query once the
+          job is in a terminal state.
         * :meth:`result`: transitions to ``DONE``, ``CANCELLED``, or
           ``ERROR`` when the job reaches a terminal state.
         * :meth:`refresh`: caches the current status (semantically identical
@@ -353,13 +354,20 @@ class Job(ABC):
     def status(self) -> JobStatus:
         """Query and return the current :class:`JobStatus` of the job.
 
-        For a job that has not yet reached a terminal state, this performs
-        a *live query*: it fetches the most up-to-date status available,
-        which for remote backends may involve a network call. As a side
-        effect, concrete implementations should store the result in
-        ``_last_known_status`` before returning, so that
+        This is a *live query*: it fetches the most up-to-date status
+        available, which for remote backends may involve a network call.
+        As a side effect, concrete implementations should store the
+        result in ``_last_known_status`` before returning, so that
         :attr:`last_known_status` always reflects the most recently
         observed state.
+
+        Once a job has reached a terminal state (:attr:`~JobStatus.DONE`,
+        :attr:`~JobStatus.CANCELLED`, or :attr:`~JobStatus.ERROR`), that
+        state cannot change again. Implementations *may* take advantage
+        of this as an optimization and return the already-known terminal
+        status without repeating the query — but this is not guaranteed:
+        a given implementation may still re-query the backend even after
+        the job is terminal.
 
         Callers that want to avoid the cost of a live query should read
         :attr:`last_known_status` directly. Call :meth:`refresh` (or
@@ -411,8 +419,9 @@ class Job(ABC):
 
         This method exists as a named alias that makes the intent
         explicit: the caller wants to refresh the cached status, not
-        merely read it. As with :meth:`status`, no new live query is
-        performed if the job has already reached a terminal state.
+        merely read it. As with :meth:`status`, implementations *may*
+        skip the live query once the job is in a terminal state, but
+        are not required to.
 
         Returns
         -------

--- a/src/qrisp/interface/job.py
+++ b/src/qrisp/interface/job.py
@@ -354,7 +354,7 @@ class Job(ABC):
     def status(self) -> JobStatus:
         """Query and return the current :class:`JobStatus` of the job.
 
-        This is a *live query*: it fetches the most up-to-date status
+        Typically this is a *live query*: it fetches the most up-to-date status
         available, which for remote backends may involve a network call.
         As a side effect, concrete implementations should store the
         result in ``_last_known_status`` before returning, so that

--- a/src/qrisp/interface/job.py
+++ b/src/qrisp/interface/job.py
@@ -363,13 +363,11 @@ class Job(ABC):
 
         Once a job has reached a terminal state (:attr:`~JobStatus.DONE`,
         :attr:`~JobStatus.CANCELLED`, or :attr:`~JobStatus.ERROR`), that
-        state cannot change again. Implementations *may* take advantage
+        state cannot change again. Implementations may take advantage
         of this as an optimization and return the already-known terminal
-        status without repeating the query — but this is not guaranteed:
-        a given implementation may still re-query the backend even after
-        the job is terminal.
+        status without repeating the query.
 
-        Callers that want to avoid the cost of a live query should read
+        Callers that want to avoid the cost of a live query can also read
         :attr:`last_known_status` directly. Call :meth:`refresh` (or
         :meth:`status`) when an explicit update is needed.
 
@@ -419,9 +417,8 @@ class Job(ABC):
 
         This method exists as a named alias that makes the intent
         explicit: the caller wants to refresh the cached status, not
-        merely read it. As with :meth:`status`, implementations *may*
-        skip the live query once the job is in a terminal state, but
-        are not required to.
+        merely read it. As with :meth:`status`, implementations may
+        skip the live query once the job is in a terminal state.
 
         Returns
         -------

--- a/src/qrisp/interface/provider_backends/aqt_backend.py
+++ b/src/qrisp/interface/provider_backends/aqt_backend.py
@@ -22,6 +22,7 @@ from qiskit import QuantumCircuit as QiskitQuantumCircuit
 from qrisp.circuit.quantum_circuit import QuantumCircuit
 from qrisp.interface.backend import Backend
 from qrisp.interface.job import (
+    JOB_FINAL_STATES,
     Job,
     JobCancelledError,
     JobFailureError,
@@ -143,7 +144,13 @@ class AQTJob(Job):
         return False
 
     def status(self) -> JobStatus:
-        """Return the current :class:`~qrisp.interface.JobStatus` by querying the AQT job."""
+        """Return the current :class:`~qrisp.interface.JobStatus`.
+
+        Once the job has reached a terminal state, that cached status is
+        returned directly.
+        """
+        if self._last_known_status in JOB_FINAL_STATES:
+            return self._last_known_status
         self._last_known_status = _map_aqt_status(self._aqt_job)
         return self._last_known_status
 

--- a/src/qrisp/interface/provider_backends/qiskit_backend.py
+++ b/src/qrisp/interface/provider_backends/qiskit_backend.py
@@ -227,7 +227,13 @@ class QiskitJob(Job):
             return False
 
     def status(self) -> JobStatus:
-        """Return the current :class:`~qrisp.interface.JobStatus` by querying the Qiskit job."""
+        """Return the current :class:`~qrisp.interface.JobStatus`.
+
+        Once the job has reached a terminal state, that cached status is
+        returned directly.
+        """
+        if self._last_known_status in JOB_FINAL_STATES:
+            return self._last_known_status
         self._last_known_status = _map_qiskit_status(self._qiskit_job)
         return self._last_known_status
 

--- a/tests/interface_tests/test_job.py
+++ b/tests/interface_tests/test_job.py
@@ -475,7 +475,7 @@ class TestJobStatusCaching:
         assert job.last_known_status == JobStatus.QUEUED
 
     def test_refresh_returns_current_status(self, backend):
-        """refresh() returns the freshly fetched status."""
+        """refresh() returns the current status."""
         job = MinimalJob(backend=backend)
         job._set_status(JobStatus.RUNNING)
         returned = job.refresh()


### PR DESCRIPTION
## Description

I noticed during a review on a PR opened by Ville (@smite ) that `Job.status()`'s docstring promised an unconditional *live query* on every call, even though a job that has already reached a terminal state (`DONE`/`CANCELLED`/`ERROR`) can't change state again. But a live query at that point is unnecessary. 

This PR reworks the `Job` base class docstrings to describe skipping the query as an optional optimization (not a guarantee), and actually implements that optimization in the two backends that perform a real network round-trip: `QiskitJob` and `AQTJob`.

## Related Issues

<!-- No tracked issue in this repo; this surfaced from a docstring-consistency review comment on a PR in the continuous-delivery repo, which consumes this abstract Job/Backend interface. -->
Closes #
Related to #

## Type of Change

- [ ] Feature (new functionality)
- [ ] Change Request (modification of existing functionality)
- [ ] Bug Fix
- [ ] Refactoring (no behavior change)
- [x] Performance improvement
- [x] Documentation
- [ ] CI / Build

## Breaking Change?
- [ ] Yes
- [x] No

## What was changed?

- `src/qrisp/interface/job.py`: reworded `Job.status()`, `Job.refresh()`, and the `last_known_status` docstring so all three consistently describe the terminal-state live-query skip as something implementations *may* do, not something they do unconditionally.
- `src/qrisp/interface/provider_backends/qiskit_backend.py`: `QiskitJob.status()` now returns the cached status directly once the job is in a terminal state, instead of always re-querying the underlying Qiskit job.
- `src/qrisp/interface/provider_backends/aqt_backend.py`: same optimization added to `AQTJob.status()`.
- `tests/interface_tests/test_job.py`: updated one test docstring that used the same "freshly fetched" wording being corrected above.
- `documentation/source/general/changelog/changelog-dev.rst`: added a changelog entry under *Improvements*.

## How was it tested?

No tracked issue / Test-IDs for this change. Testing performed:

- Ran the full existing suites for the affected modules: `test_job.py`, `test_backend.py`, `test_qiskit_backend.py`, `test_aqt_backend.py` — 313 passed, 1 unrelated skip.
- Manually verified the actual new behavior with mock-based scripts (not yet committed as permanent tests — see Reviewer Notes): for both `QiskitJob` and `AQTJob`, once the job reaches `DONE`, the underlying provider's `.status()` call count stays at 1 across repeated calls to `job.status()`.
- `pylint` on the three changed source files: 9.56/10, no new findings (only pre-existing, unrelated `duplicate-code` warnings between the two backend files).

## Screenshots / Output (if applicable)

N/A

## Checklist
- [x] My code follows the project's coding standards
- [x] I have performed a self-review
- [ ] I have added/updated tests (referencing issue Test-IDs) — *no dedicated regression test added for the short-circuit behavior itself; see Reviewer Notes*
- [x] All tests pass locally (CI not yet run)
- [x] I have updated the documentation
- [x] I have added a changelog entry to `changelog-dev.rst`
- [x] Breaking changes are documented with migration path *(N/A — no breaking changes)*