### PR TITLE
Linear Combination of BlockEncodings

### DIFF
--- a/documentation/source/general/changelog/changelog-dev.rst
+++ b/documentation/source/general/changelog/changelog-dev.rst
@@ -25,6 +25,14 @@ New Features
 Improvements
 ------------
 
+- **Flattened block-encoding arithmetic**
+  Block-encoding linear combinations now use a single LCU construction instead
+  of recursively nested binary combinations. Mutually exclusive LCU branches
+  reuse one shared ancilla workspace, including for heterogeneous ancilla
+  layouts. Block-encoding linear combinations can be constructed explicitly with
+  :meth:`~qrisp.block_encodings.BlockEncoding.linear_combination`
+  (`PR #832 <https://github.com/eclipse-qrisp/Qrisp/pull/832>`_).
+
 - :class:`~qrisp.interface.QiskitJob` and :class:`~qrisp.interface.AQTJob`
   now skip the live provider query and return the cached status once a job
   is done, cancelled, or errored. The :class:`~qrisp.interface.Job` base

--- a/documentation/source/reference/Block Encodings/BlockEncoding.rst
+++ b/documentation/source/reference/Block Encodings/BlockEncoding.rst
@@ -29,6 +29,8 @@ Constructors
      - Constructs a BlockEncoding of a 2-D array with ones on the diagonal and zeros elsewhere.
    * - :func:`~qrisp.block_encodings.BlockEncoding.from_projector`
      - Constructs a BlockEncoding of a projector.
+   * - :func:`~qrisp.block_encodings.BlockEncoding.linear_combination`
+     - Constructs a BlockEncoding using the Linear Combination of Unitaries (LCU) protocol.
 
 .. toctree:: 
    :hidden:
@@ -40,6 +42,7 @@ Constructors
    methods/from_foqcs_lcu_operator
    methods/from_foqcs_lcu_prep
    methods/from_projector
+   methods/linear_combination
 
 Utilities
 ---------

--- a/documentation/source/reference/Block Encodings/methods/linear_combination.rst
+++ b/documentation/source/reference/Block Encodings/methods/linear_combination.rst
@@ -1,0 +1,8 @@
+.. _BlockEncoding.linear_combination:
+
+BlockEncoding.linear_combination
+================================
+
+.. currentmodule:: qrisp.block_encodings
+
+.. automethod:: BlockEncoding.linear_combination

--- a/src/qrisp/block_encodings/ancilla_layout.py
+++ b/src/qrisp/block_encodings/ancilla_layout.py
@@ -1,3 +1,19 @@
+# ********************************************************************************
+# * Copyright (c) 2026 the Qrisp authors
+# *
+# * This program and the accompanying materials are made available under the
+# * terms of the Eclipse Public License 2.0 which is available at
+# * http://www.eclipse.org/legal/epl-2.0.
+# *
+# * This Source Code may also be made available under the following Secondary
+# * Licenses when the conditions for such availability set forth in the Eclipse
+# * Public License, v. 2.0 are satisfied: GNU General Public License, version 2
+# * with the GNU Classpath Exception which is
+# * available at https://www.gnu.org/software/classpath/license.html.
+# *
+# * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+# ********************************************************************************
+
 """Utilities for packing block-encoding ancillas into shared workspaces."""
 
 from __future__ import annotations

--- a/src/qrisp/block_encodings/ancilla_layout.py
+++ b/src/qrisp/block_encodings/ancilla_layout.py
@@ -1,0 +1,51 @@
+"""Utilities for packing block-encoding ancillas into shared workspaces."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import jax.numpy as jnp
+
+from qrisp.core import QuantumVariable
+from qrisp.jasp.tracing_logic import QuantumVariableTemplate
+
+
+@dataclass(frozen=True)
+class _AncillaLayout:
+    """Describe typed ancillas packed consecutively into one register.
+
+    A layout stores the original templates and their individual register sizes.
+    It can then reconstruct typed views into a shared workspace. The sizes may be
+    traced JAX values, which keeps the same implementation usable in static and
+    Jasp execution.
+    """
+
+    templates: tuple[QuantumVariableTemplate, ...]
+    sizes: tuple[Any, ...]
+    total_size: Any
+
+    @classmethod
+    def from_templates(cls, templates: list[QuantumVariableTemplate] | tuple[QuantumVariableTemplate, ...]):
+        """Create a layout from an ordered collection of ancilla templates."""
+        templates = tuple(templates)
+        sizes = tuple(template.qv_size for template in templates)
+        total_size = sum(sizes, start=jnp.array(0, dtype=int))
+        return cls(templates, sizes, total_size)
+
+    def construct_views(self, shared_ancilla: QuantumVariable) -> list[QuantumVariable]:
+        """Construct typed views into the beginning of ``shared_ancilla``."""
+        offset = jnp.array(0, dtype=int)
+        views = []
+        for template, size in zip(self.templates, self.sizes):
+            views.append(template.construct(reg=shared_ancilla.reg[offset : offset + size]))
+            offset += size
+        return views
+
+
+def _maximum_layout_size(layouts: list[_AncillaLayout] | tuple[_AncillaLayout, ...]):
+    """Return the largest total workspace size across the supplied layouts."""
+    maximum_size = jnp.array(0, dtype=int)
+    for layout in layouts:
+        maximum_size = jnp.maximum(maximum_size, layout.total_size)
+    return maximum_size

--- a/src/qrisp/block_encodings/block_encoding_base.py
+++ b/src/qrisp/block_encodings/block_encoding_base.py
@@ -27,6 +27,7 @@ import numpy as np
 from jax.tree_util import register_pytree_node_class
 
 from qrisp.alg_primitives.reflection import reflection
+from qrisp.alg_primitives.state_preparation import prepare
 from qrisp.core import QuantumVariable
 from qrisp.core.gate_application_functions import gphase, h, measure, reset, ry, x, z
 from qrisp.environments import conjugate, control, invert
@@ -37,17 +38,26 @@ from qrisp.jasp import (
     expectation_value,
     jrange,
     num_qubits,
+    q_switch,
 )
 from qrisp.jasp import (
     check_for_tracing_mode as is_tracing,
 )
 from qrisp.jasp.tracing_logic import QuantumVariableTemplate
-from qrisp.qtypes import QuantumBool
+from qrisp.qtypes import QuantumBool, QuantumFloat
 
 if TYPE_CHECKING:
     from jax.typing import ArrayLike
 
     from qrisp.interface.backend import BackendLike
+
+
+def _is_non_negative_real(value: Any) -> bool:
+    try:
+        value = np.asarray(value)
+    except Exception:
+        return False
+    return bool(np.all(np.isreal(value)) and np.all(np.real(value) >= 0))
 
 
 @register_pytree_node_class
@@ -271,6 +281,7 @@ class BlockEncoding:
         self.num_ancs = len(ancillas)
         # More robust than inferring the number of operands for the unitary via inspect.
         self.num_ops = num_ops
+        self._lcu_terms = None
 
     def tree_flatten(self):
         """PyTree flatten for JAX.
@@ -282,6 +293,20 @@ class BlockEncoding:
             the digits array, and `aux_data` is `None`.
 
         """
+        if self._lcu_terms is not None:
+            children = tuple(
+                [self.alpha, self._anc_templates]
+                + [value for coefficient, block_encoding in self._lcu_terms for value in (coefficient, block_encoding)]
+            )
+            aux_data = (
+                self.unitary,
+                self.num_ops,
+                self.is_hermitian,
+                "lcu_terms",
+                len(self._lcu_terms),
+            )
+            return (children, aux_data)
+
         children = (
             self.alpha,
             self._anc_templates,
@@ -310,6 +335,18 @@ class BlockEncoding:
             Reconstructed instance.
 
         """
+        if aux_data[-2:-1] == ("lcu_terms",):
+            terms = [(children[2 * index + 2], children[2 * index + 3]) for index in range(aux_data[-1])]
+            result = cls(
+                children[0],
+                children[1],
+                aux_data[0],
+                num_ops=aux_data[1],
+                is_hermitian=aux_data[2],
+            )
+            result._lcu_terms = terms
+            return result
+
         return cls(*children, *aux_data)
 
     #
@@ -1029,6 +1066,165 @@ class BlockEncoding:
     # Arithmetic
     #
 
+    def _get_lcu_terms(self):
+        if self._lcu_terms is None:
+            return [(1, self)]
+        return self._lcu_terms
+
+    @classmethod
+    def linear_combination(
+        cls,
+        block_encodings: list[BlockEncoding],
+        coefficients: "ArrayLike | None" = None,
+    ) -> BlockEncoding:
+        r"""Constructs one LCU block-encoding from several block-encodings.
+
+        The child block-encodings are combined in one selector instead of
+        recursively composing binary LCU block-encodings. This is also the
+        lowering target used by ``+``, ``-`` and scalar multiplication.
+
+        Parameters
+        ----------
+        block_encodings : list[BlockEncoding]
+            Block-encodings of operators acting on the same operands.
+        coefficients : ArrayLike, optional
+            Coefficients multiplying the encoded operators. Defaults to one
+            for every block-encoding.
+
+        Returns
+        -------
+        BlockEncoding
+            A block-encoding of the linear combination.
+
+        Raises
+        ------
+        ValueError
+            If no block-encodings are supplied, the coefficient count does
+            not match, or operand counts differ.
+        TypeError
+            If an item is not a BlockEncoding.
+        """
+        if len(block_encodings) == 0:
+            raise ValueError("At least one block-encoding is required.")
+
+        if coefficients is None:
+            coefficients = [1] * len(block_encodings)
+        elif len(coefficients) != len(block_encodings):
+            raise ValueError("The number of coefficients must match the number of block-encodings.")
+
+        terms = []
+        for block_encoding, coefficient in zip(block_encodings, coefficients):
+            if not isinstance(block_encoding, BlockEncoding):
+                raise TypeError(f"Expected every item to be a BlockEncoding, but got {type(block_encoding).__name__}.")
+            terms.append((coefficient, block_encoding))
+
+        return cls._from_lcu_terms(terms)
+
+    @classmethod
+    def _from_lcu_terms(cls, terms):
+        """Build one block-encoding from a flattened list of weighted terms.
+
+        Each term is a ``(coefficient, block_encoding)`` pair. If the child
+        block-encoding represents ``A_i / alpha_i``, the combined LCU uses
+        ``coefficient * alpha_i`` as the coefficient of its child unitary.
+        The resulting normalization is therefore
+        ``sum(abs(coefficient * alpha_i))``.
+
+        The child ancilla templates are concatenated after one selector
+        register. The selector chooses exactly one child unitary, so nested
+        sums can be lowered to one preparation/select/preparation sequence.
+        The term list is retained on the result so subsequent arithmetic can
+        extend it instead of rebuilding a binary LCU tree.
+
+        Parameters
+        ----------
+        terms : list[tuple[ArrayLike, BlockEncoding]]
+            Weighted block-encoding terms. All terms must have the same
+            operand count.
+
+        Returns
+        -------
+        BlockEncoding
+            A block-encoding of the weighted sum.
+        """
+        num_ops = terms[0][1].num_ops
+        if any(block_encoding.num_ops != num_ops for _, block_encoding in terms):
+            raise ValueError("All block-encodings must have the same number of operands.")
+
+        if len(terms) == 1:
+            coefficient, block_encoding = terms[0]
+            if isinstance(coefficient, (int, float, complex, np.number)) and coefficient == 1:
+                return block_encoding
+
+            def unitary(*args):
+                block_encoding.unitary(*args)
+                with control(coefficient < 0):
+                    gphase(np.pi, args[0][0])
+
+            result = cls(
+                jnp.abs(coefficient * block_encoding.alpha),
+                block_encoding._anc_templates,
+                unitary,
+                num_ops=block_encoding.num_ops,
+                is_hermitian=block_encoding.is_hermitian,
+            )
+            result._lcu_terms = terms
+            return result
+
+        selector_size = (len(terms) - 1).bit_length()
+        child_anc_templates = [template for _, block_encoding in terms for template in block_encoding._anc_templates]
+        new_anc_templates = [QuantumFloat(selector_size).template()] + child_anc_templates
+
+        def unitary(*args):
+            selector = args[0]
+            ancilla_offset = 1
+            branches = []
+
+            for _, block_encoding in terms:
+                child_ancillas = args[ancilla_offset : ancilla_offset + block_encoding.num_ancs]
+                ancilla_offset += block_encoding.num_ancs
+
+                def branch(
+                    *branch_args,
+                    block_encoding=block_encoding,
+                    child_ancillas=child_ancillas,
+                ):
+                    block_encoding.unitary(*child_ancillas, *branch_args)
+
+                branches.append(branch)
+
+            def identity_branch(*unused_args):
+                pass
+
+            branches.extend([identity_branch] * ((1 << selector_size) - len(branches)))
+            operands = args[ancilla_offset:]
+            coefficients = jnp.array(
+                [coefficient * block_encoding.alpha for coefficient, block_encoding in terms],
+                dtype=complex,
+            )
+            coefficients = jnp.pad(coefficients, (0, (1 << selector_size) - len(terms)))
+            alpha = jnp.sum(jnp.abs(coefficients))
+            amplitudes = jnp.sqrt(coefficients / alpha)
+
+            if all(_is_non_negative_real(coefficient) for coefficient, _ in terms):
+                with conjugate(prepare)(selector, jnp.abs(amplitudes)):
+                    q_switch(selector, branches, *operands)
+            else:
+                prepare(selector, amplitudes)
+                q_switch(selector, branches, *operands)
+                with invert():
+                    prepare(selector, jnp.conjugate(amplitudes))
+
+        result = cls(
+            sum(jnp.abs(coefficient * block_encoding.alpha) for coefficient, block_encoding in terms),
+            new_anc_templates,
+            unitary,
+            num_ops=num_ops,
+            is_hermitian=all(block_encoding.is_hermitian for _, block_encoding in terms),
+        )
+        result._lcu_terms = terms
+        return result
+
     def __add__(self, other: BlockEncoding) -> BlockEncoding:
         r"""Returns a BlockEncoding of the sum of two operators.
 
@@ -1093,39 +1289,7 @@ class BlockEncoding:
         if not isinstance(other, BlockEncoding):
             return NotImplemented
 
-        alpha = self.alpha
-        beta = other.alpha
-        m = len(self._anc_templates)
-        n = len(other._anc_templates)
-
-        def prep(qb, arr):
-            theta = 2 * jnp.arctan(arr[1] / arr[0])
-            ry(theta, qb)
-
-        def new_unitary(*args):
-            self_ancs = args[1 : 1 + m]
-            other_ancs = args[1 + m : 1 + m + n]
-            operands = args[1 + m + n :]
-
-            with conjugate(prep)(
-                args[0],
-                jnp.sqrt(jnp.array([alpha, beta]) / (alpha + beta)),
-            ):
-                with control(args[0], ctrl_state=0):
-                    self.unitary(*self_ancs, *operands)
-
-                with control(args[0], ctrl_state=1):
-                    other.unitary(*other_ancs, *operands)
-
-        new_anc_templates = [QuantumBool().template()] + self._anc_templates + other._anc_templates
-        new_alpha = alpha + beta
-        return BlockEncoding(
-            new_alpha,
-            new_anc_templates,
-            new_unitary,
-            num_ops=self.num_ops,
-            is_hermitian=self.is_hermitian and other.is_hermitian,
-        )
+        return type(self)._from_lcu_terms(self._get_lcu_terms() + other._get_lcu_terms())
 
     def __sub__(self, other: BlockEncoding) -> BlockEncoding:
         r"""Returns a BlockEncoding of the difference between two operators.
@@ -1191,41 +1355,8 @@ class BlockEncoding:
         if not isinstance(other, BlockEncoding):
             return NotImplemented
 
-        alpha = self.alpha
-        beta = other.alpha
-        m = len(self._anc_templates)
-        n = len(other._anc_templates)
-
-        def prep(qb, arr):
-            theta = 2 * jnp.arctan(arr[1] / arr[0])
-            ry(theta, qb)
-
-        def new_unitary(*args):
-            self_ancs = args[1 : 1 + m]
-            other_ancs = args[1 + m : 1 + m + n]
-            operands = args[1 + m + n :]
-
-            with conjugate(prep)(
-                args[0],
-                jnp.sqrt(jnp.array([alpha, beta]) / (alpha + beta)),
-            ):
-                z(args[0])  # Apply Z gate to flip the sign for subtraction
-
-                with control(args[0], ctrl_state=0):
-                    self.unitary(*self_ancs, *operands)
-
-                with control(args[0], ctrl_state=1):
-                    other.unitary(*other_ancs, *operands)
-
-        new_anc_templates = [QuantumBool().template()] + self._anc_templates + other._anc_templates
-        new_alpha = alpha + beta
-        return BlockEncoding(
-            new_alpha,
-            new_anc_templates,
-            new_unitary,
-            num_ops=self.num_ops,
-            is_hermitian=self.is_hermitian and other.is_hermitian,
-        )
+        other_terms = [(-coefficient, block_encoding) for coefficient, block_encoding in other._get_lcu_terms()]
+        return type(self)._from_lcu_terms(self._get_lcu_terms() + other_terms)
 
     def __mul__(self, other: "ArrayLike") -> BlockEncoding:
         r"""Returns a BlockEncoding of the scaled operator.
@@ -1295,19 +1426,8 @@ class BlockEncoding:
         from jax.typing import ArrayLike
 
         if isinstance(other, ArrayLike):
-
-            def new_unitary(*args):
-                self.unitary(*args)
-                with control(other < 0):
-                    gphase(np.pi, args[0][0])
-
-            return BlockEncoding(
-                self.alpha * jnp.abs(other),
-                self._anc_templates,
-                new_unitary,
-                num_ops=self.num_ops,
-                is_hermitian=self.is_hermitian,
-            )
+            terms = [(other * coefficient, block_encoding) for coefficient, block_encoding in self._get_lcu_terms()]
+            return type(self)._from_lcu_terms(terms)
 
         return NotImplemented
 
@@ -1387,7 +1507,11 @@ class BlockEncoding:
         new_alpha = self.alpha * other.alpha
         return BlockEncoding(new_alpha, new_anc_templates, new_unitary, num_ops=self.num_ops)
 
-    __radd__ = __add__
+    def __radd__(self, other):
+        if other == 0:
+            return self
+        return NotImplemented
+
     __rmul__ = __mul__
 
     def kron(self, other: BlockEncoding) -> BlockEncoding:

--- a/src/qrisp/block_encodings/block_encoding_base.py
+++ b/src/qrisp/block_encodings/block_encoding_base.py
@@ -1079,11 +1079,13 @@ class BlockEncoding:
         block_encodings: list[BlockEncoding],
         coefficients: "ArrayLike | None" = None,
     ) -> BlockEncoding:
-        r"""Constructs one LCU block-encoding from several block-encodings.
+        r"""Returns a BlockEncoding of a linear combination of operators.
 
-        The child block-encodings are combined in one selector instead of
-        recursively composing binary LCU block-encodings. This is also the
-        lowering target used by ``+``, ``-`` and scalar multiplication.
+        This method implements the linear combination $\sum_i\alpha_iA_i$ via the LCU
+        (Linear Combination of Unitaries) framework, where $A_i$ are
+        the operators encoded by the respective instances, and $\alpha_i$ are real coefficients.
+
+        Equivalently, block-encoded operators can also be combined via ``+``, ``-`` and scalar multiplication.
 
         Parameters
         ----------
@@ -1243,7 +1245,7 @@ class BlockEncoding:
     def __add__(self, other: BlockEncoding) -> BlockEncoding:
         r"""Returns a BlockEncoding of the sum of two operators.
 
-        This method implements the linear combination $A + B$ via the LCU
+        This method implements the addition $A + B$ via the LCU
         (Linear Combination of Unitaries) framework, where $A$ and $B$ are
         the operators encoded by the respective instances.
 
@@ -1309,9 +1311,9 @@ class BlockEncoding:
     def __sub__(self, other: BlockEncoding) -> BlockEncoding:
         r"""Returns a BlockEncoding of the difference between two operators.
 
-        This method implements the subtraction $A - B$ using a linear combination
-        of unitaries (LCU), where $A$ is the operator encoded by this instance
-        and $B$ is the operator encoded by 'other'.
+        This method implements the subtraction $A - B$ via the LCU
+        (Linear Combination of Unitaries) framework, where $A$ and $B$ are
+        the operators encoded by the respective instances.
 
         Parameters
         ----------

--- a/src/qrisp/block_encodings/block_encoding_base.py
+++ b/src/qrisp/block_encodings/block_encoding_base.py
@@ -1105,6 +1105,7 @@ class BlockEncoding:
             not match, or operand counts differ.
         TypeError
             If an item is not a BlockEncoding.
+
         """
         if len(block_encodings) == 0:
             raise ValueError("At least one block-encoding is required.")
@@ -1151,6 +1152,7 @@ class BlockEncoding:
         -------
         BlockEncoding
             A block-encoding of the weighted sum.
+
         """
         num_ops = terms[0][1].num_ops
         if any(block_encoding.num_ops != num_ops for _, block_encoding in terms):
@@ -1521,6 +1523,7 @@ class BlockEncoding:
         return BlockEncoding(new_alpha, new_anc_templates, new_unitary, num_ops=self.num_ops)
 
     def __radd__(self, other):
+        """Support adding a BlockEncoding to the start value used by sum()."""
         if other == 0:
             return self
         return NotImplemented

--- a/src/qrisp/block_encodings/block_encoding_base.py
+++ b/src/qrisp/block_encodings/block_encoding_base.py
@@ -28,6 +28,7 @@ from jax.tree_util import register_pytree_node_class
 
 from qrisp.alg_primitives.reflection import reflection
 from qrisp.alg_primitives.state_preparation import prepare
+from qrisp.block_encodings.ancilla_layout import _AncillaLayout, _maximum_layout_size
 from qrisp.core import QuantumVariable
 from qrisp.core.gate_application_functions import gphase, h, measure, reset, ry, x, z
 from qrisp.environments import conjugate, control, invert
@@ -1130,9 +1131,12 @@ class BlockEncoding:
         The resulting normalization is therefore
         ``sum(abs(coefficient * alpha_i))``.
 
-        The child ancilla templates are concatenated after one selector
-        register. The selector chooses exactly one child unitary, so nested
-        sums can be lowered to one preparation/select/preparation sequence.
+        The child ancillas are packed into one shared workspace after one
+        selector register. The workspace is sized to the largest child layout,
+        and each selected branch reconstructs its typed ancillas as views into
+        that workspace. Since the selector chooses exactly one child unitary,
+        nested sums can be lowered to one preparation/select/preparation
+        sequence.
         The term list is retained on the result so subsequent arithmetic can
         extend it instead of rebuilding a binary LCU tree.
 
@@ -1172,16 +1176,12 @@ class BlockEncoding:
             return result
 
         selector_size = (len(terms) - 1).bit_length()
-        term_anc_templates = [block_encoding._anc_templates for _, block_encoding in terms]
-        term_anc_sizes = [[template.qv_size for template in anc_templates] for anc_templates in term_anc_templates]
-        term_sizes = [sum(anc_sizes, start=jnp.array(0, dtype=int)) for anc_sizes in term_anc_sizes]
+        term_layouts = [_AncillaLayout.from_templates(block_encoding._anc_templates) for _, block_encoding in terms]
 
         # All LCU branches are selected exclusively, so their ancillas can share
-        # one flat workspace. Use jnp.maximum even for static sizes, keeping the
-        # sizing path identical when sizes become dynamic during Jasp tracing.
-        shared_anc_size = jnp.array(0, dtype=int)
-        for term_size in term_sizes:
-            shared_anc_size = jnp.maximum(shared_anc_size, term_size)
+        # one flat workspace. The helper uses jnp.maximum for static and dynamic
+        # sizes alike, keeping this allocation strategy uniform under Jasp.
+        shared_anc_size = _maximum_layout_size(term_layouts)
 
         # The shared register is allocated once. Each branch below reconstructs
         # its original typed ancillas as views into the prefix it actually uses.
@@ -1194,13 +1194,7 @@ class BlockEncoding:
             branches = []
 
             for term_index, (_, block_encoding) in enumerate(terms):
-                ancilla_offset = jnp.array(0, dtype=int)
-                child_ancillas = []
-                for template, anc_size in zip(term_anc_templates[term_index], term_anc_sizes[term_index]):
-                    child_ancillas.append(
-                        template.construct(reg=shared_ancilla.reg[ancilla_offset : ancilla_offset + anc_size])
-                    )
-                    ancilla_offset += anc_size
+                child_ancillas = term_layouts[term_index].construct_views(shared_ancilla)
 
                 def branch(
                     *branch_args,

--- a/src/qrisp/block_encodings/block_encoding_base.py
+++ b/src/qrisp/block_encodings/block_encoding_base.py
@@ -1172,17 +1172,35 @@ class BlockEncoding:
             return result
 
         selector_size = (len(terms) - 1).bit_length()
-        child_anc_templates = [template for _, block_encoding in terms for template in block_encoding._anc_templates]
-        new_anc_templates = [QuantumFloat(selector_size).template()] + child_anc_templates
+        term_anc_templates = [block_encoding._anc_templates for _, block_encoding in terms]
+        term_anc_sizes = [[template.qv_size for template in anc_templates] for anc_templates in term_anc_templates]
+        term_sizes = [sum(anc_sizes, start=jnp.array(0, dtype=int)) for anc_sizes in term_anc_sizes]
+
+        # All LCU branches are selected exclusively, so their ancillas can share
+        # one flat workspace. Use jnp.maximum even for static sizes, keeping the
+        # sizing path identical when sizes become dynamic during Jasp tracing.
+        shared_anc_size = jnp.array(0, dtype=int)
+        for term_size in term_sizes:
+            shared_anc_size = jnp.maximum(shared_anc_size, term_size)
+
+        # The shared register is allocated once. Each branch below reconstructs
+        # its original typed ancillas as views into the prefix it actually uses.
+        shared_anc_template = QuantumVariable(shared_anc_size).template()
+        new_anc_templates = [QuantumFloat(selector_size).template(), shared_anc_template]
 
         def unitary(*args):
             selector = args[0]
-            ancilla_offset = 1
+            shared_ancilla = args[1]
             branches = []
 
-            for _, block_encoding in terms:
-                child_ancillas = args[ancilla_offset : ancilla_offset + block_encoding.num_ancs]
-                ancilla_offset += block_encoding.num_ancs
+            for term_index, (_, block_encoding) in enumerate(terms):
+                ancilla_offset = jnp.array(0, dtype=int)
+                child_ancillas = []
+                for template, anc_size in zip(term_anc_templates[term_index], term_anc_sizes[term_index]):
+                    child_ancillas.append(
+                        template.construct(reg=shared_ancilla.reg[ancilla_offset : ancilla_offset + anc_size])
+                    )
+                    ancilla_offset += anc_size
 
                 def branch(
                     *branch_args,
@@ -1197,7 +1215,7 @@ class BlockEncoding:
                 pass
 
             branches.extend([identity_branch] * ((1 << selector_size) - len(branches)))
-            operands = args[ancilla_offset:]
+            operands = args[2:]
             coefficients = jnp.array(
                 [coefficient * block_encoding.alpha for coefficient, block_encoding in terms],
                 dtype=complex,

--- a/tests/block_encodings_tests/test_ancilla_layout.py
+++ b/tests/block_encodings_tests/test_ancilla_layout.py
@@ -1,0 +1,39 @@
+from qrisp import QuantumBool, QuantumFloat, QuantumVariable, jaspify, measure, x
+from qrisp.block_encodings.ancilla_layout import _AncillaLayout, _maximum_layout_size
+
+
+def test_ancilla_layout_constructs_typed_views():
+    """Test that _AncillaLayout constructs typed views correctly."""
+    layout = _AncillaLayout.from_templates([QuantumFloat(2).template(), QuantumBool().template()])
+    shared_ancilla = QuantumVariable(layout.total_size)
+
+    views = layout.construct_views(shared_ancilla)
+
+    assert [view.size for view in views] == [2, 1]
+    assert all(view_qubit is shared_qubit for view_qubit, shared_qubit in zip(views[0].reg, shared_ancilla.reg[:2]))
+    assert views[1].reg[0] is shared_ancilla.reg[2]
+
+
+def test_ancilla_layout_uses_maximum_total_size():
+    """Test that _maximum_layout_size returns the correct maximum size."""
+    layouts = [
+        _AncillaLayout.from_templates([QuantumFloat(2).template(), QuantumBool().template()]),
+        _AncillaLayout.from_templates([QuantumFloat(1).template()]),
+    ]
+
+    assert _maximum_layout_size(layouts) == 3
+
+
+def test_ancilla_layout_constructs_jasp_views():
+    """Test that _AncillaLayout constructs typed views correctly in Jasp execution."""
+
+    @jaspify
+    def main():
+        layout = _AncillaLayout.from_templates([QuantumFloat(2).template(), QuantumBool().template()])
+        shared_ancilla = QuantumVariable(_maximum_layout_size([layout]))
+        views = layout.construct_views(shared_ancilla)
+        x(views[0])
+        x(views[1])
+        return measure(shared_ancilla)
+
+    assert main() == 7

--- a/tests/block_encodings_tests/test_ancilla_layout.py
+++ b/tests/block_encodings_tests/test_ancilla_layout.py
@@ -1,3 +1,20 @@
+"""********************************************************************************
+* Copyright (c) 2026 the Qrisp authors
+*
+* This program and the accompanying materials are made available under the
+* terms of the Eclipse Public License 2.0 which is available at
+* http://www.eclipse.org/legal/epl-2.0.
+*
+* This Source Code may also be made available under the following Secondary
+* Licenses when the conditions for such availability set forth in the Eclipse
+* Public License, v. 2.0 are satisfied: GNU General Public License, version 2
+* with the GNU Classpath Exception which is
+* available at https://www.gnu.org/software/classpath/license.html.
+*
+* SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+********************************************************************************
+"""
+
 from qrisp import QuantumBool, QuantumFloat, QuantumVariable, jaspify, measure, x
 from qrisp.block_encodings.ancilla_layout import _AncillaLayout, _maximum_layout_size
 

--- a/tests/block_encodings_tests/test_block_encoding_arithmetic.py
+++ b/tests/block_encodings_tests/test_block_encoding_arithmetic.py
@@ -148,6 +148,7 @@ def test_block_encoding_scalar_multiplication(H1, H2, scalar):
 
 
 def test_block_encoding_flattened_linear_combination():
+    """Verify that linear combinations of block encodings are flattened into one LCU."""
     from jax.tree_util import tree_flatten, tree_unflatten
 
     H1 = X(0) * X(1)
@@ -187,6 +188,24 @@ def test_block_encoding_flattened_linear_combination():
     res_target = main(BE_target)
     compare_results(res_target, main(BE_chain), n)
     compare_results(res_target, main(BE_direct), n)
+
+
+def test_block_encoding_linear_combination_validates_inputs():
+    """Verify that linear combination input errors are reported."""
+    block_encoding = BlockEncoding(1, [], lambda operand: None)
+    two_operand_block_encoding = BlockEncoding(1, [], lambda first, second: None, num_ops=2)
+
+    with pytest.raises(ValueError, match="At least one block-encoding is required"):
+        BlockEncoding.linear_combination([])
+
+    with pytest.raises(ValueError, match="number of coefficients"):
+        BlockEncoding.linear_combination([block_encoding], coefficients=[1, 2])
+
+    with pytest.raises(TypeError, match="Expected every item to be a BlockEncoding"):
+        BlockEncoding.linear_combination([object()])
+
+    with pytest.raises(ValueError, match="same number of operands"):
+        BlockEncoding.linear_combination([block_encoding, two_operand_block_encoding])
 
 
 def test_block_encoding_lcu_reuses_heterogeneous_ancillas():

--- a/tests/block_encodings_tests/test_block_encoding_arithmetic.py
+++ b/tests/block_encodings_tests/test_block_encoding_arithmetic.py
@@ -15,6 +15,7 @@
 ********************************************************************************
 """
 
+from jax.tree_util import tree_flatten, tree_unflatten
 import numpy as np
 import pytest
 
@@ -23,11 +24,11 @@ from qrisp.block_encodings import BlockEncoding
 from qrisp.operators import X, Y, Z
 
 
-def compare_results(res_dict_1, res_dict_2, n):
+def _compare_results(res_dict_1, res_dict_2, n):
     for k in range(2**n):
         val_1 = res_dict_1.get(k, 0)
         val_2 = res_dict_2.get(k, 0)
-        assert np.isclose(val_1, val_2), f"Mismatch at state |{k}>: {val_1} vs {val_2}"
+        assert np.isclose(val_1, val_2)
 
 
 @pytest.mark.parametrize(
@@ -39,6 +40,7 @@ def compare_results(res_dict_1, res_dict_2, n):
     ],
 )
 def test_block_encoding_addition(H1, H2):
+    """Test addition of block encodings corresponding to Hermitian operators."""
 
     BE1 = BlockEncoding.from_operator(H1)
     BE2 = BlockEncoding.from_operator(H2)
@@ -55,7 +57,7 @@ def test_block_encoding_addition(H1, H2):
 
     res_be3 = main(BE3)
     res_be_add = main(BE_addition)
-    compare_results(res_be3, res_be_add, n)
+    _compare_results(res_be3, res_be_add, n)
 
 
 @pytest.mark.parametrize(
@@ -67,6 +69,7 @@ def test_block_encoding_addition(H1, H2):
     ],
 )
 def test_block_encoding_subtraction(H1, H2):
+    """Test subtraction of block encodings corresponding to Hermitian operators."""
 
     BE1 = BlockEncoding.from_operator(H1)
     BE2 = BlockEncoding.from_operator(H2)
@@ -83,7 +86,7 @@ def test_block_encoding_subtraction(H1, H2):
 
     res_be3 = main(BE3)
     res_be_sub = main(BE_subtraction)
-    compare_results(res_be3, res_be_sub, n)
+    _compare_results(res_be3, res_be_sub, n)
 
 
 # The product of two Hermitian operators A and B is Hermitian if and only if they commute, i.e., AB = BA.
@@ -97,6 +100,7 @@ def test_block_encoding_subtraction(H1, H2):
     ],
 )
 def test_block_encoding_multiplication(H1, H2):
+    """Test multiplication of block encodings corresponding to commuting Hermitian operators."""
 
     BE1 = BlockEncoding.from_operator(H1)
     BE2 = BlockEncoding.from_operator(H2)
@@ -113,7 +117,7 @@ def test_block_encoding_multiplication(H1, H2):
 
     res_be3 = main(BE3)
     res_be_mul = main(BE_multiplication)
-    compare_results(res_be3, res_be_mul, n)
+    _compare_results(res_be3, res_be_mul, n)
 
 
 @pytest.mark.parametrize(
@@ -143,13 +147,12 @@ def test_block_encoding_scalar_multiplication(H1, H2, scalar):
     res_target = main(BE_target)
     res_left = main(BE_left)
     res_right = main(BE_right)
-    compare_results(res_target, res_left, n)
-    compare_results(res_target, res_right, n)
+    _compare_results(res_target, res_left, n)
+    _compare_results(res_target, res_right, n)
 
 
 def test_block_encoding_flattened_linear_combination():
     """Verify that linear combinations of block encodings are flattened into one LCU."""
-    from jax.tree_util import tree_flatten, tree_unflatten
 
     H1 = X(0) * X(1)
     H2 = 0.4 * Y(0) + Z(1)
@@ -166,7 +169,9 @@ def test_block_encoding_flattened_linear_combination():
     assert len(BE_chain._lcu_terms) == 3
     assert len(BE_direct._lcu_terms) == 3
     assert BE_chain._anc_templates[0].qv_size == 2
-    assert BE_chain.num_ancs == 1 + BE1.num_ancs + BE2.num_ancs + BE3.num_ancs
+    # A linear combination of block encodings has exactly 2 ancillas:
+    # one for the LCU selection and one for the workspace.
+    assert BE_chain.num_ancs == 2
 
     leaves, treedef = tree_flatten(BE_chain)
     reconstructed = tree_unflatten(treedef, leaves)
@@ -186,8 +191,8 @@ def test_block_encoding_flattened_linear_combination():
         return BE.apply_rus(lambda: QuantumVariable(n))()
 
     res_target = main(BE_target)
-    compare_results(res_target, main(BE_chain), n)
-    compare_results(res_target, main(BE_direct), n)
+    _compare_results(res_target, main(BE_chain), n)
+    _compare_results(res_target, main(BE_direct), n)
 
 
 def test_block_encoding_linear_combination_validates_inputs():
@@ -226,10 +231,12 @@ def test_block_encoding_lcu_reuses_heterogeneous_ancillas():
     BE_one_ancilla = BlockEncoding(1, [QuantumFloat(1)], one_ancilla_unitary)
     BE = BlockEncoding.linear_combination([BE_two_ancillas, BE_one_ancilla])
 
-    expected_ancilla_count = 2
-    expected_shared_size = 3
-    assert BE.num_ancs == expected_ancilla_count
-    assert BE._anc_templates[1].qv_size == expected_shared_size
+    # A linear combination of block encodings has exactly 2 ancillas:
+    # one for the LCU selection and one for the workspace.
+    assert BE.num_ancs == 2
+    # The workspace ancilla is the second one, which is a QuantumVariable of size 3
+    # (2 for the float and 1 for the bool).
+    assert BE._anc_templates[1].qv_size == 3
 
     operand = QuantumVariable(1)
     BE.apply(operand)
@@ -252,6 +259,7 @@ def test_block_encoding_lcu_reuses_heterogeneous_ancillas():
     ],
 )
 def test_block_encoding_negation(H1, H2):
+    """Test negation of block encodings corresponding to Hermitian operators."""
 
     BE1 = BlockEncoding.from_operator(H1)
     BE_neg = -BE1
@@ -266,7 +274,7 @@ def test_block_encoding_negation(H1, H2):
 
     res_be2 = main(BE2)
     res_be_neg = main(BE_neg)
-    compare_results(res_be2, res_be_neg, n)
+    _compare_results(res_be2, res_be_neg, n)
 
 
 @pytest.mark.parametrize(
@@ -277,6 +285,7 @@ def test_block_encoding_negation(H1, H2):
     ],
 )
 def test_block_encoding_kron(H1, H2):
+    """Test the Kronecker product of two block encodings corresponding to Hermitian operators."""
 
     BE1 = BlockEncoding.from_operator(H1)
     BE2 = BlockEncoding.from_operator(H2)
@@ -309,4 +318,4 @@ def test_block_encoding_kron(H1, H2):
         for l in range(2**n2):
             val_be_kron = result_be_kron.get((k, l), 0)
             val_be1_be2 = result_be1_be2.get((k, l), 0)
-            assert np.isclose(val_be_kron, val_be1_be2), f"Mismatch at state |{k}>: {val_be_kron} vs {val_be1_be2}"
+            assert np.isclose(val_be_kron, val_be1_be2)

--- a/tests/block_encodings_tests/test_block_encoding_arithmetic.py
+++ b/tests/block_encodings_tests/test_block_encoding_arithmetic.py
@@ -18,7 +18,7 @@
 import numpy as np
 import pytest
 
-from qrisp import QuantumFloat, QuantumVariable, terminal_sampling
+from qrisp import QuantumBool, QuantumFloat, QuantumVariable, jaspify, measure, terminal_sampling, x
 from qrisp.block_encodings import BlockEncoding
 from qrisp.operators import X, Y, Z
 
@@ -187,6 +187,41 @@ def test_block_encoding_flattened_linear_combination():
     res_target = main(BE_target)
     compare_results(res_target, main(BE_chain), n)
     compare_results(res_target, main(BE_direct), n)
+
+
+def test_block_encoding_lcu_reuses_heterogeneous_ancillas():
+    """Verify that heterogeneous child ancillas share one workspace."""
+
+    def two_ancilla_unitary(float_ancilla, bool_ancilla, operand):
+        x(float_ancilla)
+        x(bool_ancilla)
+
+    def one_ancilla_unitary(float_ancilla, operand):
+        x(float_ancilla)
+
+    BE_two_ancillas = BlockEncoding(
+        1,
+        [QuantumFloat(2), QuantumBool()],
+        two_ancilla_unitary,
+    )
+    BE_one_ancilla = BlockEncoding(1, [QuantumFloat(1)], one_ancilla_unitary)
+    BE = BlockEncoding.linear_combination([BE_two_ancillas, BE_one_ancilla])
+
+    expected_ancilla_count = 2
+    expected_shared_size = 3
+    assert BE.num_ancs == expected_ancilla_count
+    assert BE._anc_templates[1].qv_size == expected_shared_size
+
+    operand = QuantumVariable(1)
+    BE.apply(operand)
+
+    @jaspify
+    def main(block_encoding):
+        operand = QuantumVariable(1)
+        block_encoding.apply(operand)
+        return measure(operand)
+
+    assert main(BE) == 0
 
 
 @pytest.mark.parametrize(

--- a/tests/block_encodings_tests/test_block_encoding_arithmetic.py
+++ b/tests/block_encodings_tests/test_block_encoding_arithmetic.py
@@ -147,6 +147,48 @@ def test_block_encoding_scalar_multiplication(H1, H2, scalar):
     compare_results(res_target, res_right, n)
 
 
+def test_block_encoding_flattened_linear_combination():
+    from jax.tree_util import tree_flatten, tree_unflatten
+
+    H1 = X(0) * X(1)
+    H2 = 0.4 * Y(0) + Z(1)
+    H3 = 0.7 * X(2)
+    coefficients = [2.0, -1.0, 0.5]
+
+    BE1 = BlockEncoding.from_operator(H1)
+    BE2 = BlockEncoding.from_operator(H2)
+    BE3 = BlockEncoding.from_operator(H3)
+
+    BE_chain = coefficients[0] * BE1 + coefficients[1] * BE2 + coefficients[2] * BE3
+    BE_direct = BlockEncoding.linear_combination([BE1, BE2, BE3], coefficients=coefficients)
+
+    assert len(BE_chain._lcu_terms) == 3
+    assert len(BE_direct._lcu_terms) == 3
+    assert BE_chain._anc_templates[0].qv_size == 2
+    assert BE_chain.num_ancs == 1 + BE1.num_ancs + BE2.num_ancs + BE3.num_ancs
+
+    leaves, treedef = tree_flatten(BE_chain)
+    reconstructed = tree_unflatten(treedef, leaves)
+    assert len(reconstructed._lcu_terms) == 3
+    assert len((reconstructed + BE1)._lcu_terms) == 4
+
+    H_target = coefficients[0] * H1 + coefficients[1] * H2 + coefficients[2] * H3
+    BE_target = BlockEncoding.from_operator(H_target)
+    n = max(
+        H1.find_minimal_qubit_amount(),
+        H2.find_minimal_qubit_amount(),
+        H3.find_minimal_qubit_amount(),
+    )
+
+    @terminal_sampling
+    def main(BE):
+        return BE.apply_rus(lambda: QuantumVariable(n))()
+
+    res_target = main(BE_target)
+    compare_results(res_target, main(BE_chain), n)
+    compare_results(res_target, main(BE_direct), n)
+
+
 @pytest.mark.parametrize(
     "H1, H2",
     [


### PR DESCRIPTION
## Description

This PR improves `BlockEncoding` arithmetic by lowering linear combinations into a single flattened LCU construction. Mutually exclusive LCU branches reuse one shared ancilla workspace, reducing unnecessary ancilla allocation from recursively nested combinations.

## Related Issues

No related issue linked.

## Type of Change

- [x] Feature (new functionality)
- [x] Refactoring (no behavior change)
- [x] Performance improvement
- [x] Documentation

## Breaking Change?

- [ ] Yes
- [x] No

## What was changed?

- Added `BlockEncoding.linear_combination()` for explicitly combining block encodings.
- Flattened chained addition, subtraction, and scalar multiplication into one LCU representation.
- Added JAX pytree support for preserving flattened LCU terms.
- Added `_AncillaLayout` to reconstruct heterogeneous typed ancilla views from one shared workspace.
- Added static and Jasp tests for ancilla reuse, flattening, serialization, validation, and numerical equivalence.
- Added API documentation and a changelog entry.

## How was it tested?

| Test-ID | Status |
|---------|--------|
| T-001 | ✅ Arithmetic regression tests passed |
| T-002 | ✅ Flattened and direct linear-combination equivalence tested |
| T-003 | ✅ Ancilla layout tests passed in static and Jasp execution |
| T-004 | ✅ Input validation exception tests passed |

Additional validation: `git diff --check main...BE_experiments` passed.

## Screenshots / Output

Not applicable.

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review
- [x] I have added/updated tests
- [x] All relevant tests pass locally
- [x] I have updated the documentation
- [x] I have added a changelog entry to changelog-dev.rst
- [ ] Breaking changes are documented with migration path

## Reviewer Notes

Please review the shared ancilla workspace construction and the preservation of flattened LCU terms through JAX pytree serialization.