### PR TITLE
Fix typo in Jasp tutorial

### DIFF
--- a/documentation/source/general/changelog/changelog-dev.rst
+++ b/documentation/source/general/changelog/changelog-dev.rst
@@ -119,6 +119,10 @@ Bug Fixes
   negative-length loop range under Jasp
   (`PR #767 <https://github.com/eclipse-qrisp/Qrisp/pull/767>`_).
 
+* Fix a code typo in the Jasp tutorial which printed the wrong variable
+  when checking which variables are dynamic.
+  (`PR #828 <https://github.com/eclipse-qrisp/Qrisp/pull/828>`_).
+
 Compatibility
 -------------
 

--- a/documentation/source/general/tutorial/Jasp.ipynb
+++ b/documentation/source/general/tutorial/Jasp.ipynb
@@ -478,7 +478,7 @@
     "\n",
     "    qf = QuantumFloat(5)\n",
     "    j = qf.size\n",
-    "    print(\"j is dynamic?: \", isinstance(i, Tracer))\n",
+    "    print(\"j is dynamic?: \", isinstance(j, Tracer))\n",
     "\n",
     "    h(qf)\n",
     "    k = measure(qf)\n",


### PR DESCRIPTION
## Description

<!-- What does this PR do? Keep it concise. -->

Code used `i` when it should use `j`, fix typo.