### PR TITLE
Update GitHub Actions to use specific versions of commits

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request' && github.actor != 'dependabot[bot]'
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
 

--- a/.github/workflows/qrisp_coverage.yml
+++ b/.github/workflows/qrisp_coverage.yml
@@ -22,8 +22,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 120
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-python@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.12.*"
           cache: 'pip'
@@ -39,7 +39,7 @@ jobs:
         env:
           COVERAGE_FILE: .coverage.core
       - name: Upload core coverage data
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: coverage-core
           path: .coverage.core
@@ -49,8 +49,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 120
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-python@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.12.*"
           cache: 'pip'
@@ -66,7 +66,7 @@ jobs:
         env:
           COVERAGE_FILE: .coverage.algorithms
       - name: Upload algorithms coverage data
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: coverage-algorithms
           path: .coverage.algorithms
@@ -76,13 +76,13 @@ jobs:
     needs: [core, algorithms-and-integrations]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-python@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.12.*"
       - run: pip install coverage
       - name: Download coverage data
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           pattern: coverage-*
           merge-multiple: true

--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -20,9 +20,9 @@ jobs:
     name: ruff
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - uses: actions/setup-python@v7
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.11"
 

--- a/.github/workflows/ruff_checks.yml
+++ b/.github/workflows/ruff_checks.yml
@@ -13,9 +13,9 @@ jobs:
   ruff:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Set up Python
-        uses: actions/setup-python@v7
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.12.*"
       - name: Install dependencies
@@ -23,10 +23,10 @@ jobs:
           python -m pip install --upgrade pip
           pip install -e ".[dev-code-style]"
       - name: Ruff format
-        uses: astral-sh/ruff-action@v3
+        uses: astral-sh/ruff-action@4919ec5cf1f49eff0871dbcea0da843445b837e6 # v3.6.1
         with:
           args: format --check
       # - name: Ruff linter
-      #   uses: astral-sh/ruff-action@v3
+      #   uses: astral-sh/ruff-action@4919ec5cf1f49eff0871dbcea0da843445b837e6 # v3.6.1
       #   with:
       #     args: check  # wait for fix from Niko's student

--- a/documentation/source/general/changelog/changelog-dev.rst
+++ b/documentation/source/general/changelog/changelog-dev.rst
@@ -197,6 +197,7 @@ Development
   ``xdsl``, ``docs``, and ``dev``) and updated the Development Guide's
   installation instructions to reference it
   (`PR #807 <https://github.com/eclipse-qrisp/Qrisp/pull/807>`_).
+
 * Added a ``reviewdog``-based CI workflow that runs ``ruff`` on pull requests
   and surfaces lint findings as annotations on the GitHub Checks tab of
   newly added lines instead of as inline review comments on the PR
@@ -209,6 +210,9 @@ Development
   used to avoid circular imports) and ``E402`` (module-level imports placed
   after a module docstring)
   (`PR #811 <https://github.com/eclipse-qrisp/Qrisp/pull/811>`_).
+
+  * GitHub Actions pinned to commit SHA in CI workflows
+  (`PR #829 <https://github.com/eclipse-qrisp/Qrisp/pull/829>`_).
 
 Dependency Upgrades
 -------------------


### PR DESCRIPTION
## Description

Update GitHub Actions to use specific versions of commits.

## Related Issues

<!-- Link related issues. Use closing keywords to auto-close them on merge. -->
Closes #
Related to #531 

## Type of Change

<!-- Check all that apply -->
- [ ] Feature (new functionality)
- [ ] Change Request (modification of existing functionality)
- [ ] Bug Fix
- [x] Refactoring (no behavior change)
- [ ] Performance improvement
- [ ] Documentation
- [x] CI / Build

## Breaking Change?
- [ ] Yes
- [x] No

If yes, describe the impact and migration path:


## What was changed?

<!-- Bullet list of concrete changes -->
Pinned version of Actions according to files:

- `changelog.yml` - checkout
- `qrisp_coverage.yml` - checkout, setup-python, upload-artifact, download-artifact
- `reviewdog.yml` - checkout, setup-python
- `ruff_checks.yml` - checkout, setup-python, ruff-action

## How was it tested?

<!-- Optional - Reference Test-IDs from the linked issue(s) and describe any additional testing. -->

| Test-ID | Status |
|---------|--------|
| T-001   | ✅ / ❌ |
| T-002   | ✅ / ❌ |
| T-003   | ✅ / ❌ |
| T-004   | ✅ / ❌ |

## Screenshots / Output (if applicable)

<!-- Add additional information if it helps -->

## Checklist
- [x] My code follows the project's coding standards
- [x] I have performed a self-review
- [ ] I have added/updated tests (referencing issue Test-IDs)
- [x] All tests pass locally and in CI
- [ ] I have updated the documentation
- [x] I have added a changelog entry to `changelog-dev.rst`
- [ ] Breaking changes are documented with migration path

## Reviewer Notes

<!-- Anything specific the reviewer should focus on? -->