### PR TITLE
Update cc.log_output to quake.log_output

### DIFF
--- a/src/qrisp/jasp/cudaq_interface/cudaq_ingestion/__init__.py
+++ b/src/qrisp/jasp/cudaq_interface/cudaq_ingestion/__init__.py
@@ -34,7 +34,7 @@
 # cudaq_prep
 #     Stage 2 -- "Interface Adaptation": restructure the module to match what
 #     CUDA-Q's Module.parse expects (entrypoint renaming/attributes,
-#     .run/.run.entry variants, cc.log_output synthesis, etc.).
+#     .run/.run.entry variants, quake.log_output synthesis, etc.).
 # xdsl_ingestion
 #     Stage 3 -- "Re-Compilation": serialize the adapted module, normalize it
 #     from xDSL's to CUDA-Q's MLIR printing conventions, and parse it back

--- a/src/qrisp/jasp/cudaq_interface/cudaq_ingestion/cudaq_prep.py
+++ b/src/qrisp/jasp/cudaq_interface/cudaq_ingestion/cudaq_prep.py
@@ -27,7 +27,7 @@
 # - Removes old-style attrs, strips visibility
 # - Adds cudaq-entrypoint / cudaq-kernel unit attrs
 # - Packs multiple return values into !cc.struct
-# - Synthesizes .run variant (cc.log_output + void return)
+# - Synthesizes .run variant (quake.log_output + void return)
 # - Synthesizes .run.entry
 # - Injects module-level attributes (llvm.data_layout, quake.mangled_name_map, etc.)
 #
@@ -53,10 +53,10 @@ from xdsl.ir import Block, Region
 
 from qrisp.jasp.cudaq_interface.quake_lowering.dialects.cc_dialect import (
     CcInsertValueOp,
-    CcLogOutputOp,
     CcStructType,
     CcUndefOp,
 )
+from qrisp.jasp.cudaq_interface.quake_lowering.dialects.quake_dialect import QuakeLogOutputOp
 
 # ===========================================================================
 # Internal helpers
@@ -217,12 +217,12 @@ def _pass_synthesize_run(module: ModuleOp, source_func: func.FuncOp, run_func_na
     run_func = source_func.clone()
     run_func.properties["sym_name"] = StringAttr(run_func_name)
 
-    # Replace return with cc.log_output + void return
+    # Replace return with quake.log_output + void return
     return_op = _find_entry_return(run_func)
     if return_op is not None:
         block = return_op.parent_block()
         for val in list(return_op.operands):
-            block.insert_op_before(CcLogOutputOp(val), return_op)
+            block.insert_op_before(QuakeLogOutputOp(val), return_op)
         block.insert_op_before(func.ReturnOp(), return_op)
         block.erase_op(return_op)
 

--- a/src/qrisp/jasp/cudaq_interface/cudaq_ingestion/xdsl_ingestion.py
+++ b/src/qrisp/jasp/cudaq_interface/cudaq_ingestion/xdsl_ingestion.py
@@ -124,7 +124,7 @@ def _cudaq_kernel_from_xdsl_module(
         - ``"run"`` — Prepares the kernel for use with ``cudaq.run()``. This mode
           preserves the function's return values by synthesizing additional
           ``.run`` and ``.run.entry`` function variants. The ``.run`` variant
-          replaces ``func.return`` operations with ``cc.log_output`` calls,
+          replaces ``func.return`` operations with ``quake.log_output`` calls,
           which is the mechanism CUDA-Q uses to capture and aggregate per-shot
           measurement results across repeated executions. Use this mode when
           you need to retrieve computed classical values (e.g., expectation

--- a/src/qrisp/jasp/cudaq_interface/cudaq_kernel.py
+++ b/src/qrisp/jasp/cudaq_interface/cudaq_kernel.py
@@ -44,7 +44,7 @@
 #    We inject the extracted hardware specifications
 #    into the Qrisp-generated MLIR. Crucially, we also clone the primary
 #    entry function to create a required `.run` variant. During this cloning,
-#    we translate standard `func.return` instructions into `cc.log_output`
+#    we translate standard `func.return` instructions into `quake.log_output`
 #    operations. This structural change is required, as it is the exact
 #    mechanism CUDA-Q uses to capture and aggregate individual per-shot
 #    measurement data during simulation.

--- a/src/qrisp/jasp/cudaq_interface/quake_lowering/dialects/cc_dialect.py
+++ b/src/qrisp/jasp/cudaq_interface/quake_lowering/dialects/cc_dialect.py
@@ -25,7 +25,7 @@
 # - Structured control-flow ops (cc.if, cc.loop, cc.condition, cc.continue, cc.break)
 # - Pointer arithmetic ops (cc.compute_ptr, cc.cast)
 # - StdVec ops (cc.stdvec_data)
-# - Struct ops (cc.undef, cc.insert_value, cc.log_output) – used by CUDA-Q
+# - Struct ops (cc.undef, cc.insert_value) – used by CUDA-Q
 #   preparation for multi-return packing and .run variant synthesis.
 #
 # Control-flow semantics
@@ -675,33 +675,6 @@ class CcInsertValueOp(IRDLOperation):
         printer.print_attribute(self.result.type)
 
 
-@irdl_op_definition
-class CcLogOutputOp(IRDLOperation):
-    """Log a classical value for retrieval by ``cudaq.run``.
-
-    ::
-
-        cc.log_output %val : i64
-
-    This op is a side-effecting terminator-like op that records the value
-    for the CUDA-Q runtime to collect across shots. It has no results.
-    """
-
-    name = "cc.log_output"
-    value = operand_def(AnyAttr())
-
-    def __init__(self, value: SSAValue) -> None:
-        """Initialize the object."""
-        super().__init__(operands=[value])
-
-    def print(self, printer: Printer) -> None:
-        """Print the CC log-output operation."""
-        printer.print_string(" ")
-        printer.print_ssa_value(self.value)
-        printer.print_string(" : ")
-        printer.print_attribute(self.value.type)
-
-
 # ---------------------------------------------------------------------------
 # Dialect registration
 # ---------------------------------------------------------------------------
@@ -730,6 +703,5 @@ class CcDialect(Dialect):
         # Struct / value
         CcUndefOp,
         CcInsertValueOp,
-        CcLogOutputOp,
     ]
     attributes = [CcArrayType, CcPtrType, CcMeasureHandleType, CcStdVecType, CcStructType]

--- a/src/qrisp/jasp/cudaq_interface/quake_lowering/dialects/quake_dialect.py
+++ b/src/qrisp/jasp/cudaq_interface/quake_lowering/dialects/quake_dialect.py
@@ -560,6 +560,34 @@ class ResetOp(IRDLOperation):
         printer.print_string(") -> ()")
 
 
+@irdl_op_definition
+class QuakeLogOutputOp(IRDLOperation):
+    """Log a classical value for retrieval by ``cudaq.run``.
+
+    ::
+
+        quake.log_output %val : (i64) -> ()
+
+    This op records the value for the CUDA-Q runtime to collect across shots.
+    It has no results.
+    """
+
+    name = "quake.log_output"
+    value = operand_def(AnyAttr())
+
+    def __init__(self, value: SSAValue) -> None:
+        """Initialize the object."""
+        super().__init__(operands=[value])
+
+    def print(self, printer: Printer) -> None:
+        """Print the Quake log-output operation."""
+        printer.print_string(" ")
+        printer.print_ssa_value(self.value)
+        printer.print_string(" : (")
+        printer.print_attribute(self.value.type)
+        printer.print_string(") -> ()")
+
+
 # ---------------------------------------------------------------------------
 # Dialect registration
 # ---------------------------------------------------------------------------
@@ -582,6 +610,7 @@ class QuakeDialect(Dialect):
         MzOp,
         DiscriminateOp,
         ResetOp,
+        QuakeLogOutputOp,
         *_ALL_GATE_CLASSES,
     ]
     attributes = [QuakeRefType, QuakeVeqType, QuakeMeasureType, CcStdVecType, CcMeasureHandleType]


### PR DESCRIPTION
Update cc.log_output to quake.log_output. This will be a future breaking change in cudaq>0.15.1.