### PR TITLE
Improvements to `QuantumFloat`

### DIFF
--- a/documentation/source/general/changelog/changelog-dev.rst
+++ b/documentation/source/general/changelog/changelog-dev.rst
@@ -43,9 +43,10 @@ Improvements
 
 - Improved the performance of :class:`~qrisp.QuantumFloat`'s ``significant()``,
   ``init_from()``, and ``encode(..., rounding=True)``. The latter previously
-  decoded every representable outcome one at a time in a Python loop —
-  exponential in the qubit count — and now does so with a single vectorized
-  call
+  searched every representable outcome for the closest one — exponential in
+  the qubit count — and now finds it directly the same way ``truncate()``
+  does (round-and-clip against the uniform grid of representable values),
+  in O(1)
   (`PR #846 <https://github.com/eclipse-qrisp/Qrisp/pull/846>`_).
 
 Other New Features

--- a/documentation/source/general/changelog/changelog-dev.rst
+++ b/documentation/source/general/changelog/changelog-dev.rst
@@ -37,16 +37,9 @@ Improvements
   ``terminal_sampling()`` to use "sampling kernel" terminology and document
   the new arbitrary-return-value capability.
 
-- Added type hints across :class:`~qrisp.QuantumFloat` using the ``qrisp.typing``
-  aliases, and fixed several stale docstring examples
-  (`PR #846 <https://github.com/eclipse-qrisp/Qrisp/pull/846>`_).
-
-- Improved the performance of :class:`~qrisp.QuantumFloat`'s ``significant()``,
-  ``init_from()``, and ``encode(..., rounding=True)``. The latter previously
-  searched every representable outcome for the closest one (exponential in
-  the qubit count) and now finds it directly the same way ``truncate()``
-  does (round-and-clip against the uniform grid of representable values),
-  in O(1)
+- Added type hints across :class:`~qrisp.QuantumFloat`, fixed stale
+  docstring examples, and sped up ``significant()``, ``init_from()``, and
+  ``encode(..., rounding=True)`` (now O(1))
   (`PR #846 <https://github.com/eclipse-qrisp/Qrisp/pull/846>`_).
 
 Other New Features
@@ -152,11 +145,9 @@ Bug Fixes
   by an import-hoisting cleanup, which broke ``ruff format --check`` on
   ``main`` right after merge.
 
-* Fixed a bug where adding or subtracting two :class:`~qrisp.QuantumFloat`
-  operands with different exponents, outside of Jasp tracing, silently
-  turned the result's exponent into a 0-d ``jax.Array`` instead of a plain
-  ``int``. This crashed any later operation computing ``2**exponent`` with a
-  negative exponent, including the class's own docstring example
+* Fixed a bug where :class:`~qrisp.QuantumFloat` add/sub with different
+  exponents silently produced a ``jax.Array`` exponent instead of a plain
+  ``int`` outside tracing, crashing later negative ``2**exponent`` calls
   (`PR #846 <https://github.com/eclipse-qrisp/Qrisp/pull/846>`_).
 
 Compatibility
@@ -169,11 +160,8 @@ Compatibility
   (`PR #767 <https://github.com/eclipse-qrisp/Qrisp/pull/767>`_).
 
 * :class:`~qrisp.QuantumFloat` methods now raise specific exception types
-  (``TypeError`` for an unsupported operand type, ``ValueError`` for an
-  invalid value or state, ``NotImplementedError`` for a genuinely
-  unimplemented feature) instead of a generic ``Exception``, at the 26
-  call sites that previously did so. Code using ``except Exception:``
-  continues to work; code catching a more specific type now can
+  (``TypeError``, ``ValueError``, ``NotImplementedError``) instead of a
+  generic ``Exception``. Code using ``except Exception:`` is unaffected
   (`PR #846 <https://github.com/eclipse-qrisp/Qrisp/pull/846>`_).
 
 .. Add compatibility notes above this line
@@ -278,12 +266,6 @@ Development
   which previously ran only on pushes to ``main``. This meant formatting
   regressions were never caught during PR review and only surfaced once
   merged into ``main``.
-
-* Fixed pylint/pyright findings in ``QuantumFloat``, verified its docstring
-  examples against ``doctest``, added regression tests for previously
-  uncovered code paths, and added explanatory comments to the local imports
-  required to avoid circular imports with ``qrisp.alg_primitives.arithmetic``
-  (`PR #846 <https://github.com/eclipse-qrisp/Qrisp/pull/846>`_).
 
 Dependency Upgrades
 -------------------

--- a/documentation/source/general/changelog/changelog-dev.rst
+++ b/documentation/source/general/changelog/changelog-dev.rst
@@ -37,6 +37,17 @@ Improvements
   ``terminal_sampling()`` to use "sampling kernel" terminology and document
   the new arbitrary-return-value capability.
 
+- Added type hints across :class:`~qrisp.QuantumFloat` using the ``qrisp.typing``
+  aliases, and fixed several stale docstring examples
+  (`PR #846 <https://github.com/eclipse-qrisp/Qrisp/pull/846>`_).
+
+- Improved the performance of :class:`~qrisp.QuantumFloat`'s ``significant()``,
+  ``init_from()``, and ``encode(..., rounding=True)``. The latter previously
+  decoded every representable outcome one at a time in a Python loop —
+  exponential in the qubit count — and now does so with a single vectorized
+  call
+  (`PR #846 <https://github.com/eclipse-qrisp/Qrisp/pull/846>`_).
+
 Other New Features
 ------------------
 
@@ -140,6 +151,13 @@ Bug Fixes
   by an import-hoisting cleanup, which broke ``ruff format --check`` on
   ``main`` right after merge.
 
+* Fixed a bug where adding or subtracting two :class:`~qrisp.QuantumFloat`
+  operands with different exponents, outside of Jasp tracing, silently
+  turned the result's exponent into a 0-d ``jax.Array`` instead of a plain
+  ``int``. This crashed any later operation computing ``2**exponent`` with a
+  negative exponent — including the class's own docstring example
+  (`PR #846 <https://github.com/eclipse-qrisp/Qrisp/pull/846>`_).
+
 Compatibility
 -------------
 
@@ -148,6 +166,14 @@ Compatibility
   plain Python integers (i.e. outside of Jasp tracing).  The latter previously
   produced an incorrect state silently
   (`PR #767 <https://github.com/eclipse-qrisp/Qrisp/pull/767>`_).
+
+* :class:`~qrisp.QuantumFloat` methods now raise specific exception types —
+  ``TypeError`` for an unsupported operand type, ``ValueError`` for an
+  invalid value or state, ``NotImplementedError`` for a genuinely
+  unimplemented feature — instead of a generic ``Exception``, at the 26
+  call sites that previously did so. Code using ``except Exception:``
+  continues to work; code catching a more specific type now can
+  (`PR #846 <https://github.com/eclipse-qrisp/Qrisp/pull/846>`_).
 
 .. Add compatibility notes above this line
 
@@ -251,6 +277,12 @@ Development
   which previously ran only on pushes to ``main``. This meant formatting
   regressions were never caught during PR review and only surfaced once
   merged into ``main``.
+
+* Fixed pylint/pyright findings in ``QuantumFloat``, verified its docstring
+  examples against ``doctest``, added regression tests for previously
+  uncovered code paths, and added explanatory comments to the local imports
+  required to avoid circular imports with ``qrisp.alg_primitives.arithmetic``
+  (`PR #846 <https://github.com/eclipse-qrisp/Qrisp/pull/846>`_).
 
 Dependency Upgrades
 -------------------

--- a/documentation/source/general/changelog/changelog-dev.rst
+++ b/documentation/source/general/changelog/changelog-dev.rst
@@ -43,8 +43,8 @@ Improvements
 
 - Improved the performance of :class:`~qrisp.QuantumFloat`'s ``significant()``,
   ``init_from()``, and ``encode(..., rounding=True)``. The latter previously
-  searched every representable outcome for the closest one — exponential in
-  the qubit count — and now finds it directly the same way ``truncate()``
+  searched every representable outcome for the closest one (exponential in
+  the qubit count) and now finds it directly the same way ``truncate()``
   does (round-and-clip against the uniform grid of representable values),
   in O(1)
   (`PR #846 <https://github.com/eclipse-qrisp/Qrisp/pull/846>`_).
@@ -156,7 +156,7 @@ Bug Fixes
   operands with different exponents, outside of Jasp tracing, silently
   turned the result's exponent into a 0-d ``jax.Array`` instead of a plain
   ``int``. This crashed any later operation computing ``2**exponent`` with a
-  negative exponent — including the class's own docstring example
+  negative exponent, including the class's own docstring example
   (`PR #846 <https://github.com/eclipse-qrisp/Qrisp/pull/846>`_).
 
 Compatibility
@@ -168,10 +168,10 @@ Compatibility
   produced an incorrect state silently
   (`PR #767 <https://github.com/eclipse-qrisp/Qrisp/pull/767>`_).
 
-* :class:`~qrisp.QuantumFloat` methods now raise specific exception types —
-  ``TypeError`` for an unsupported operand type, ``ValueError`` for an
+* :class:`~qrisp.QuantumFloat` methods now raise specific exception types
+  (``TypeError`` for an unsupported operand type, ``ValueError`` for an
   invalid value or state, ``NotImplementedError`` for a genuinely
-  unimplemented feature — instead of a generic ``Exception``, at the 26
+  unimplemented feature) instead of a generic ``Exception``, at the 26
   call sites that previously did so. Code using ``except Exception:``
   continues to work; code catching a more specific type now can
   (`PR #846 <https://github.com/eclipse-qrisp/Qrisp/pull/846>`_).

--- a/src/qrisp/alg_primitives/arithmetic/SBP_arithmetic.py
+++ b/src/qrisp/alg_primitives/arithmetic/SBP_arithmetic.py
@@ -16,6 +16,10 @@
 
 """Implements QuantumFloat mult/add/sub and phase-polynomial application via semi-Boolean polynomials."""
 
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 import numpy as np
 import sympy as sp
 
@@ -38,6 +42,10 @@ from qrisp.core import (
     z,
 )
 from qrisp.misc import gate_wrap
+
+if TYPE_CHECKING:
+    # NOTE: Local import to avoid a circular import (qrisp.qtypes imports from qrisp.alg_primitives.arithmetic).
+    from qrisp.qtypes.quantum_float import QuantumFloat
 
 # Threshold of rounding used in detecting integer multiples of pi
 pi_mult_round_threshold = 11
@@ -633,14 +641,14 @@ def U_g_inpl_adder(modified_var, summand, mult_factor=1):
 # while performing conditional additions using CNOT gates.
 # The approach is therefore a hybrid of SBP-method and traditional logic approaches
 def hybrid_mult(
-    x,
-    y,
-    output_qf=None,
+    x: QuantumFloat,
+    y: QuantumFloat,
+    output_qf: QuantumFloat | None = None,
     init_op="h",
     terminal_op="qft",
     phase_tolerant=False,
     cl_factor=1,
-):
+) -> QuantumFloat:
     """An advanced algorithm for multiplication which has better depth, gate-count
     and compile time than :meth:`sbp_mult <qrisp.sbp_mult>`.
     It does not support squaring a single QuantumFloat though.
@@ -905,7 +913,37 @@ def hybrid_mult(
 
 
 # Wrapper for choosing the best multiplication algorithm
-def q_mult(factor_1, factor_2, target=None, method="auto"):
+def q_mult(
+    factor_1: QuantumFloat, factor_2: QuantumFloat, target: QuantumFloat | None = None, method: str = "auto"
+) -> QuantumFloat:
+    """Multiply two QuantumFloats, picking (or forcing) the underlying algorithm.
+
+    Parameters
+    ----------
+    factor_1 : QuantumFloat
+        The first factor.
+    factor_2 : QuantumFloat
+        The second factor.
+    target : QuantumFloat, optional
+        The QuantumFloat to store the result in. By default, a suitably
+        sized QuantumFloat is created (ignored for ``method="hybrid"``,
+        which always creates its own).
+    method : str, optional
+        Either ``"auto"`` (squares via ``"sbp"`` when ``factor_1`` and
+        ``factor_2`` share a register, ``"hybrid"`` otherwise),
+        ``"sbp"``, or ``"hybrid"``. The default is ``"auto"``.
+
+    Returns
+    -------
+    QuantumFloat
+        The QuantumFloat containing the product.
+
+    Raises
+    ------
+    ValueError
+        If ``method`` is not one of ``"auto"``, ``"sbp"``, or ``"hybrid"``.
+
+    """
     if method == "auto":
         if factor_1.reg == factor_2.reg:
             return q_mult(factor_1, factor_2, target, method="sbp")
@@ -925,6 +963,9 @@ def q_mult(factor_1, factor_2, target=None, method="auto"):
         from qrisp.alg_primitives.arithmetic import hybrid_mult
 
         return hybrid_mult(factor_1, factor_2)
+
+    else:
+        raise ValueError(f"Don't know multiplication method {method} (available are 'auto', 'sbp', 'hybrid')")
 
 
 def QFT_inpl_mult(qv, inplace_mult=1):

--- a/src/qrisp/alg_primitives/arithmetic/matrix_multiplication.py
+++ b/src/qrisp/alg_primitives/arithmetic/matrix_multiplication.py
@@ -27,6 +27,42 @@ from qrisp.core import QuantumArray
 from qrisp.core.gate_application_functions import p, z
 
 
+def _trunc_poly(poly: sp.Expr, trunc_bounds: tuple[int, int]) -> sp.Expr:
+    """Truncate a polynomial to the given power-of-2 bounds.
+
+    Truncates a polynomial of the form ``p(x) = 2**k_0*x**i_0 +
+    2**k_1*x**i_1 + ...`` by removing every summand whose coefficient's
+    power of 2 does not lie within ``trunc_bounds``.
+
+    Parameters
+    ----------
+    poly : sympy.Expr
+        The polynomial to truncate.
+    trunc_bounds : tuple[int, int]
+        The (lower, upper) power-of-2 bounds to truncate to.
+
+    Returns
+    -------
+    sympy.Expr
+        The truncated polynomial, expanded.
+
+    """
+    # sympy's type stubs don't model Poly's dynamic attribute surface, so
+    # pyright can't see .trunc()/.expr here even though they're real members.
+    # Convert to sympy polynomial
+    poly_repr = sp.poly(poly)
+
+    # Clip upper bound
+    poly_repr = poly_repr.trunc(2.0 ** (trunc_bounds[1]))  # pyright: ignore[reportAttributeAccessIssue]
+
+    # Clip lower bound
+    poly_repr = poly_repr / 2.0 ** trunc_bounds[0]
+    poly_repr = poly_repr - sp.poly(poly_repr).trunc(1)
+    poly_repr = poly_repr * 2.0 ** trunc_bounds[0]
+
+    return poly_repr.expr.expand()
+
+
 def q_matmul(q_array_0, q_array_1, output_array=None, res_bit_shape="eq", phase_tolerant=False):
     """Matrix multiplication for QuantumArrays.
 
@@ -453,10 +489,8 @@ def inplace_matrix_app(vector, matrix):
         # Generate inverse equation
         eval_inverse = modinv(coeff, 2**bit) * (-target_values[i].subs({x[j]: 0}) + ancilla_symbol)
 
-        from qrisp.qtypes.quantum_float import trunc_poly
-
         # Truncate coefficients in order to stay inside Z/ 2^n Z
-        eval_inverse = trunc_poly(eval_inverse, (0, bit))
+        eval_inverse = _trunc_poly(eval_inverse, (0, bit))
 
         # Rewrite the remaining evaluation equations in terms of the new variable
         subs_dic = {x[j]: eval_inverse}
@@ -466,7 +500,7 @@ def inplace_matrix_app(vector, matrix):
             target_values[k] = target_values[k].subs(subs_dic).subs({ancilla_symbol: x[j]})
 
             # Truncate coefficients
-            target_values[k] = trunc_poly(target_values[k], (0, bit))
+            target_values[k] = _trunc_poly(target_values[k], (0, bit))
 
         eliminated_variables.append(j)
 

--- a/src/qrisp/qtypes/quantum_float.py
+++ b/src/qrisp/qtypes/quantum_float.py
@@ -237,7 +237,7 @@ class QuantumFloat(QuantumVariable):
 
     >>> d = a//b
     >>> print(d)
-    {3.0: 1.0}
+    {3: 1.0}
 
     Inversion:
 
@@ -659,8 +659,7 @@ class QuantumFloat(QuantumVariable):
             return output_qf
 
         raise TypeError(
-            "QuantumFloat multiplication for type " + str(type(other)) + ""
-            " not implemented (available are QuantumFloat and int)"
+            f"QuantumFloat multiplication for type {type(other)} not implemented (available are QuantumFloat and int)"
         )
 
     @gate_wrap(permeability="args", is_qfree=True)
@@ -682,7 +681,7 @@ class QuantumFloat(QuantumVariable):
             cx(self, res)
             res += other
             return res
-        raise TypeError("Addition with type " + str(type(other)) + " not implemented")
+        raise TypeError(f"Addition with type {type(other)} not implemented")
 
     @gate_wrap(permeability="args", is_qfree=True)
     def __sub__(self, other: QuantumFloat | FloatLike) -> QuantumFloat:
@@ -703,7 +702,7 @@ class QuantumFloat(QuantumVariable):
             cx(self, res)
             res -= other
             return res
-        raise TypeError("Subtraction with type " + str(type(other)) + " not implemented")
+        raise TypeError(f"Subtraction with type {type(other)} not implemented")
 
     __radd__ = __add__
     __rmul__ = __mul__
@@ -723,7 +722,7 @@ class QuantumFloat(QuantumVariable):
             x(res)
             res += other + 2**res.exponent
             return res
-        raise TypeError("Subtraction with type " + str(type(other)) + " not implemented")
+        raise TypeError(f"Subtraction with type {type(other)} not implemented")
 
     @gate_wrap(permeability="args", is_qfree=True)
     def __truediv__(self, other: QuantumFloat | FloatLike) -> QuantumFloat:
@@ -806,7 +805,8 @@ class QuantumFloat(QuantumVariable):
             polynomial_encoder(input_qf_list, self, poly)
 
         elif isinstance(other, (int, float, np.number)):
-            if not int(other / 2**self.exponent) == other / 2**self.exponent:
+            scaled = other / 2**self.exponent
+            if int(scaled) != scaled:
                 raise ValueError(
                     "Tried to perform in-place addition with invalid number. QuantumFloat precision too low."
                 )
@@ -817,7 +817,7 @@ class QuantumFloat(QuantumVariable):
             polynomial_encoder(input_qf_list, self, poly)
 
         else:
-            raise TypeError("In-place addition for type " + str(type(other)) + " not implemented")
+            raise TypeError(f"In-place addition for type {type(other)} not implemented")
 
         return self
 
@@ -839,7 +839,8 @@ class QuantumFloat(QuantumVariable):
             polynomial_encoder(input_qf_list, self, poly)
 
         elif isinstance(other, (int, float, np.integer, np.floating)):
-            if not int(other / 2**self.exponent) == other / 2**self.exponent:
+            scaled = other / 2**self.exponent
+            if int(scaled) != scaled:
                 raise ValueError(
                     "Tried to perform in-place subtraction with invalid number. QuantumFloat precision too low."
                 )
@@ -850,7 +851,7 @@ class QuantumFloat(QuantumVariable):
             polynomial_encoder(input_qf_list, self, poly)
 
         else:
-            raise TypeError("In-place substraction for type " + str(type(other)) + " not implemented")
+            raise TypeError(f"In-place subtraction for type {type(other)} not implemented")
 
         return self
 
@@ -970,22 +971,19 @@ class QuantumFloat(QuantumVariable):
         >>> print(a)
         {8: 1.0}
         >>> print(a.qs)
-
-        .. code-block:: none
-
-            QuantumCircuit:
-            --------------
-            a.0: ─────
-                 ┌───┐
-            a.1: ┤ X ├
-                 └───┘
-            a.2: ─────
-            <BLANKLINE>
-            a.3: ─────
-
-            Live QuantumVariables:
-            ---------------------
-            QuantumFloat a
+        QuantumCircuit:
+        ---------------
+        a.0: ─────
+             ┌───┐
+        a.1: ┤ X ├
+             └───┘
+        a.2: ─────
+        <BLANKLINE>
+        a.3: ─────
+        <BLANKLINE>
+        Live QuantumVariables:
+        ----------------------
+        QuantumFloat a
 
         """
         if not isinstance(shift, int):
@@ -1013,7 +1011,7 @@ class QuantumFloat(QuantumVariable):
 
         """
         if self.signed:
-            raise ValueError(r"Tried to add sign to signed QuantumFloat")
+            raise ValueError("Tried to add sign to signed QuantumFloat")
 
         self.extend(1, self.size)
         self.signed = True
@@ -1244,7 +1242,7 @@ class QuantumFloat(QuantumVariable):
 
         .. note::
 
-            Bit bit shifts based on a QuantumFloat are currently only possible
+            Bit shifts based on a QuantumFloat are currently only possible
             if both self and ``shift_amount`` are unsigned.
 
         .. warning::
@@ -1444,7 +1442,7 @@ def create_output_qf(operands: list[QuantumFloat], op: str | sp.Expr) -> Quantum
         msize = max_sig - min_sig
         exponent = min_sig
 
-        signed = bool(sum(int(operand.signed) for operand in operands))
+        signed = any(operand.signed for operand in operands)
 
         return QuantumFloat(msize, exponent=exponent, signed=signed)
 
@@ -1529,7 +1527,7 @@ def copy_qf(
 
     if qf2.signed:
         if not qf1.signed:
-            raise ValueError("Tried to copy signed into unsigend float")
+            raise ValueError("Tried to copy signed into unsigned float")
 
         qf1_len -= 1
         qf2_len -= 1

--- a/src/qrisp/qtypes/quantum_float.py
+++ b/src/qrisp/qtypes/quantum_float.py
@@ -111,6 +111,13 @@ class QuantumFloat(QuantumVariable):
     Here, the 3 indicates the number of mantissa qubits and the -1 indicates the
     exponent.
 
+    .. note::
+
+        ``msize`` and ``exponent`` also accept a ``jax.Array`` under Jasp
+        tracing, but only in the sense of a 0-d, traced scalar (e.g. a value
+        computed from a measurement inside ``@jaspify``/``make_jaspr``).
+        Never an actual multi-element array.
+
     For unsigned QuantumFloats, the decoder function is given by
 
     .. math::
@@ -327,6 +334,14 @@ class QuantumFloat(QuantumVariable):
         signed: bool = False,
     ) -> None:
         """Construct a QuantumFloat with the given mantissa size, exponent, and sign.
+
+        .. note::
+
+            The ``jax.Array`` accepted by ``msize`` and ``exponent`` is a
+            0-d, traced scalar under Jasp tracing (e.g. a value computed from
+            a measurement inside ``@jaspify``/``make_jaspr``), not an actual
+            multi-element array. Outside of tracing, both are plain Python
+            integers.
 
         Parameters
         ----------

--- a/src/qrisp/qtypes/quantum_float.py
+++ b/src/qrisp/qtypes/quantum_float.py
@@ -621,7 +621,7 @@ class QuantumFloat(QuantumVariable):
         super().encode(value, permit_dirtyness=permit_dirtyness)
 
     @gate_wrap(permeability="args", is_qfree=True)
-    def __mul__(self, other: QuantumFloat | FloatLike) -> QuantumFloat:
+    def __mul__(self, other: QuantumFloat | int | np.integer) -> QuantumFloat:
         """Multiply this QuantumFloat by another QuantumFloat or a classical int."""
         if check_for_tracing_mode():
             # NOTE: Local import to avoid a circular import (qrisp.alg_primitives.arithmetic imports from qrisp.qtypes).
@@ -1568,13 +1568,13 @@ def copy_qf(
     qf1_start = qf1.exponent
     qf2_start = qf2.exponent
 
-    # qf2_max is only computed when the loop can actually reach it, so it
-    # still raises the same error max() over an empty range would for a
-    # signed, zero-mantissa qf2 -- an edge case that otherwise never gets
-    # touched because qf1_len would then also be 0. Falls back to qf2_start
-    # (any same-typed value would do) when unused, so qf2_max never needs an
-    # Optional type.
-    qf2_max = max(range(qf2_start, qf2_start + qf2_len)) if (qf2.signed and qf1_len) else qf2_start
+    # Highest significance in qf2's own mantissa range, i.e.
+    # max(range(qf2_start, qf2_start + qf2_len)) without constructing a range
+    # (and calling max() on it) just to handle qf2_len == 0: for a signed,
+    # zero-mantissa qf2, this correctly evaluates to qf2_start - 1, so every
+    # significance in qf1 at or above qf2_start (there being no actual qf2
+    # mantissa bit to overlap with) is still sign-extended below.
+    qf2_max = qf2_start + qf2_len - 1
 
     # QuantumVariable.qs/__getitem__ aren't typed precisely enough for pyright
     # to see qs as a QuantumSession (with .cx) here rather than the

--- a/src/qrisp/qtypes/quantum_float.py
+++ b/src/qrisp/qtypes/quantum_float.py
@@ -1213,9 +1213,9 @@ class QuantumFloat(QuantumVariable):
         {0.5: 1.0}
 
         """
-        # Clip in floating point before converting to int64: a huge input (e.g.
-        # 1e30) would otherwise overflow int64 on the cast, which is platform-
-        # dependent behavior rather than a guaranteed saturating clamp.
+        # Clip in floating point before converting to int64: converting a
+        # float far outside int64's range is platform-dependent behavior, not
+        # a guaranteed saturating clamp.
         res = jnp.round(value / jnp.float64(2) ** self.exponent)
         res = jnp.minimum(2.0**self.msize - 1, res)
 
@@ -1580,10 +1580,8 @@ def copy_qf(
     qf1_start = qf1.exponent
     qf2_start = qf2.exponent
 
-    # Highest significance in qf2's own mantissa range, i.e.
-    # max(range(qf2_start, qf2_start + qf2_len)) without constructing a range
-    # (and calling max() on it) just to handle qf2_len == 0: for a signed,
-    # zero-mantissa qf2, this correctly evaluates to qf2_start - 1, so every
+    # Highest significance in qf2's own mantissa range. For a signed,
+    # zero-mantissa qf2 (qf2_len == 0), this is qf2_start - 1, so every
     # significance in qf1 at or above qf2_start (there being no actual qf2
     # mantissa bit to overlap with) is still sign-extended below.
     qf2_max = qf2_start + qf2_len - 1

--- a/src/qrisp/qtypes/quantum_float.py
+++ b/src/qrisp/qtypes/quantum_float.py
@@ -33,7 +33,7 @@ from qrisp.misc import gate_wrap
 from qrisp.typing import FloatLike, ScalarLike
 
 if TYPE_CHECKING:
-    from collections.abc import Callable, Iterable
+    from collections.abc import Iterable
 
     from qrisp.circuit.qubit import Qubit
     from qrisp.qtypes.quantum_bool import QuantumBool
@@ -610,20 +610,13 @@ class QuantumFloat(QuantumVariable):
         """
         value = encoding_number
         if rounding:
-            # Round value to closest fitting number. Vectorized equivalent of
-            # [self.decoder(i) for i in range(2**self.size)], since that grows
-            # exponentially with the qubit count.
-            indices = np.arange(2**self.size)
-            if self.signed:
-                outcome_labels = np.asarray(_signed_int_iso_inv(indices, self.msize)) * (2.0**self.exponent)
-            else:
-                outcome_labels = indices * (2.0**self.exponent)
-            # Coerce explicitly: ScalarLike also covers complex/Tracer, which
-            # encoding_number never actually is here (this is an eager-only
-            # rounding path), but numpy's stubs can't express that narrowing.
-            diffs = np.asarray(encoding_number, dtype=float) - outcome_labels
-            closest = outcome_labels[np.argmin(np.abs(diffs))]
-            value = int(closest) if self.exponent >= 0 else float(closest)
+            # Round to the closest representable value the same way truncate()
+            # does: representable values form a uniform grid, so the nearest
+            # one is found directly by rounding and clipping, in O(1) --
+            # no need to enumerate all 2**size outcomes to search for it.
+            # ScalarLike also covers complex/Tracer, which encoding_number
+            # never actually is here (this is an eager-only rounding path).
+            value = self.truncate(encoding_number)  # pyright: ignore[reportArgumentType]
 
         super().encode(value, permit_dirtyness=permit_dirtyness)
 
@@ -881,81 +874,73 @@ class QuantumFloat(QuantumVariable):
         self.exp_shift(k)
         return self
 
-    def _compare(
-        self,
-        other: object,
-        cmp: Callable[..., "QuantumBool"],
-        uint_cmp: Callable[..., "QuantumBool"] | None = None,
-    ) -> "QuantumBool":
-        """Share the dispatch logic behind <, >, <=, >=, ==, and !=.
-
-        While tracing, ``uint_cmp`` (called with ``self``, ``other``, and
-        ``gidney_adder``) is used if given -- <, >, <=, and >= dispatch to a
-        dedicated unsigned-integer comparator during tracing, whereas == and
-        != (``uint_cmp=None``) use ``cmp`` unconditionally, tracing or not.
-        Outside of tracing, ``other``'s type is always validated first.
-
-        """
-        tracing = check_for_tracing_mode()
-        if tracing and uint_cmp is not None:
-            # NOTE: Local import to avoid a circular import (qrisp.alg_primitives.arithmetic imports from qrisp.qtypes).
-            from qrisp.alg_primitives.arithmetic import gidney_adder
-
-            return uint_cmp(self, other, gidney_adder)
-        if tracing:
-            return cmp(self, other)
-        if not isinstance(other, (QuantumFloat, int, float)):
-            raise TypeError(f"Comparison with type {type(other)} not implemented")
-
-        return cmp(self, other)
-
     def __lt__(self, other: QuantumFloat | FloatLike) -> "QuantumBool":
         """Compare this QuantumFloat to another QuantumFloat or a classical scalar (<)."""
         # NOTE: Local import to avoid a circular import (qrisp.alg_primitives.arithmetic imports from qrisp.qtypes).
-        from qrisp.alg_primitives.arithmetic import lt, uint_lt
+        from qrisp.alg_primitives.arithmetic import gidney_adder, lt, uint_lt
 
-        # lt's inferred signature admits a None return that never actually
-        # happens for QuantumFloat/int/float operands (the only ones reaching
-        # this point).
-        return self._compare(other, lt, uint_lt)  # pyright: ignore[reportArgumentType]
+        if check_for_tracing_mode():
+            return uint_lt(self, other, gidney_adder)  # pyright: ignore[reportReturnType]
+        if not isinstance(other, (QuantumFloat, int, float)):
+            raise TypeError(f"Comparison with type {type(other)} not implemented")
+
+        return lt(self, other)  # pyright: ignore[reportReturnType]
 
     def __gt__(self, other: QuantumFloat | FloatLike) -> "QuantumBool":
         """Compare this QuantumFloat to another QuantumFloat or a classical scalar (>)."""
         # NOTE: Local import to avoid a circular import (qrisp.alg_primitives.arithmetic imports from qrisp.qtypes).
-        from qrisp.alg_primitives.arithmetic import gt, uint_gt
+        from qrisp.alg_primitives.arithmetic import gidney_adder, gt, uint_gt
 
-        # gt's inferred signature admits a None return that never actually
-        # happens for QuantumFloat/int/float operands (the only ones reaching
-        # this point).
-        return self._compare(other, gt, uint_gt)  # pyright: ignore[reportArgumentType]
+        if check_for_tracing_mode():
+            return uint_gt(self, other, gidney_adder)  # pyright: ignore[reportReturnType]
+        if not isinstance(other, (QuantumFloat, int, float)):
+            raise TypeError(f"Comparison with type {type(other)} not implemented")
+
+        return gt(self, other)  # pyright: ignore[reportReturnType]
 
     def __le__(self, other: QuantumFloat | FloatLike) -> "QuantumBool":
         """Compare this QuantumFloat to another QuantumFloat or a classical scalar (<=)."""
         # NOTE: Local import to avoid a circular import (qrisp.alg_primitives.arithmetic imports from qrisp.qtypes).
-        from qrisp.alg_primitives.arithmetic import leq, uint_le
+        from qrisp.alg_primitives.arithmetic import gidney_adder, leq, uint_le
 
-        return self._compare(other, leq, uint_le)
+        if check_for_tracing_mode():
+            return uint_le(self, other, gidney_adder)
+        if not isinstance(other, (QuantumFloat, int, float)):
+            raise TypeError(f"Comparison with type {type(other)} not implemented")
+
+        return leq(self, other)
 
     def __ge__(self, other: QuantumFloat | FloatLike) -> "QuantumBool":
         """Compare this QuantumFloat to another QuantumFloat or a classical scalar (>=)."""
         # NOTE: Local import to avoid a circular import (qrisp.alg_primitives.arithmetic imports from qrisp.qtypes).
-        from qrisp.alg_primitives.arithmetic import geq, uint_ge
+        from qrisp.alg_primitives.arithmetic import geq, gidney_adder, uint_ge
 
-        return self._compare(other, geq, uint_ge)
+        if check_for_tracing_mode():
+            return uint_ge(self, other, gidney_adder)
+        if not isinstance(other, (QuantumFloat, int, float)):
+            raise TypeError(f"Comparison with type {type(other)} not implemented")
+
+        return geq(self, other)
 
     def __eq__(self, other: object) -> "QuantumBool":
         """Compare this QuantumFloat to another QuantumFloat or a classical scalar (==)."""
         # NOTE: Local import to avoid a circular import (qrisp.alg_primitives.arithmetic imports from qrisp.qtypes).
         from qrisp.alg_primitives.arithmetic import eq
 
-        return self._compare(other, eq)
+        if not check_for_tracing_mode() and not isinstance(other, (QuantumFloat, int, float)):
+            raise TypeError(f"Comparison with type {type(other)} not implemented")
+
+        return eq(self, other)
 
     def __ne__(self, other: object) -> "QuantumBool":
         """Compare this QuantumFloat to another QuantumFloat or a classical scalar (!=)."""
         # NOTE: Local import to avoid a circular import (qrisp.alg_primitives.arithmetic imports from qrisp.qtypes).
         from qrisp.alg_primitives.arithmetic import neq
 
-        return self._compare(other, neq)
+        if not check_for_tracing_mode() and not isinstance(other, (QuantumFloat, int, float)):
+            raise TypeError(f"Comparison with type {type(other)} not implemented")
+
+        return neq(self, other)
 
     def exp_shift(self, shift: int) -> None:
         """Performs an internal bit shift.

--- a/src/qrisp/qtypes/quantum_float.py
+++ b/src/qrisp/qtypes/quantum_float.py
@@ -30,7 +30,7 @@ from qrisp.core import QuantumVariable, cx, x
 from qrisp.environments import conjugate, invert
 from qrisp.jasp import check_for_tracing_mode
 from qrisp.misc import gate_wrap
-from qrisp.typing import FloatLike, ScalarLike
+from qrisp.typing import FloatLike
 
 if TYPE_CHECKING:
     from collections.abc import Iterable
@@ -463,7 +463,7 @@ class QuantumFloat(QuantumVariable):
         """
         return self.decoder(i)
 
-    def encoder(self, i: ScalarLike) -> int | Array:  # pyright: ignore[reportIncompatibleMethodOverride]
+    def encoder(self, i: int | float | bool | np.integer | np.floating | Tracer) -> int | Array:  # pyright: ignore[reportIncompatibleMethodOverride]
         """Convert a human-readable value to an integer that represents the measurement result.
 
         Also validates that the input value can be represented within the bounds of the provided
@@ -475,10 +475,14 @@ class QuantumFloat(QuantumVariable):
             <qrisp.QuantumVariable.encoder>`, this parameter is named ``i``
             (not ``value``) for historical reasons specific to QuantumFloat.
 
+            Unlike the base's ``ScalarLike``, this does not accept ``complex``:
+            the bounds/sign checks below order ``i`` with ``<``/``>``, which
+            complex values don't support.
+
         Parameters
         ----------
-        i : ScalarLike
-            A human-readable numeric value.
+        i : int, float, bool, np.integer, np.floating, or jax.core.Tracer
+            A human-readable, real-valued number.
 
         Returns
         -------
@@ -488,9 +492,6 @@ class QuantumFloat(QuantumVariable):
         """
         # check if the encoding number is negative while the QuantumFloat is unsigned.
         # We do this before converting to integer to prevent wrapping.
-        # ScalarLike includes complex, which isn't orderable -- i is never
-        # actually complex here (a complex value could never satisfy the
-        # bounds check below either), so this comparison is always safe.
         if not check_for_tracing_mode() and not self.signed and i < 0:  # pyright: ignore[reportOperatorIssue]
             raise ValueError("Tried to encode negative number in an unsigned QuantumFloat")
 
@@ -580,7 +581,10 @@ class QuantumFloat(QuantumVariable):
         return 2**self.exponent * poly  # pyright: ignore[reportReturnType]
 
     def encode(  # pyright: ignore[reportIncompatibleMethodOverride]
-        self, encoding_number: ScalarLike, rounding: bool = False, permit_dirtyness: bool = False
+        self,
+        encoding_number: int | float | bool | np.integer | np.floating | Tracer,
+        rounding: bool = False,
+        permit_dirtyness: bool = False,
     ) -> None:
         """Initialize a QuantumFloat to a specific value.
 
@@ -591,9 +595,13 @@ class QuantumFloat(QuantumVariable):
             ``rounding`` (inserted before ``permit_dirtyness``, for
             historical reasons specific to QuantumFloat).
 
+            Unlike the base's ``ScalarLike``, this does not accept ``complex``
+            (see :meth:`encoder <qrisp.QuantumFloat.encoder>`, which this
+            delegates to).
+
         Parameters
         ----------
-        encoding_number : ScalarLike
+        encoding_number : int, float, bool, np.integer, np.floating, or jax.core.Tracer
             The value to encode.
         rounding : bool, optional
             If ``True``, round ``encoding_number`` to the value this
@@ -614,8 +622,8 @@ class QuantumFloat(QuantumVariable):
             # does: representable values form a uniform grid, so the nearest
             # one is found directly by rounding and clipping, in O(1) --
             # no need to enumerate all 2**size outcomes to search for it.
-            # ScalarLike also covers complex/Tracer, which encoding_number
-            # never actually is here (this is an eager-only rounding path).
+            # truncate() is typed strictly as float, but a bool/np.integer/
+            # np.floating/Tracer here all support the same arithmetic at runtime.
             value = self.truncate(encoding_number)  # pyright: ignore[reportArgumentType]
 
         super().encode(value, permit_dirtyness=permit_dirtyness)
@@ -669,7 +677,7 @@ class QuantumFloat(QuantumVariable):
         )
 
     @gate_wrap(permeability="args", is_qfree=True)
-    def __add__(self, other: QuantumFloat | FloatLike) -> QuantumFloat:
+    def __add__(self, other: QuantumFloat | int | float | Tracer) -> QuantumFloat:
         """Add another QuantumFloat or a classical scalar to this QuantumFloat."""
         # NOTE: Local import to avoid a circular import (qrisp.alg_primitives.arithmetic imports from qrisp.qtypes).
         from qrisp.alg_primitives.arithmetic import sbp_add
@@ -690,7 +698,7 @@ class QuantumFloat(QuantumVariable):
         raise TypeError(f"Addition with type {type(other)} not implemented")
 
     @gate_wrap(permeability="args", is_qfree=True)
-    def __sub__(self, other: QuantumFloat | FloatLike) -> QuantumFloat:
+    def __sub__(self, other: QuantumFloat | int | float | Tracer) -> QuantumFloat:
         """Subtract another QuantumFloat or a classical scalar from this QuantumFloat."""
         # NOTE: Local import to avoid a circular import (qrisp.alg_primitives.arithmetic imports from qrisp.qtypes).
         from qrisp.alg_primitives.arithmetic import sbp_sub
@@ -714,7 +722,7 @@ class QuantumFloat(QuantumVariable):
     __rmul__ = __mul__
 
     @gate_wrap(permeability="args", is_qfree=True)
-    def __rsub__(self, other: QuantumFloat | FloatLike) -> QuantumFloat:
+    def __rsub__(self, other: QuantumFloat | int | float) -> QuantumFloat:
         """Subtract this QuantumFloat from a classical scalar or QuantumFloat."""
         # NOTE: Local import to avoid a circular import (qrisp.alg_primitives.arithmetic imports from qrisp.qtypes).
         from qrisp.alg_primitives.arithmetic import sbp_sub
@@ -731,7 +739,7 @@ class QuantumFloat(QuantumVariable):
         raise TypeError(f"Subtraction with type {type(other)} not implemented")
 
     @gate_wrap(permeability="args", is_qfree=True)
-    def __truediv__(self, other: QuantumFloat | FloatLike) -> QuantumFloat:
+    def __truediv__(self, other: QuantumFloat) -> QuantumFloat:
         """Divide this QuantumFloat by another QuantumFloat."""
         # NOTE: Local import to avoid a circular import (qrisp.alg_primitives.arithmetic imports from qrisp.qtypes).
         from qrisp.alg_primitives.arithmetic import q_div
@@ -1205,14 +1213,18 @@ class QuantumFloat(QuantumVariable):
         {0.5: 1.0}
 
         """
-        res = jnp.int64(jnp.round(value / jnp.float64(2) ** self.exponent))
-        res = jnp.minimum(2**self.msize - 1, res)
+        # Clip in floating point before converting to int64: a huge input (e.g.
+        # 1e30) would otherwise overflow int64 on the cast, which is platform-
+        # dependent behavior rather than a guaranteed saturating clamp.
+        res = jnp.round(value / jnp.float64(2) ** self.exponent)
+        res = jnp.minimum(2.0**self.msize - 1, res)
 
         if self.signed:
-            res = jnp.maximum(-(2**self.msize), res)
-            res = _signed_int_iso(res, self.size)
+            res = jnp.maximum(-(2.0**self.msize), res)
+            res = _signed_int_iso(jnp.int64(res), self.size)
         else:
-            res = jnp.maximum(0, res)
+            res = jnp.maximum(0.0, res)
+            res = jnp.int64(res)
 
         return self.decoder(res)  # pyright: ignore[reportReturnType]
 

--- a/src/qrisp/qtypes/quantum_float.py
+++ b/src/qrisp/qtypes/quantum_float.py
@@ -16,28 +16,37 @@
 
 """Defines the QuantumFloat type for arbitrary-precision signed/unsigned quantum floating-point numbers."""
 
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
 import jax.numpy as jnp
 import numpy as np
 import sympy as sp
 from jax import Array, jit
 from jax.core import Tracer
 
-from qrisp.core import QuantumVariable, cx
+from qrisp.core import QuantumVariable, cx, x
 from qrisp.environments import conjugate, invert
 from qrisp.jasp import check_for_tracing_mode
 from qrisp.misc import gate_wrap
+from qrisp.typing import FloatLike, ScalarLike
+
+if TYPE_CHECKING:
+    from qrisp.circuit.qubit import Qubit
+    from qrisp.qtypes.quantum_bool import QuantumBool
 
 
-def _signed_int_iso(x, n):
-    """Computes the signed integer isomorphism for a given bit-width.
+def _signed_int_iso(value: int | Array, n: int) -> Array:
+    """Compute the signed integer isomorphism for a given bit-width.
 
-    This function maps an integer `x` from the signed range [-2^n, 2^n - 1]
-    into the unsigned range [0, 2^(n+1) - 1].
-    This is equivalent to the mathematical operation: x % 2^(n+1).
+    This function maps an integer ``value`` from the signed range
+    [-2^n, 2^n - 1] into the unsigned range [0, 2^(n+1) - 1].
+    This is equivalent to the mathematical operation: value % 2^(n+1).
 
     Parameters
     ----------
-    x : int or jax.Array
+    value : int or jax.Array
         The signed integer or array of integers to be transformed.
     n : int
         The bit-width for the signed integer representation.
@@ -45,18 +54,18 @@ def _signed_int_iso(x, n):
     Returns
     -------
     jax.Array
-        A jnp.int64 array where each element of `x` has been mapped to
+        A jnp.int64 array where each element of ``value`` has been mapped to
         the unsigned range [0, 2^(n+1) - 1].
 
     """
-    # 1. Modular wrap: Ensure x is within [0, 2**(n+1) - 1]
+    # 1. Modular wrap: Ensure value is within [0, 2**(n+1) - 1]
     mask = (jnp.int64(1) << (n + 1)) - 1
-    return jnp.int64(x) & mask
+    return jnp.int64(value) & mask
 
 
 @jit
-def _signed_int_iso_inv(y, n):
-    """Computes the inverse signed integer isomorphism for a given bit-width.
+def _signed_int_iso_inv(y: int | Array, n: int) -> Array:
+    """Compute the inverse signed integer isomorphism for a given bit-width.
 
     This function maps an integer `y` from the unsigned range [0, 2^(n+1) - 1]
     back into the signed range [-2^n, 2^n - 1]. It performs a manual
@@ -86,40 +95,40 @@ def _signed_int_iso_inv(y, n):
     return jnp.where(y_wrapped & sign_bit, y_wrapped - (jnp.int64(1) << (n + 1)), y_wrapped)
 
 
-# def signed_int_iso(x, n):
-#    if int(x) < -(2**n) or int(x) >= 2**n:
-#        raise Exception("Applying signed integer isomorphism resulted in overflow")
+def trunc_poly(poly: sp.Expr, trunc_bounds: tuple[int, int]) -> sp.Expr:
+    """Truncate a polynomial to the given power-of-2 bounds.
 
-#    if x >= 0:
-#        return x % 2**n
-#    else:
-#        return -abs(x) % 2 ** (n + 1)
+    Truncates a polynomial of the form ``p(x) = 2**k_0*x**i_0 +
+    2**k_1*x**i_1 + ...`` by removing every summand whose coefficient's
+    power of 2 does not lie within ``trunc_bounds``.
 
+    Parameters
+    ----------
+    poly : sympy.Expr
+        The polynomial to truncate.
+    trunc_bounds : tuple[int, int]
+        The (lower, upper) power-of-2 bounds to truncate to.
 
-# def signed_int_iso_inv(y, n):
-#    y = y % 2 ** (n + 1)
-#    if y < 2**n:
-#        return y
-#    else:
-#        return -(2 ** (n + 1)) + y
+    Returns
+    -------
+    sympy.Expr
+        The truncated polynomial, expanded.
 
-
-# Truncates a polynomial of the form p(x) = 2**k_0*x*i_0 + 2**k_1*x**i_1 ...
-# where every summand where the power of the coefficients does not lie in the interval
-# trunc bounds is removed
-def trunc_poly(poly, trunc_bounds):
+    """
+    # sympy's type stubs don't model Poly's dynamic attribute surface, so
+    # pyright can't see .trunc()/.expr here even though they're real members.
     # Convert to sympy polynomial
-    poly = sp.poly(poly)
+    poly_repr = sp.poly(poly)
 
     # Clip upper bound
-    poly = poly.trunc(2.0 ** (trunc_bounds[1]))
+    poly_repr = poly_repr.trunc(2.0 ** (trunc_bounds[1]))  # pyright: ignore[reportAttributeAccessIssue]
 
     # Clip lower bound
-    poly = poly / 2.0 ** trunc_bounds[0]
-    poly = poly - sp.poly(poly).trunc(1)
-    poly = poly * 2.0 ** trunc_bounds[0]
+    poly_repr = poly_repr / 2.0 ** trunc_bounds[0]
+    poly_repr = poly_repr - sp.poly(poly_repr).trunc(1)
+    poly_repr = poly_repr * 2.0 ** trunc_bounds[0]
 
-    return poly.expr.expand()
+    return poly_repr.expr.expand()
 
 
 class QuantumFloat(QuantumVariable):
@@ -319,7 +328,7 @@ class QuantumFloat(QuantumVariable):
 
     >>> from qrisp import h
     >>> a = QuantumFloat(4)
-    >>> h(a[2])
+    >>> _ = h(a[2])
     >>> print(a)
     {0: 0.5, 4: 0.5}
     >>> comparison_qbl_0 = (a < 4 )
@@ -339,7 +348,32 @@ class QuantumFloat(QuantumVariable):
 
     """
 
-    def __init__(self, msize, exponent=0, qs=None, name=None, signed=False):
+    def __init__(
+        self,
+        msize: int | Array,
+        exponent: int | Array = 0,
+        qs: Any = None,
+        name: str | None = None,
+        signed: bool = False,
+    ) -> None:
+        """Construct a QuantumFloat with the given mantissa size, exponent, and sign.
+
+        Parameters
+        ----------
+        msize : int or jax.Array
+            The amount of mantissa qubits.
+        exponent : int or jax.Array, optional
+            The exponent, determining the precision. The default is 0.
+        qs : QuantumSession, optional
+            A QuantumSession object, where the QuantumFloat is supposed to be
+            registered. The default is None.
+        name : str, optional
+            A name which uniquely identifies the QuantumFloat. The default is None.
+        signed : bool, optional
+            If ``True``, an additional qubit is allocated to represent the
+            sign. The default is False.
+
+        """
         # Boolean to indicate if the float is signed
         self.signed = signed
         # Exponent
@@ -355,19 +389,47 @@ class QuantumFloat(QuantumVariable):
         self.static_attributes = ["signed"]
 
     @property
-    def msize(self):
+    def msize(self) -> int:
+        """The amount of mantissa qubits (excludes the sign qubit, if any).
+
+        Returns
+        -------
+        int
+            The mantissa size.
+
+        """
         return self.size - self.signed
 
     @property
-    def mshape(self):
-        # Tuple that consists of (log2(min), log2(max)) where min and max are the
-        # minimal and maximal values of the absolutes that the QuantumFloat can
-        # represent.
+    def mshape(self) -> tuple[int | Array, int | Array]:
+        """The (log2(min), log2(max)) bounds of the absolute values this
+        QuantumFloat can represent.
+
+        Returns
+        -------
+        tuple[int, int]
+            The (minimal, maximal) exponent of the representable magnitude.
+
+        """
         return (self.exponent, self.exponent + self.msize)
 
     # Define outcome_labels
-    def decoder(self, i):
-        """Convert measurement outcome (integer) back to human-readable value."""
+    def decoder(self, i: int | Array) -> int | float | Array:  # pyright: ignore[reportIncompatibleMethodOverride]
+        """Convert a measurement outcome (integer) back to a human-readable value.
+
+        Parameters
+        ----------
+        i : int or jax.Array
+            The integer outcome of a measurement of this QuantumFloat's qubits.
+
+        Returns
+        -------
+        int, float, or jax.Array
+            The decoded value: an ``int`` or ``float`` outside of tracing
+            mode (depending on whether the exponent is non-negative), or a
+            traced ``jax.Array`` while tracing.
+
+        """
         if self.signed:
             res = _signed_int_iso_inv(i, self.msize) * jnp.float64(2) ** self.exponent
         else:
@@ -375,23 +437,55 @@ class QuantumFloat(QuantumVariable):
 
         if check_for_tracing_mode():
             return res
-        elif self.exponent >= 0:
+        if self.exponent >= 0:
             return int(res)
-        else:
-            return float(res)
+        return float(res)
 
-    def jdecoder(self, i):
+    def jdecoder(self, i: int | Array) -> int | float | Array:
+        """JAX-traceable version of :meth:`decoder`, used internally during tracing.
+
+        Parameters
+        ----------
+        i : int or jax.Array
+            The integer outcome of a measurement of this QuantumFloat's qubits.
+
+        Returns
+        -------
+        int, float, or jax.Array
+            The decoded value, see :meth:`decoder`.
+
+        """
         return self.decoder(i)
 
-    def encoder(self, i):
+    def encoder(self, i: ScalarLike) -> int | Array:  # pyright: ignore[reportIncompatibleMethodOverride]
         """Convert a human-readable value to an integer that represents the measurement result.
 
         Also validates that the input value can be represented within the bounds of the provided
         QuantumFloat in static mode.
+
+        .. note::
+
+            Unlike the base :meth:`QuantumVariable.encoder
+            <qrisp.QuantumVariable.encoder>`, this parameter is named ``i``
+            (not ``value``) for historical reasons specific to QuantumFloat.
+
+        Parameters
+        ----------
+        i : ScalarLike
+            A human-readable numeric value.
+
+        Returns
+        -------
+        int or jax.Array
+            The integer encoding the given value.
+
         """
         # check if the encoding number is negative while the QuantumFloat is unsigned.
         # We do this before converting to integer to prevent wrapping.
-        if not check_for_tracing_mode() and not self.signed and i < 0:
+        # ScalarLike includes complex, which isn't orderable -- i is never
+        # actually complex here (a complex value could never satisfy the
+        # bounds check below either), so this comparison is always safe.
+        if not check_for_tracing_mode() and not self.signed and i < 0:  # pyright: ignore[reportOperatorIssue]
             raise ValueError("Tried to encode negative number in an unsigned QuantumFloat")
 
         # the following check is based on the math for fixed point arithmetic which varies according to the
@@ -432,10 +526,9 @@ class QuantumFloat(QuantumVariable):
 
         if isinstance(res, (int, float)):
             return int(res)
-        else:
-            return res.astype(int)
+        return res.astype(int)
 
-    def sb_poly(self, m=0):
+    def sb_poly(self, m: int = 0) -> sp.Expr:
         """Returns the semi-boolean polynomial of this `QuantumFloat` where `m` specifies
         the image extension parameter.
 
@@ -455,10 +548,15 @@ class QuantumFloat(QuantumVariable):
 
         Examples
         --------
+        The polynomial's symbols are named after this QuantumFloat's ``hash``
+        (to guarantee uniqueness across QuantumFloats), so we inspect its
+        coefficients rather than its literal string representation:
+
         >>> from qrisp import QuantumFloat
+        >>> import sympy as sp
         >>> x = QuantumFloat(3, -1, signed = True, name = "x")
-        >>> print(x.sb_poly(5))
-        0.5*x_0 + 1.0*x_1 + 2.0*x_2 + 28.0*x_3
+        >>> [float(c) for c in sp.Poly(x.sb_poly(5)).coeffs()]
+        [0.5, 1.0, 2.0, 28.0]
 
         """
         if m == 0:
@@ -466,43 +564,71 @@ class QuantumFloat(QuantumVariable):
 
         symbols = [sp.symbols(str(hash(self)) + "_" + str(i)) for i in range(self.size)]
 
-        poly = sum([2.0 ** (i) * symbols[i] for i in range(self.size)])
+        poly = sum(2.0**i * symbols[i] for i in range(self.size))
 
         if self.signed:
             poly += (2.0 ** (m + 1) - 2.0 ** (self.size)) * symbols[-1]
 
-        return 2**self.exponent * poly
+        # sympy's Symbol arithmetic isn't precisely typed, and self.exponent
+        # can be a traced jax.Array -- both are real Expr-producing operations
+        # at runtime.
+        return 2**self.exponent * poly  # pyright: ignore[reportReturnType]
 
-    def encode(self, encoding_number, rounding=False, permit_dirtyness=False):
-        """Initialize a QuantumFloat to a specific value."""
+    def encode(  # pyright: ignore[reportIncompatibleMethodOverride]
+        self, encoding_number: ScalarLike, rounding: bool = False, permit_dirtyness: bool = False
+    ) -> None:
+        """Initialize a QuantumFloat to a specific value.
+
+        .. note::
+
+            Unlike the base :meth:`QuantumVariable.encode
+            <qrisp.QuantumVariable.encode>`, this method additionally accepts
+            ``rounding`` (inserted before ``permit_dirtyness``, for
+            historical reasons specific to QuantumFloat).
+
+        Parameters
+        ----------
+        encoding_number : ScalarLike
+            The value to encode.
+        rounding : bool, optional
+            If ``True``, round ``encoding_number`` to the value this
+            QuantumFloat can represent that is closest to it, before
+            encoding. The default is False.
+        permit_dirtyness : bool, optional
+            Suppresses the error message when calling encode on dirty
+            qubits. The default is False.
+
+        Returns
+        -------
+        None
+
+        """
+        value = encoding_number
         if rounding:
             # Round value to closest fitting number
             outcome_labels = [self.decoder(i) for i in range(2**self.size)]
-            encoding_number = outcome_labels[np.argmin(np.abs(encoding_number - np.array(outcome_labels)))]
+            value = outcome_labels[np.argmin(np.abs(encoding_number - np.array(outcome_labels)))]
 
-        super().encode(encoding_number, permit_dirtyness=permit_dirtyness)
+        super().encode(value, permit_dirtyness=permit_dirtyness)
 
     @gate_wrap(permeability="args", is_qfree=True)
-    def __mul__(self, other):
-
-        from qrisp.jasp import check_for_tracing_mode
-
+    def __mul__(self, other: QuantumFloat | FloatLike) -> QuantumFloat:
+        """Multiply this QuantumFloat by another QuantumFloat or a classical int."""
         if check_for_tracing_mode():
             from qrisp.alg_primitives.arithmetic import jasp_multiplyer, jasp_squaring
 
             if isinstance(other, QuantumFloat):
                 if self is other:
                     return jasp_squaring(self)
-                else:
-                    return jasp_multiplyer(other, self)
-            else:
-                raise Exception(f"Tried to multiply class {type(other)} with QuantumFloat")
+                return jasp_multiplyer(other, self)
+            raise TypeError(f"Tried to multiply class {type(other)} with QuantumFloat")
 
         from qrisp.alg_primitives.arithmetic import polynomial_encoder, q_mult
 
         if isinstance(other, QuantumFloat):
-            return q_mult(self, other)
-        elif isinstance(other, (int, np.integer)):
+            return q_mult(self, other)  # pyright: ignore[reportReturnType]
+
+        if isinstance(other, (int, np.integer)):
             bit_shift = 0
             while not other % 2:
                 other = other >> 1
@@ -521,21 +647,21 @@ class QuantumFloat(QuantumVariable):
                     signed=False,
                 )
 
-            polynomial_encoder([self], output_qf, other * sp.Symbol("x"))
+            # int.__mul__ doesn't know about Symbol's __rmul__, but this works fine at runtime.
+            polynomial_encoder([self], output_qf, other * sp.Symbol("x"))  # pyright: ignore[reportOperatorIssue]
 
             output_qf.exp_shift(bit_shift)
 
             return output_qf
-        else:
-            raise Exception(
-                "QuantumFloat multiplication for type " + str(type(other)) + ""
-                " not implemented (available are QuantumFloat and int)"
-            )
+
+        raise TypeError(
+            "QuantumFloat multiplication for type " + str(type(other)) + ""
+            " not implemented (available are QuantumFloat and int)"
+        )
 
     @gate_wrap(permeability="args", is_qfree=True)
-    def __add__(self, other):
-
-        from qrisp import check_for_tracing_mode
+    def __add__(self, other: QuantumFloat | FloatLike) -> QuantumFloat:
+        """Add another QuantumFloat or a classical scalar to this QuantumFloat."""
         from qrisp.alg_primitives.arithmetic import sbp_add
 
         if isinstance(other, QuantumFloat):
@@ -544,20 +670,18 @@ class QuantumFloat(QuantumVariable):
                 cx(self, res)
                 res += other
                 return res
-            else:
-                return sbp_add(self, other)
+            return sbp_add(self, other)
 
-        elif isinstance(other, (int, float, Tracer)):
+        if isinstance(other, (int, float, Tracer)):
             res = self.duplicate()
             cx(self, res)
             res += other
             return res
-        else:
-            raise Exception("Addition with type " + str(type(other)) + " not implemented")
+        raise TypeError("Addition with type " + str(type(other)) + " not implemented")
 
     @gate_wrap(permeability="args", is_qfree=True)
-    def __sub__(self, other):
-        from qrisp import check_for_tracing_mode
+    def __sub__(self, other: QuantumFloat | FloatLike) -> QuantumFloat:
+        """Subtract another QuantumFloat or a classical scalar from this QuantumFloat."""
         from qrisp.alg_primitives.arithmetic import sbp_sub
 
         if isinstance(other, QuantumFloat):
@@ -566,89 +690,86 @@ class QuantumFloat(QuantumVariable):
                 cx(self, res)
                 res -= other
                 return res
-            else:
-                return sbp_sub(self, other)
+            return sbp_sub(self, other)
 
-        elif isinstance(other, (int, float, Tracer)):
+        if isinstance(other, (int, float, Tracer)):
             res = self.duplicate()
             cx(self, res)
             res -= other
             return res
-        else:
-            raise Exception("Subtraction with type " + str(type(other)) + " not implemented")
+        raise TypeError("Subtraction with type " + str(type(other)) + " not implemented")
 
     __radd__ = __add__
     __rmul__ = __mul__
 
     @gate_wrap(permeability="args", is_qfree=True)
-    def __rsub__(self, other):
-        from qrisp import x
+    def __rsub__(self, other: QuantumFloat | FloatLike) -> QuantumFloat:
+        """Subtract this QuantumFloat from a classical scalar or QuantumFloat."""
         from qrisp.alg_primitives.arithmetic import sbp_sub
 
         if isinstance(other, QuantumFloat):
             return sbp_sub(other, self)
-        elif isinstance(other, (int, float)):
+        if isinstance(other, (int, float)):
             res = self.duplicate(init=True)
             if not res.signed:
                 res.add_sign()
             x(res)
             res += other + 2**res.exponent
             return res
-        else:
-            raise Exception("Subtraction with type " + str(type(other)) + " not implemented")
+        raise TypeError("Subtraction with type " + str(type(other)) + " not implemented")
 
     @gate_wrap(permeability="args", is_qfree=True)
-    def __truediv__(self, other):
+    def __truediv__(self, other: QuantumFloat | FloatLike) -> QuantumFloat:
+        """Divide this QuantumFloat by another QuantumFloat."""
         from qrisp.alg_primitives.arithmetic import q_div
 
         return q_div(self, other)
 
     @gate_wrap(permeability="args", is_qfree=True)
-    def __floordiv__(self, other):
+    def __floordiv__(self, other: QuantumFloat) -> QuantumFloat:
+        """Floor-divide this (unsigned, integer) QuantumFloat by another one."""
         if self.signed or other.signed:
-            raise Exception("Floor division not implemented for signed QuantumFloats")
+            raise NotImplementedError("Floor division not implemented for signed QuantumFloats")
 
         if self.exponent < 0 or other.exponent < 0:
-            raise Exception("Tried to perform floor division on non-integer QuantumFloats")
+            raise ValueError("Tried to perform floor division on non-integer QuantumFloats")
         from qrisp.alg_primitives.arithmetic import q_div
 
         return q_div(self, other, prec=0)
 
     @gate_wrap(permeability="args", is_qfree=True)
-    def __pow__(self, power):
+    def __pow__(self, power: int) -> QuantumFloat:
+        """Raise this QuantumFloat to an integer power (-1 means inversion)."""
         if power == -1:
             from qrisp.alg_primitives.arithmetic import qf_inversion
 
             return qf_inversion(self)
-        elif power == 0:
+        if power == 0:
             res = self.duplicate()
             res[:] = 1
             return res
-        else:
-            from qrisp import jasp_multiplyer
 
-            def power_conjugator(base, power, temp_results):
-                cx(base, temp_results[0])
-                for i in range(power - 1):
-                    (temp_results[i + 1] << jasp_multiplyer)(base, temp_results[i])
-                    # (temp_results[i+1] << (lambda a, b : a * b))(base, temp_results[i])
+        from qrisp.alg_primitives.arithmetic import jasp_multiplyer
 
-            temp_results = [QuantumFloat((i + 1) * self.size) for i in range(power)]
+        def power_conjugator(base, power, temp_results):
+            cx(base, temp_results[0])
+            for i in range(power - 1):
+                (temp_results[i + 1] << jasp_multiplyer)(base, temp_results[i])
 
-            res = QuantumFloat(self.size * power)
-            with conjugate(power_conjugator)(self, power, temp_results):
-                cx(temp_results[-1], res)
+        temp_results = [QuantumFloat((i + 1) * self.size) for i in range(power)]
 
-            for qv in temp_results:
-                qv.delete()
+        res = QuantumFloat(self.size * power)
+        with conjugate(power_conjugator)(self, power, temp_results):
+            cx(temp_results[-1], res)
 
-            return res
+        for qv in temp_results:
+            qv.delete()
+
+        return res
 
     @gate_wrap(permeability=[1], is_qfree=True)
-    def __iadd__(self, other):
-
-        from qrisp.jasp import check_for_tracing_mode
-
+    def __iadd__(self, other: QuantumFloat | FloatLike) -> QuantumFloat:
+        """Add another QuantumFloat or a classical scalar to this QuantumFloat, in place."""
         if check_for_tracing_mode():
             from qrisp.alg_primitives.arithmetic.adders import gidney_adder
 
@@ -662,11 +783,12 @@ class QuantumFloat(QuantumVariable):
             elif isinstance(other, (int, float, np.integer, np.floating)) or (
                 isinstance(other, Tracer) and isinstance(other, Array)
             ):
-                gidney_adder(self.encoder(other), self)
+                # gidney_adder's stub predates encoder() returning a traced
+                # jax.Array here; a concrete int or a traced Array both work
+                # at runtime.
+                gidney_adder(self.encoder(other), self)  # pyright: ignore[reportArgumentType]
             else:
-                print(isinstance(other, Tracer))
-                print(type(other.dtype))
-                raise Exception(f"Don't know how to handle quantum addition with type {type(other)}")
+                raise TypeError(f"Don't know how to handle quantum addition with type {type(other)}")
 
             return self
 
@@ -679,10 +801,8 @@ class QuantumFloat(QuantumVariable):
             polynomial_encoder(input_qf_list, self, poly)
 
         elif isinstance(other, (int, float, np.number)):
-            # self.incr(other)
-
             if not int(other / 2**self.exponent) == other / 2**self.exponent:
-                raise Exception(
+                raise ValueError(
                     "Tried to perform in-place addition with invalid number. QuantumFloat precision too low."
                 )
 
@@ -692,15 +812,14 @@ class QuantumFloat(QuantumVariable):
             polynomial_encoder(input_qf_list, self, poly)
 
         else:
-            raise Exception("In-place addition for type " + str(type(other)) + " not implemented")
+            raise TypeError("In-place addition for type " + str(type(other)) + " not implemented")
 
         return self
 
     @gate_wrap(permeability=[1], is_qfree=True)
-    def __isub__(self, other):
-
+    def __isub__(self, other: QuantumFloat | FloatLike) -> QuantumFloat:
+        """Subtract another QuantumFloat or a classical scalar from this QuantumFloat, in place."""
         from qrisp.alg_primitives.arithmetic import polynomial_encoder
-        from qrisp.jasp import check_for_tracing_mode
 
         if check_for_tracing_mode():
             with invert():
@@ -715,7 +834,7 @@ class QuantumFloat(QuantumVariable):
 
         elif isinstance(other, (int, float, np.integer, np.floating)):
             if not int(other / 2**self.exponent) == other / 2**self.exponent:
-                raise Exception(
+                raise ValueError(
                     "Tried to perform in-place subtraction with invalid number. QuantumFloat precision too low."
                 )
 
@@ -725,90 +844,92 @@ class QuantumFloat(QuantumVariable):
             polynomial_encoder(input_qf_list, self, poly)
 
         else:
-            raise Exception("In-place substraction for type " + str(type(other)) + " not implemented")
+            raise TypeError("In-place substraction for type " + str(type(other)) + " not implemented")
 
         return self
 
     @gate_wrap(permeability=[], is_qfree=True)
-    def __imul__(self, other):
-
+    def __imul__(self, other: FloatLike) -> QuantumFloat:
+        """Multiply this QuantumFloat by a classical scalar, in place."""
         from qrisp.alg_primitives.arithmetic import inpl_mult
 
         inpl_mult(self, other)
 
         return self
 
-    def __irshift__(self, k):
+    def __irshift__(self, k: int) -> QuantumFloat:
+        """Shift this QuantumFloat's exponent down by k (a free, gate-less bitshift)."""
         self.exp_shift(-k)
         return self
 
-    def __ilshift__(self, k):
+    def __ilshift__(self, k: int) -> QuantumFloat:
+        """Shift this QuantumFloat's exponent up by k (a free, gate-less bitshift)."""
         self.exp_shift(k)
         return self
 
-    def __lt__(self, other):
+    def __lt__(self, other: QuantumFloat | FloatLike) -> "QuantumBool":
+        """Compare this QuantumFloat to another QuantumFloat or a classical scalar (<)."""
         from qrisp.alg_primitives.arithmetic import gidney_adder, lt, uint_lt
 
         if check_for_tracing_mode():
-            return uint_lt(self, other, gidney_adder)
-        else:
-            if not isinstance(other, (QuantumFloat, int, float)):
-                raise Exception(f"Comparison with type {type(other)} not implemented")
+            return uint_lt(self, other, gidney_adder)  # pyright: ignore[reportReturnType]
+        if not isinstance(other, (QuantumFloat, int, float)):
+            raise TypeError(f"Comparison with type {type(other)} not implemented")
 
-            return lt(self, other)
+        return lt(self, other)  # pyright: ignore[reportReturnType]
 
-    def __gt__(self, other):
+    def __gt__(self, other: QuantumFloat | FloatLike) -> "QuantumBool":
+        """Compare this QuantumFloat to another QuantumFloat or a classical scalar (>)."""
         from qrisp.alg_primitives.arithmetic import gidney_adder, gt, uint_gt
 
         if check_for_tracing_mode():
-            return uint_gt(self, other, gidney_adder)
-        else:
-            if not isinstance(other, (QuantumFloat, int, float)):
-                raise Exception(f"Comparison with type {type(other)} not implemented")
+            return uint_gt(self, other, gidney_adder)  # pyright: ignore[reportReturnType]
+        if not isinstance(other, (QuantumFloat, int, float)):
+            raise TypeError(f"Comparison with type {type(other)} not implemented")
 
-            return gt(self, other)
+        return gt(self, other)  # pyright: ignore[reportReturnType]
 
-    def __le__(self, other):
+    def __le__(self, other: QuantumFloat | FloatLike) -> "QuantumBool":
+        """Compare this QuantumFloat to another QuantumFloat or a classical scalar (<=)."""
         from qrisp.alg_primitives.arithmetic import gidney_adder, leq, uint_le
 
         if check_for_tracing_mode():
             return uint_le(self, other, gidney_adder)
-        else:
-            if not isinstance(other, (QuantumFloat, int, float)):
-                raise Exception(f"Comparison with type {type(other)} not implemented")
+        if not isinstance(other, (QuantumFloat, int, float)):
+            raise TypeError(f"Comparison with type {type(other)} not implemented")
 
-            return leq(self, other)
+        return leq(self, other)
 
-    def __ge__(self, other):
+    def __ge__(self, other: QuantumFloat | FloatLike) -> "QuantumBool":
+        """Compare this QuantumFloat to another QuantumFloat or a classical scalar (>=)."""
         from qrisp.alg_primitives.arithmetic import geq, gidney_adder, uint_ge
 
         if check_for_tracing_mode():
             return uint_ge(self, other, gidney_adder)
-        else:
-            if not isinstance(other, (QuantumFloat, int, float)):
-                raise Exception(f"Comparison with type {type(other)} not implemented")
+        if not isinstance(other, (QuantumFloat, int, float)):
+            raise TypeError(f"Comparison with type {type(other)} not implemented")
 
-            return geq(self, other)
+        return geq(self, other)
 
-    def __eq__(self, other):
-
+    def __eq__(self, other: object) -> "QuantumBool":
+        """Compare this QuantumFloat to another QuantumFloat or a classical scalar (==)."""
         from qrisp.alg_primitives.arithmetic import eq
 
         if not check_for_tracing_mode() and not isinstance(other, (QuantumFloat, int, float)):
-            raise Exception(f"Comparison with type {type(other)} not implemented")
+            raise TypeError(f"Comparison with type {type(other)} not implemented")
 
         return eq(self, other)
 
-    def __ne__(self, other):
-
+    def __ne__(self, other: object) -> "QuantumBool":
+        """Compare this QuantumFloat to another QuantumFloat or a classical scalar (!=)."""
         from qrisp.alg_primitives.arithmetic import neq
 
         if not check_for_tracing_mode() and not isinstance(other, (QuantumFloat, int, float)):
-            raise Exception(f"Comparison with type {type(other)} not implemented")
+            raise TypeError(f"Comparison with type {type(other)} not implemented")
 
         return neq(self, other)
 
-    def exp_shift(self, shift):
+    def exp_shift(self, shift: int) -> None:
         """Performs an internal bit shift. Note that this method doesn't cost any
         quantum gates. For the quantum version of this method, see
         :meth:`quantum_bit_shift<qrisp.QuantumFloat.quantum_bitshift>`.
@@ -820,7 +941,7 @@ class QuantumFloat(QuantumVariable):
 
         Raises
         ------
-        Exception
+        TypeError
             Tried to shift QuantumFloat exponent by non-integer value
 
         Examples
@@ -853,16 +974,16 @@ class QuantumFloat(QuantumVariable):
 
         """
         if not isinstance(shift, int):
-            raise Exception("Tried to shift QuantumFloat exponent by non-integer value")
+            raise TypeError("Tried to shift QuantumFloat exponent by non-integer value")
 
         self.exponent += shift
 
-    def add_sign(self):
+    def add_sign(self) -> None:
         """Turns an unsigned QuantumFloat into its signed version.
 
         Raises
         ------
-        Exception
+        ValueError
             Tried to add sign to signed QuantumFloat.
 
         Examples
@@ -877,12 +998,12 @@ class QuantumFloat(QuantumVariable):
 
         """
         if self.signed:
-            raise Exception(r"Tried to add sign to signed QuantumFloat")
+            raise ValueError(r"Tried to add sign to signed QuantumFloat")
 
         self.extend(1, self.size)
         self.signed = True
 
-    def sign(self):
+    def sign(self) -> "Qubit":
         r"""Returns the sign qubit.
 
         This qubit is in state $\ket{1}$ if the QuantumFloat holds a negative value and
@@ -905,7 +1026,7 @@ class QuantumFloat(QuantumVariable):
 
         Raises
         ------
-        Exception
+        ValueError
             Tried to retrieve sign qubit of unsigned QuantumFloat.
 
         Returns
@@ -923,17 +1044,33 @@ class QuantumFloat(QuantumVariable):
         >>> n_amp = 1/3**0.5
         >>> qf[:] = {-1 : n_amp, -2 : n_amp, 1 : n_amp}
         >>> qbl = QuantumBool()
-        >>> cx(qf.sign(), qbl)
+        >>> _ = cx(qf.sign(), qbl)
         >>> print(qbl)
-        {True: 0.6667, False: 0.3333}
+        {True: 0.66667, False: 0.33333}
 
         """
         if not self.signed:
-            raise Exception("Tried to retrieve sign qubit of unsigned QuantumFloat")
+            raise ValueError("Tried to retrieve sign qubit of unsigned QuantumFloat")
 
-        return self[-1]
+        return self[-1]  # pyright: ignore[reportReturnType]
 
-    def init_from(self, other, ignore_rounding_errors=False, ignore_overflow_errors=False):
+    def init_from(
+        self, other: QuantumFloat, ignore_rounding_errors: bool = False, ignore_overflow_errors: bool = False
+    ) -> None:
+        """Initialize this (zero-valued) QuantumFloat with the value of another one.
+
+        Parameters
+        ----------
+        other : QuantumFloat
+            The QuantumFloat to copy the value from.
+        ignore_rounding_errors : bool, optional
+            If ``True``, don't raise if ``other`` has more precision than
+            this QuantumFloat can represent. The default is False.
+        ignore_overflow_errors : bool, optional
+            If ``True``, don't raise if ``other`` can represent larger
+            magnitudes than this QuantumFloat. The default is False.
+
+        """
         copy_qf(
             self,
             other,
@@ -941,17 +1078,27 @@ class QuantumFloat(QuantumVariable):
             ignore_overflow_errors=ignore_overflow_errors,
         )
 
-    def incr(self, x=None):
+    def incr(self, value: FloatLike | None = None) -> None:
+        """Increment this QuantumFloat in place by a classical value.
+
+        Parameters
+        ----------
+        value : FloatLike, optional
+            The value to increment by. The default is this QuantumFloat's
+            smallest representable increment, ``2**self.exponent``.
+
+        """
         from qrisp.alg_primitives.arithmetic.adders.incrementation import increment
 
-        if x is None:
-            x = 2**self.exponent
-        increment(self, x)
+        if value is None:
+            value = 2**self.exponent
+        increment(self, value)
 
-    def __hash__(self):
+    def __hash__(self) -> int:
+        """Hash by object identity (QuantumFloats define __eq__, which disables the default hash)."""
         return id(self)
 
-    def significant(self, k):
+    def significant(self, k: int) -> "Qubit":
         """Returns the qubit with significance $k$.
 
         Parameters
@@ -961,7 +1108,7 @@ class QuantumFloat(QuantumVariable):
 
         Raises
         ------
-        Exception
+        ValueError
             Tried to retrieve invalid significant from QuantumFloat
 
         Returns
@@ -975,13 +1122,14 @@ class QuantumFloat(QuantumVariable):
 
         >>> from qrisp import QuantumFloat, x
         >>> qf = QuantumFloat(6, -3)
-        >>> x(qf.significant(-2))
+        >>> _ = x(qf.significant(-2))
         >>> print(qf)
         {0.25: 1.0}
 
         The qubit with significance $-2$ corresponds to the value $0.25 = 2^{-2}$.
 
-        >>> x(qf.significant(2))
+        >>> _ = x(qf.significant(2))
+        >>> print(qf)
         {4.25: 1.0}
 
         The qubit with significance $2$ corresponds to the value $4 = 2^{2}$.
@@ -990,19 +1138,19 @@ class QuantumFloat(QuantumVariable):
         sig_list = list(range(self.mshape[0], self.mshape[1]))
 
         if k not in sig_list:
-            raise Exception(
+            raise ValueError(
                 f"Tried to retrieve invalid significant {k} from QuantumFloat with mantissa shape {self.mshape}"
             )
 
-        return self[sig_list.index(k)]
+        return self[sig_list.index(k)]  # pyright: ignore[reportReturnType]
 
-    def truncate(self, x):
+    def truncate(self, value: float) -> float:
         """Receives a regular float and returns the float that is closest to the input but
         can still be encoded.
 
         Parameters
         ----------
-        x : float
+        value : float
             A float that is supposed to be truncated.
 
         Returns
@@ -1012,14 +1160,15 @@ class QuantumFloat(QuantumVariable):
 
         Examples
         --------
-        We create a QuantumFloat and round a value to fit the encoder and subsequently
-        initiate:
+        We create a QuantumFloat and round a value to the closest one it can
+        represent. Note that directly encoding an unrepresentable value (like
+        ``0.5102341`` below, which doesn't fit this QuantumFloat's precision
+        of $2^{-1} = 0.5$) already truncates silently, so ``truncate`` is
+        most useful when you want to know the resulting value ahead of time:
 
         >>> from qrisp import QuantumFloat
         >>> qf = QuantumFloat(4, -1)
         >>> value = 0.5102341
-        >>> qf[:] = value
-        Exception: Value 0.5102341 not supported by encoder.
         >>> rounded_value = qf.truncate(value)
         >>> rounded_value
         0.5
@@ -1028,7 +1177,7 @@ class QuantumFloat(QuantumVariable):
         {0.5: 1.0}
 
         """
-        res = jnp.int64(jnp.round(x / jnp.float64(2) ** self.exponent))
+        res = jnp.int64(jnp.round(value / jnp.float64(2) ** self.exponent))
         res = jnp.minimum(2**self.msize - 1, res)
 
         if self.signed:
@@ -1037,9 +1186,9 @@ class QuantumFloat(QuantumVariable):
         else:
             res = jnp.maximum(0, res)
 
-        return self.decoder(res)
+        return self.decoder(res)  # pyright: ignore[reportReturnType]
 
-    def get_ev(self, **mes_kwargs):
+    def get_ev(self, **mes_kwargs: Any) -> float:
         """Retrieves the expectation value of self.
 
         Parameters
@@ -1058,16 +1207,16 @@ class QuantumFloat(QuantumVariable):
 
         >>> from qrisp import QuantumFloat, h
         >>> qf = QuantumFloat(4)
-        >>> h(qf)
+        >>> _ = h(qf)
         >>> qf.get_ev()
         7.5
 
         """
         mes_res = self.get_measurement(**mes_kwargs)
 
-        return sum([k * v for k, v in mes_res.items()])
+        return sum(k * v for k, v in mes_res.items())  # pyright: ignore[reportReturnType]
 
-    def quantum_bit_shift(self, shift_amount):
+    def quantum_bit_shift(self, shift_amount: int | QuantumFloat) -> None:
         """Performs a bit shift in the quantum device.
         While :meth:`exp_shift<qrisp.QuantumFloat.exp_shift>` performs a bit shift
         in the compiler (thus costing no quantum gates) this method performs the
@@ -1094,14 +1243,15 @@ class QuantumFloat(QuantumVariable):
 
         Raises
         ------
-        Exception
+        TypeError
             Tried to shift QuantumFloat exponent by non-integer value
         Exception
             Quantum-quantum bitshifting is currently only supported for unsigned arguments
 
         Examples
         --------
-        We create a QuantumFloat and a QuantumBool to perform a controlled bit shift.
+        We create a QuantumFloat and a QuantumBool to perform a controlled bit
+        shift, then evaluate the resulting (superposed) state:
 
         ::
 
@@ -1114,10 +1264,9 @@ class QuantumFloat(QuantumVariable):
             with qbl:
                 qf.quantum_bit_shift(2)
 
-        Evaluate the result
-
-        >>> print(qf.qs.statevector())
-        sqrt(2)*(|1>*|False> + |4>*|True>)/2
+            print(qf.qs.statevector())
+            # Yields
+            # sqrt(2)*(|1>*|False> + |4>*|True>)/2
 
         """
         from qrisp.alg_primitives.arithmetic import quantum_bit_shift
@@ -1125,37 +1274,90 @@ class QuantumFloat(QuantumVariable):
         quantum_bit_shift(self, shift_amount)
 
 
-def create_output_qf(operands, op):
+def _addsub_bounds(op0: QuantumFloat, op1: QuantumFloat) -> tuple[int | Array, int | Array]:
+    """Compute the (exponent, max_sig) bounds for an add/sub output QuantumFloat.
+
+    Comparisons like min/max need concrete values to branch on, which a jax
+    tracer can't provide -- so this only uses jnp when actually tracing (see
+    :func:`check_for_tracing_mode`). Outside of tracing, jnp.minimum/maximum
+    would silently turn a plain-int exponent into a 0-d jax.Array, which then
+    breaks any later ``2**exponent`` with a negative exponent (jax's
+    integer_pow rejects negative integer exponents).
+
+    Parameters
+    ----------
+    op0 : QuantumFloat
+        The first operand.
+    op1 : QuantumFloat
+        The second operand.
+
+    Returns
+    -------
+    tuple[int or jax.Array, int or jax.Array]
+        The (exponent, max_sig) bounds for sizing the output QuantumFloat.
+
+    """
+    if check_for_tracing_mode():
+        exponent = jnp.minimum(op0.exponent, op1.exponent)
+        max_sig = jnp.maximum(op0.mshape[1], op1.mshape[1]) + 1
+    else:
+        exponent = min(op0.exponent, op1.exponent)
+        max_sig = max(op0.mshape[1], op1.mshape[1]) + 1
+    return exponent, max_sig
+
+
+def create_output_qf(operands: list[QuantumFloat], op: str | sp.Expr) -> QuantumFloat:
+    """Determine the appropriately-sized output QuantumFloat for an arithmetic operation.
+
+    Parameters
+    ----------
+    operands : list[QuantumFloat]
+        The QuantumFloats participating in the operation.
+    op : str or sympy.Expr
+        Either one of "add", "sub", "mul", or a sympy expression describing
+        a polynomial encoding (see :func:`polynomial_encoder <qrisp.polynomial_encoder>`).
+
+    Returns
+    -------
+    QuantumFloat
+        A freshly allocated QuantumFloat, sized to hold the result of ``op``
+        without overflow.
+
+    """
     if isinstance(op, sp.core.expr.Expr):
         from qrisp.alg_primitives.arithmetic.poly_tools import expr_to_list
 
         expr_list = expr_to_list(op)
 
-        for i in range(len(expr_list)):
-            if not isinstance(expr_list[i][0], sp.Symbol):
-                expr_list[i].pop(0)
+        for term in expr_list:
+            if not isinstance(term[0], sp.Symbol):
+                term.pop(0)
 
-        operands.sort(key=lambda x: x.name)
+        operands.sort(key=lambda operand: operand.name)
 
-        def prod(iter):
-            iter = list(iter)
-            a = iter[0]
-            for i in range(1, len(iter)):
-                a *= iter[i]
+        def prod(values):
+            values = list(values)
+            res = values[0]
+            for value in values[1:]:
+                res *= value
 
-            return a
+            return res
 
-        from sympy import Abs, Poly, Symbol
+        # sympy's type stubs don't model Poly's/Abs's dynamic attribute
+        # surface, so pyright can't see .gens/.coeffs()/.monoms()/.subs()
+        # here even though they're all real Poly/Basic members.
+        poly = sp.Poly(op)  # pyright: ignore[reportAttributeAccessIssue]
+        monom_list = [
+            a * prod(sym**k for sym, k in zip(poly.gens, mon))  # pyright: ignore[reportAttributeAccessIssue]
+            for a, mon in zip(poly.coeffs(), poly.monoms())  # pyright: ignore[reportAttributeAccessIssue]
+        ]
 
-        poly = Poly(op)
-        monom_list = [a * prod(x**k for x, k in zip(poly.gens, mon)) for a, mon in zip(poly.coeffs(), poly.monoms())]
+        max_value_dic = {sp.Symbol(qf.name): 2.0 ** qf.mshape[1] for qf in operands}
+        min_value_dic = {sp.Symbol(qf.name): 2.0 ** qf.mshape[0] for qf in operands}
 
-        max_value_dic = {Symbol(qf.name): 2.0 ** qf.mshape[1] for qf in operands}
-        min_value_dic = {Symbol(qf.name): 2.0 ** qf.mshape[0] for qf in operands}
+        abs_poly = sum((sp.Abs(monom) for monom in monom_list), 0)  # pyright: ignore[reportCallIssue, reportArgumentType]
 
-        abs_poly = sum([Abs(monom) for monom in monom_list], 0)
-
-        min_poly_value = min([float(Abs(monom).subs(min_value_dic)) for monom in monom_list])
+        min_poly_value = min(float(sp.Abs(monom).subs(min_value_dic)) for monom in monom_list)  # pyright: ignore[reportAttributeAccessIssue]
 
         max_poly_value = float(abs_poly.subs(max_value_dic))
 
@@ -1165,26 +1367,30 @@ def create_output_qf(operands, op):
         msize = max_sig - min_sig
         exponent = min_sig
 
-        signed = bool(sum([int(operand.signed) for operand in operands]))
+        signed = bool(sum(int(operand.signed) for operand in operands))
 
         return QuantumFloat(msize, exponent=exponent, signed=signed)
 
     from qrisp.qtypes import QuantumModulus
 
+    # pyright can't narrow `operands`' element type through all(isinstance(...)
+    # for ... in ...), even though every element is a QuantumModulus here.
     if all(isinstance(operand, QuantumModulus) for operand in operands):
         res = operands[0].duplicate()
         if op == "mul":
-            res.m = (
-                operands[0].m
-                + operands[1].m
-                - (int(np.ceil(np.log2((operands[0].modulus - 1) ** 2) + 1)) - operands[0].size)
+            res.m = (  # pyright: ignore[reportAttributeAccessIssue]
+                operands[0].m  # pyright: ignore[reportAttributeAccessIssue]
+                + operands[1].m  # pyright: ignore[reportAttributeAccessIssue]
+                - (
+                    int(np.ceil(np.log2((operands[0].modulus - 1) ** 2) + 1))  # pyright: ignore[reportAttributeAccessIssue]
+                    - operands[0].size
+                )
             )
         return res
 
     if op == "add":
         signed = operands[0].signed or operands[1].signed
-        exponent = jnp.minimum(operands[0].exponent, operands[1].exponent)
-        max_sig = jnp.maximum(operands[0].mshape[1], operands[1].mshape[1]) + 1
+        exponent, max_sig = _addsub_bounds(operands[0], operands[1])
         msize = max_sig - exponent + 1
 
         return QuantumFloat(msize, exponent, operands[0].qs, signed=signed, name="add_res*")
@@ -1204,48 +1410,72 @@ def create_output_qf(operands, op):
         )
 
     if op == "sub":
-        exponent = jnp.minimum(operands[0].exponent, operands[1].exponent)
-        max_sig = jnp.maximum(operands[0].mshape[1], operands[1].mshape[1]) + 1
+        exponent, max_sig = _addsub_bounds(operands[0], operands[1])
         msize = max_sig - exponent + 1
 
         return QuantumFloat(msize, exponent, operands[0].qs, signed=True, name="sub_res*")
 
+    raise ValueError(f"Don't know how to create output QuantumFloat for operation {op}")
+
 
 # Initiates the value of qf2 into qf1 where qf1 has to hold the value 0
-def copy_qf(qf1, qf2, ignore_overflow_errors=False, ignore_rounding_errors=False):
+def copy_qf(
+    qf1: QuantumFloat, qf2: QuantumFloat, ignore_overflow_errors: bool = False, ignore_rounding_errors: bool = False
+) -> None:
+    """Initiate the value of qf2 into qf1, where qf1 has to hold the value 0.
+
+    Parameters
+    ----------
+    qf1 : QuantumFloat
+        The (zero-valued) QuantumFloat to copy the value into.
+    qf2 : QuantumFloat
+        The QuantumFloat to copy the value from.
+    ignore_overflow_errors : bool, optional
+        If ``True``, don't raise if qf2 can represent larger magnitudes than
+        qf1. The default is False.
+    ignore_rounding_errors : bool, optional
+        If ``True``, don't raise if qf2 has more precision than qf1 can
+        represent. The default is False.
+
+    """
     # Lists that translate Qubit index => Significance
     qf1_sign_list = [qf1.exponent + i for i in range(qf1.size)]
     qf2_sign_list = [qf2.exponent + i for i in range(qf2.size)]
 
     # Check overflow/underflow
     if max(qf1_sign_list) < max(qf2_sign_list) and not ignore_overflow_errors:
-        raise Exception("Copy operation would result in overflow (use ignore_overflow_errors = True)")
+        raise ValueError("Copy operation would result in overflow (use ignore_overflow_errors = True)")
 
     if min(qf1_sign_list) > min(qf2_sign_list) and not ignore_rounding_errors:
-        raise Exception("Copy operation would result in rounding (use ignore_rounding_errors = True)")
+        raise ValueError("Copy operation would result in rounding (use ignore_rounding_errors = True)")
 
     qs = qf1.qs
 
     if qf2.signed:
         if not qf1.signed:
-            raise Exception("Tried to copy signed into unsigend float")
+            raise ValueError("Tried to copy signed into unsigend float")
 
         # Remove last entry from significance list (last qubit is the sign qubit)
         qf2_sign_list.pop(-1)
         qf1_sign_list.pop(-1)
 
-    for i in range(len(qf1_sign_list)):
+    # QuantumVariable.qs/__getitem__ aren't typed precisely enough for pyright
+    # to see qs as a QuantumSession (with .cx) here rather than the
+    # TracingQuantumSession union member, or single-index __getitem__ as
+    # returning a Qubit rather than DynamicQubitArray -- both hold in this
+    # non-tracing, single-qubit-index context.
+    for i, significance in enumerate(qf1_sign_list):
         # If we are in a realm where both floats have overlapping significance
         # => CNOT into each other
-        if qf1_sign_list[i] in qf2_sign_list:
-            qf2_index = qf2_sign_list.index(qf1_sign_list[i])
-            qs.cx(qf2[qf2_index], qf1[i])
+        if significance in qf2_sign_list:
+            qf2_index = qf2_sign_list.index(significance)
+            qs.cx(qf2[qf2_index], qf1[i])  # pyright: ignore[reportAttributeAccessIssue, reportArgumentType]
             continue
 
         # Otherwise copy the sign bit into the bits of higher significance than qf2
-        if qf1_sign_list[i] > max(qf2_sign_list) and qf2.signed:
-            qs.cx(qf2[-1], qf1[i])
+        if significance > max(qf2_sign_list) and qf2.signed:
+            qs.cx(qf2[-1], qf1[i])  # pyright: ignore[reportAttributeAccessIssue, reportArgumentType]
 
     # Copy the sign bit
     if qf2.signed:
-        qs.cx(qf2[-1], qf1[-1])
+        qs.cx(qf2[-1], qf1[-1])  # pyright: ignore[reportAttributeAccessIssue, reportArgumentType]

--- a/src/qrisp/qtypes/quantum_float.py
+++ b/src/qrisp/qtypes/quantum_float.py
@@ -97,42 +97,6 @@ def _signed_int_iso_inv(y: int | Array, n: int) -> Array:
     return jnp.where(y_wrapped & sign_bit, y_wrapped - (jnp.int64(1) << (n + 1)), y_wrapped)
 
 
-def trunc_poly(poly: sp.Expr, trunc_bounds: tuple[int, int]) -> sp.Expr:
-    """Truncate a polynomial to the given power-of-2 bounds.
-
-    Truncates a polynomial of the form ``p(x) = 2**k_0*x**i_0 +
-    2**k_1*x**i_1 + ...`` by removing every summand whose coefficient's
-    power of 2 does not lie within ``trunc_bounds``.
-
-    Parameters
-    ----------
-    poly : sympy.Expr
-        The polynomial to truncate.
-    trunc_bounds : tuple[int, int]
-        The (lower, upper) power-of-2 bounds to truncate to.
-
-    Returns
-    -------
-    sympy.Expr
-        The truncated polynomial, expanded.
-
-    """
-    # sympy's type stubs don't model Poly's dynamic attribute surface, so
-    # pyright can't see .trunc()/.expr here even though they're real members.
-    # Convert to sympy polynomial
-    poly_repr = sp.poly(poly)
-
-    # Clip upper bound
-    poly_repr = poly_repr.trunc(2.0 ** (trunc_bounds[1]))  # pyright: ignore[reportAttributeAccessIssue]
-
-    # Clip lower bound
-    poly_repr = poly_repr / 2.0 ** trunc_bounds[0]
-    poly_repr = poly_repr - sp.poly(poly_repr).trunc(1)
-    poly_repr = poly_repr * 2.0 ** trunc_bounds[0]
-
-    return poly_repr.expr.expand()
-
-
 class QuantumFloat(QuantumVariable):
     r"""This subclass of :ref:`QuantumVariable` represents signed or unsigned floats to arbitrary precision.
 
@@ -408,12 +372,16 @@ class QuantumFloat(QuantumVariable):
 
     @property
     def mshape(self) -> tuple[int | Array, int | Array]:
-        """The (log2(min), log2(max)) bounds of the absolute values this QuantumFloat can represent.
+        """Return the mantissa's significance bounds.
+
+        For a ``QuantumFloat`` with exponent ``k`` and mantissa size ``n``,
+        the result is ``(k, k + n)``. The lower bound is inclusive and the
+        upper bound is exclusive: mantissa qubit ``i`` has significance ``k + i``.
 
         Returns
         -------
-        tuple[int, int]
-            The (minimal, maximal) exponent of the representable magnitude.
+        tuple[int | jax.Array, int | jax.Array]
+            The inclusive lower and exclusive upper significance bounds.
 
         """
         return (self.exponent, self.exponent + self.msize)
@@ -474,9 +442,8 @@ class QuantumFloat(QuantumVariable):
             <qrisp.QuantumVariable.encoder>`, this parameter is named ``i``
             (not ``value``) for historical reasons specific to QuantumFloat.
 
-            Unlike the base's ``ScalarLike``, this does not accept ``complex``:
-            the bounds/sign checks below order ``i`` with ``<``/``>``, which
-            complex values don't support.
+            This does not accept ``complex``: the bounds/sign checks below
+            order ``i`` with ``<``/``>``, which complex values don't support.
 
         Parameters
         ----------
@@ -594,9 +561,8 @@ class QuantumFloat(QuantumVariable):
             ``rounding`` (inserted before ``permit_dirtyness``, for
             historical reasons specific to QuantumFloat).
 
-            Unlike the base's ``ScalarLike``, this does not accept ``complex``
-            (see :meth:`encoder <qrisp.QuantumFloat.encoder>`, which this
-            delegates to).
+            This does not accept ``complex`` (see :meth:`encoder
+            <qrisp.QuantumFloat.encoder>`, which this delegates to).
 
         Parameters
         ----------

--- a/src/qrisp/qtypes/quantum_float.py
+++ b/src/qrisp/qtypes/quantum_float.py
@@ -18,7 +18,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, TypeGuard
 
 import jax.numpy as jnp
 import numpy as np
@@ -37,6 +37,7 @@ if TYPE_CHECKING:
 
     from qrisp.circuit.qubit import Qubit
     from qrisp.qtypes.quantum_bool import QuantumBool
+    from qrisp.qtypes.quantum_modulus import QuantumModulus
 
 
 def _signed_int_iso(value: int | Array, n: int) -> Array:
@@ -643,7 +644,7 @@ class QuantumFloat(QuantumVariable):
         from qrisp.alg_primitives.arithmetic import polynomial_encoder, q_mult
 
         if isinstance(other, QuantumFloat):
-            return q_mult(self, other)  # pyright: ignore[reportReturnType]
+            return q_mult(self, other)
 
         if isinstance(other, (int, np.integer)):
             bit_shift = 0
@@ -1387,6 +1388,23 @@ def _prod(values: Iterable[sp.Expr]) -> sp.Expr:
     return res
 
 
+def _all_quantum_modulus(operands: list[QuantumFloat]) -> TypeGuard[list[QuantumModulus]]:
+    """Check whether every operand is a QuantumModulus, narrowing the list element type.
+
+    A plain ``all(isinstance(operand, QuantumModulus) for operand in operands)``
+    is just as correct at runtime, but pyright can't propagate a narrowed
+    element type out of that expression -- wrapping it in a
+    :data:`~typing.TypeGuard`-annotated function is what lets callers use
+    ``operands[i].m``/``.modulus`` afterwards without a type: ignore.
+
+    """
+    # NOTE: Local import to avoid a circular import (QuantumModulus subclasses QuantumFloat, so
+    # qrisp.qtypes can only expose QuantumModulus after this module has finished loading).
+    from qrisp.qtypes import QuantumModulus
+
+    return all(isinstance(operand, QuantumModulus) for operand in operands)
+
+
 def create_output_qf(operands: list[QuantumFloat], op: str | sp.Expr) -> QuantumFloat:
     """Determine the appropriately-sized output QuantumFloat for an arithmetic operation.
 
@@ -1445,22 +1463,13 @@ def create_output_qf(operands: list[QuantumFloat], op: str | sp.Expr) -> Quantum
 
         return QuantumFloat(msize, exponent=exponent, signed=signed)
 
-    # NOTE: Local import to avoid a circular import (QuantumModulus subclasses QuantumFloat, so
-    # qrisp.qtypes can only expose QuantumModulus after this module has finished loading).
-    from qrisp.qtypes import QuantumModulus
-
-    # pyright can't narrow `operands`' element type through all(isinstance(...)
-    # for ... in ...), even though every element is a QuantumModulus here.
-    if all(isinstance(operand, QuantumModulus) for operand in operands):
+    if _all_quantum_modulus(operands):
         res = operands[0].duplicate()
         if op == "mul":
-            res.m = (  # pyright: ignore[reportAttributeAccessIssue]
-                operands[0].m  # pyright: ignore[reportAttributeAccessIssue]
-                + operands[1].m  # pyright: ignore[reportAttributeAccessIssue]
-                - (
-                    int(np.ceil(np.log2((operands[0].modulus - 1) ** 2) + 1))  # pyright: ignore[reportAttributeAccessIssue]
-                    - operands[0].size
-                )
+            res.m = (
+                operands[0].m
+                + operands[1].m
+                - (int(np.ceil(np.log2((operands[0].modulus - 1) ** 2) + 1)) - operands[0].size)
             )
         return res
 

--- a/src/qrisp/qtypes/quantum_float.py
+++ b/src/qrisp/qtypes/quantum_float.py
@@ -132,8 +132,7 @@ def trunc_poly(poly: sp.Expr, trunc_bounds: tuple[int, int]) -> sp.Expr:
 
 
 class QuantumFloat(QuantumVariable):
-    r"""This subclass of :ref:`QuantumVariable` can represent floating point numbers
-    (signed and unsigned) up to an arbitrary precision.
+    r"""This subclass of :ref:`QuantumVariable` represents signed or unsigned floats to arbitrary precision.
 
     The technical details of the employed arithmetic can be found in this
     `article <https://ieeexplore.ieee.org/document/9815035>`_.
@@ -402,8 +401,7 @@ class QuantumFloat(QuantumVariable):
 
     @property
     def mshape(self) -> tuple[int | Array, int | Array]:
-        """The (log2(min), log2(max)) bounds of the absolute values this
-        QuantumFloat can represent.
+        """The (log2(min), log2(max)) bounds of the absolute values this QuantumFloat can represent.
 
         Returns
         -------
@@ -529,8 +527,7 @@ class QuantumFloat(QuantumVariable):
         return res.astype(int)
 
     def sb_poly(self, m: int = 0) -> sp.Expr:
-        """Returns the semi-boolean polynomial of this `QuantumFloat` where `m` specifies
-        the image extension parameter.
+        """Returns the semi-boolean polynomial of this `QuantumFloat` where `m` specifies the image extension parameter.
 
         For the technical details we refer to:
         https://ieeexplore.ieee.org/document/9815035
@@ -960,8 +957,10 @@ class QuantumFloat(QuantumVariable):
         return neq(self, other)
 
     def exp_shift(self, shift: int) -> None:
-        """Performs an internal bit shift. Note that this method doesn't cost any
-        quantum gates. For the quantum version of this method, see
+        """Performs an internal bit shift.
+
+        Note that this method doesn't cost any quantum gates. For the quantum
+        version of this method, see
         :meth:`quantum_bit_shift<qrisp.QuantumFloat.quantum_bitshift>`.
 
         Parameters
@@ -1176,8 +1175,7 @@ class QuantumFloat(QuantumVariable):
         return self[k - min_sig]  # pyright: ignore[reportReturnType]
 
     def truncate(self, value: float) -> float:
-        """Receives a regular float and returns the float that is closest to the input but
-        can still be encoded.
+        """Receives a regular float and returns the float that is closest to the input but can still be encoded.
 
         Parameters
         ----------
@@ -1249,6 +1247,7 @@ class QuantumFloat(QuantumVariable):
 
     def quantum_bit_shift(self, shift_amount: int | QuantumFloat) -> None:
         """Performs a bit shift in the quantum device.
+
         While :meth:`exp_shift<qrisp.QuantumFloat.exp_shift>` performs a bit shift
         in the compiler (thus costing no quantum gates) this method performs the
         bitshift on the hardware.

--- a/src/qrisp/qtypes/quantum_float.py
+++ b/src/qrisp/qtypes/quantum_float.py
@@ -33,6 +33,8 @@ from qrisp.misc import gate_wrap
 from qrisp.typing import FloatLike, ScalarLike
 
 if TYPE_CHECKING:
+    from collections.abc import Callable, Iterable
+
     from qrisp.circuit.qubit import Qubit
     from qrisp.qtypes.quantum_bool import QuantumBool
 
@@ -347,6 +349,11 @@ class QuantumFloat(QuantumVariable):
 
     """
 
+    signed: bool
+    exponent: int | Array
+    traced_attributes: list[str]
+    static_attributes: list[str]
+
     def __init__(
         self,
         msize: int | Array,
@@ -511,7 +518,7 @@ class QuantumFloat(QuantumVariable):
 
             # add a check that the provided value is safe to be encoded in the provided QuantumFloat
             if is_out_of_bounds:
-                sign_description = ["unsigned", "signed"][self.signed]
+                sign_description = "signed" if self.signed else "unsigned"
                 raise ValueError(
                     f"Not enough qubits to encode value {i} in {sign_description} QuantumFloat"
                     + f" of {self.msize} qubits and exponent {self.exponent}."
@@ -559,7 +566,7 @@ class QuantumFloat(QuantumVariable):
         if m == 0:
             m = self.size
 
-        symbols = [sp.symbols(str(hash(self)) + "_" + str(i)) for i in range(self.size)]
+        symbols = sp.symbols(f"{hash(self)}_0:{self.size}")
 
         poly = sum(2.0**i * symbols[i] for i in range(self.size))
 
@@ -644,18 +651,11 @@ class QuantumFloat(QuantumVariable):
                 other = other >> 1
                 bit_shift += 1
 
-            if self.signed or other < 0:
-                output_qf = QuantumFloat(
-                    self.msize + int(np.ceil(np.log2(abs(other)))),
-                    self.exponent,
-                    signed=True,
-                )
-            else:
-                output_qf = QuantumFloat(
-                    self.msize + int(np.ceil(np.log2(abs(other)))),
-                    self.exponent,
-                    signed=False,
-                )
+            output_qf = QuantumFloat(
+                self.msize + int(np.ceil(np.log2(abs(other)))),
+                self.exponent,
+                signed=bool(self.signed or other < 0),
+            )
 
             # int.__mul__ doesn't know about Symbol's __rmul__, but this works fine at runtime.
             polynomial_encoder([self], output_qf, other * sp.Symbol("x"))  # pyright: ignore[reportOperatorIssue]
@@ -765,18 +765,10 @@ class QuantumFloat(QuantumVariable):
             res[:] = 1
             return res
 
-        # NOTE: Local import to avoid a circular import (qrisp.alg_primitives.arithmetic imports from qrisp.qtypes).
-        from qrisp.alg_primitives.arithmetic import jasp_multiplyer
-
-        def power_conjugator(base, power, temp_results):
-            cx(base, temp_results[0])
-            for i in range(power - 1):
-                (temp_results[i + 1] << jasp_multiplyer)(base, temp_results[i])
-
         temp_results = [QuantumFloat((i + 1) * self.size) for i in range(power)]
 
         res = QuantumFloat(self.size * power)
-        with conjugate(power_conjugator)(self, power, temp_results):
+        with conjugate(_power_conjugator)(self, power, temp_results):
             cx(temp_results[-1], res)
 
         for qv in temp_results:
@@ -838,13 +830,13 @@ class QuantumFloat(QuantumVariable):
     @gate_wrap(permeability=[1], is_qfree=True)
     def __isub__(self, other: QuantumFloat | FloatLike) -> QuantumFloat:
         """Subtract another QuantumFloat or a classical scalar from this QuantumFloat, in place."""
-        # NOTE: Local import to avoid a circular import (qrisp.alg_primitives.arithmetic imports from qrisp.qtypes).
-        from qrisp.alg_primitives.arithmetic import polynomial_encoder
-
         if check_for_tracing_mode():
             with invert():
                 self.__iadd__(other)
             return self
+
+        # NOTE: Local import to avoid a circular import (qrisp.alg_primitives.arithmetic imports from qrisp.qtypes).
+        from qrisp.alg_primitives.arithmetic import polynomial_encoder
 
         if isinstance(other, QuantumFloat):
             input_qf_list = [other]
@@ -888,73 +880,81 @@ class QuantumFloat(QuantumVariable):
         self.exp_shift(k)
         return self
 
-    def __lt__(self, other: QuantumFloat | FloatLike) -> "QuantumBool":
-        """Compare this QuantumFloat to another QuantumFloat or a classical scalar (<)."""
-        # NOTE: Local import to avoid a circular import (qrisp.alg_primitives.arithmetic imports from qrisp.qtypes).
-        from qrisp.alg_primitives.arithmetic import gidney_adder, lt, uint_lt
+    def _compare(
+        self,
+        other: object,
+        cmp: Callable[..., "QuantumBool"],
+        uint_cmp: Callable[..., "QuantumBool"] | None = None,
+    ) -> "QuantumBool":
+        """Share the dispatch logic behind <, >, <=, >=, ==, and !=.
 
-        if check_for_tracing_mode():
-            return uint_lt(self, other, gidney_adder)  # pyright: ignore[reportReturnType]
+        While tracing, ``uint_cmp`` (called with ``self``, ``other``, and
+        ``gidney_adder``) is used if given -- <, >, <=, and >= dispatch to a
+        dedicated unsigned-integer comparator during tracing, whereas == and
+        != (``uint_cmp=None``) use ``cmp`` unconditionally, tracing or not.
+        Outside of tracing, ``other``'s type is always validated first.
+
+        """
+        tracing = check_for_tracing_mode()
+        if tracing and uint_cmp is not None:
+            # NOTE: Local import to avoid a circular import (qrisp.alg_primitives.arithmetic imports from qrisp.qtypes).
+            from qrisp.alg_primitives.arithmetic import gidney_adder
+
+            return uint_cmp(self, other, gidney_adder)
+        if tracing:
+            return cmp(self, other)
         if not isinstance(other, (QuantumFloat, int, float)):
             raise TypeError(f"Comparison with type {type(other)} not implemented")
 
-        return lt(self, other)  # pyright: ignore[reportReturnType]
+        return cmp(self, other)
+
+    def __lt__(self, other: QuantumFloat | FloatLike) -> "QuantumBool":
+        """Compare this QuantumFloat to another QuantumFloat or a classical scalar (<)."""
+        # NOTE: Local import to avoid a circular import (qrisp.alg_primitives.arithmetic imports from qrisp.qtypes).
+        from qrisp.alg_primitives.arithmetic import lt, uint_lt
+
+        # lt's inferred signature admits a None return that never actually
+        # happens for QuantumFloat/int/float operands (the only ones reaching
+        # this point).
+        return self._compare(other, lt, uint_lt)  # pyright: ignore[reportArgumentType]
 
     def __gt__(self, other: QuantumFloat | FloatLike) -> "QuantumBool":
         """Compare this QuantumFloat to another QuantumFloat or a classical scalar (>)."""
         # NOTE: Local import to avoid a circular import (qrisp.alg_primitives.arithmetic imports from qrisp.qtypes).
-        from qrisp.alg_primitives.arithmetic import gidney_adder, gt, uint_gt
+        from qrisp.alg_primitives.arithmetic import gt, uint_gt
 
-        if check_for_tracing_mode():
-            return uint_gt(self, other, gidney_adder)  # pyright: ignore[reportReturnType]
-        if not isinstance(other, (QuantumFloat, int, float)):
-            raise TypeError(f"Comparison with type {type(other)} not implemented")
-
-        return gt(self, other)  # pyright: ignore[reportReturnType]
+        # gt's inferred signature admits a None return that never actually
+        # happens for QuantumFloat/int/float operands (the only ones reaching
+        # this point).
+        return self._compare(other, gt, uint_gt)  # pyright: ignore[reportArgumentType]
 
     def __le__(self, other: QuantumFloat | FloatLike) -> "QuantumBool":
         """Compare this QuantumFloat to another QuantumFloat or a classical scalar (<=)."""
         # NOTE: Local import to avoid a circular import (qrisp.alg_primitives.arithmetic imports from qrisp.qtypes).
-        from qrisp.alg_primitives.arithmetic import gidney_adder, leq, uint_le
+        from qrisp.alg_primitives.arithmetic import leq, uint_le
 
-        if check_for_tracing_mode():
-            return uint_le(self, other, gidney_adder)
-        if not isinstance(other, (QuantumFloat, int, float)):
-            raise TypeError(f"Comparison with type {type(other)} not implemented")
-
-        return leq(self, other)
+        return self._compare(other, leq, uint_le)
 
     def __ge__(self, other: QuantumFloat | FloatLike) -> "QuantumBool":
         """Compare this QuantumFloat to another QuantumFloat or a classical scalar (>=)."""
         # NOTE: Local import to avoid a circular import (qrisp.alg_primitives.arithmetic imports from qrisp.qtypes).
-        from qrisp.alg_primitives.arithmetic import geq, gidney_adder, uint_ge
+        from qrisp.alg_primitives.arithmetic import geq, uint_ge
 
-        if check_for_tracing_mode():
-            return uint_ge(self, other, gidney_adder)
-        if not isinstance(other, (QuantumFloat, int, float)):
-            raise TypeError(f"Comparison with type {type(other)} not implemented")
-
-        return geq(self, other)
+        return self._compare(other, geq, uint_ge)
 
     def __eq__(self, other: object) -> "QuantumBool":
         """Compare this QuantumFloat to another QuantumFloat or a classical scalar (==)."""
         # NOTE: Local import to avoid a circular import (qrisp.alg_primitives.arithmetic imports from qrisp.qtypes).
         from qrisp.alg_primitives.arithmetic import eq
 
-        if not check_for_tracing_mode() and not isinstance(other, (QuantumFloat, int, float)):
-            raise TypeError(f"Comparison with type {type(other)} not implemented")
-
-        return eq(self, other)
+        return self._compare(other, eq)
 
     def __ne__(self, other: object) -> "QuantumBool":
         """Compare this QuantumFloat to another QuantumFloat or a classical scalar (!=)."""
         # NOTE: Local import to avoid a circular import (qrisp.alg_primitives.arithmetic imports from qrisp.qtypes).
         from qrisp.alg_primitives.arithmetic import neq
 
-        if not check_for_tracing_mode() and not isinstance(other, (QuantumFloat, int, float)):
-            raise TypeError(f"Comparison with type {type(other)} not implemented")
-
-        return neq(self, other)
+        return self._compare(other, neq)
 
     def exp_shift(self, shift: int) -> None:
         """Performs an internal bit shift.
@@ -1305,6 +1305,28 @@ class QuantumFloat(QuantumVariable):
         quantum_bit_shift(self, shift_amount)
 
 
+def _power_conjugator(base: QuantumFloat, power: int, temp_results: list[QuantumFloat]) -> None:
+    """Conjugator for QuantumFloat.__pow__: fills temp_results[i] with base**(i + 1).
+
+    Parameters
+    ----------
+    base : QuantumFloat
+        The QuantumFloat being raised to a power.
+    power : int
+        The power ``base`` is being raised to.
+    temp_results : list[QuantumFloat]
+        Freshly allocated QuantumFloats, one per power from 1 to ``power``,
+        filled in place: ``temp_results[i]`` ends up holding ``base**(i + 1)``.
+
+    """
+    # NOTE: Local import to avoid a circular import (qrisp.alg_primitives.arithmetic imports from qrisp.qtypes).
+    from qrisp.alg_primitives.arithmetic import jasp_multiplyer
+
+    cx(base, temp_results[0])
+    for i in range(power - 1):
+        (temp_results[i + 1] << jasp_multiplyer)(base, temp_results[i])
+
+
 def _addsub_bounds(op0: QuantumFloat, op1: QuantumFloat) -> tuple[int | Array, int | Array]:
     """Compute the (exponent, max_sig) bounds for an add/sub output QuantumFloat.
 
@@ -1337,6 +1359,34 @@ def _addsub_bounds(op0: QuantumFloat, op1: QuantumFloat) -> tuple[int | Array, i
     return exponent, max_sig
 
 
+def _prod(values: Iterable[sp.Expr]) -> sp.Expr:
+    """Multiply an iterable of sympy expressions together.
+
+    Seeded from the first element (rather than ``math.prod``'s default seed
+    of ``1``) so this also accepts non-numeric multiplicative types; here,
+    the powers of sympy Symbols making up one monomial of a polynomial.
+
+    Parameters
+    ----------
+    values : Iterable[sympy.Expr]
+        The values to multiply together. Must be non-empty.
+
+    Returns
+    -------
+    sympy.Expr
+        The product of every element in ``values``.
+
+    """
+    values = list(values)
+    res = values[0]
+    for value in values[1:]:
+        # sympy's Expr stubs don't model __imul__ precisely enough for pyright
+        # here, even though multiplying two Exprs is a real, supported operation.
+        res *= value  # pyright: ignore[reportOperatorIssue]
+
+    return res
+
+
 def create_output_qf(operands: list[QuantumFloat], op: str | sp.Expr) -> QuantumFloat:
     """Determine the appropriately-sized output QuantumFloat for an arithmetic operation.
 
@@ -1367,20 +1417,12 @@ def create_output_qf(operands: list[QuantumFloat], op: str | sp.Expr) -> Quantum
 
         operands.sort(key=lambda operand: operand.name)
 
-        def prod(values):
-            values = list(values)
-            res = values[0]
-            for value in values[1:]:
-                res *= value
-
-            return res
-
         # sympy's type stubs don't model Poly's/Abs's dynamic attribute
         # surface, so pyright can't see .gens/.coeffs()/.monoms()/.subs()
         # here even though they're all real Poly/Basic members.
         poly = sp.Poly(op)  # pyright: ignore[reportAttributeAccessIssue]
         monom_list = [
-            a * prod(sym**k for sym, k in zip(poly.gens, mon))  # pyright: ignore[reportAttributeAccessIssue]
+            a * _prod(sym**k for sym, k in zip(poly.gens, mon))  # pyright: ignore[reportAttributeAccessIssue]
             for a, mon in zip(poly.coeffs(), poly.monoms())  # pyright: ignore[reportAttributeAccessIssue]
         ]
 
@@ -1472,46 +1514,51 @@ def copy_qf(
         represent. The default is False.
 
     """
-    # Lists that translate Qubit index => Significance
-    qf1_sign_list = [qf1.exponent + i for i in range(qf1.size)]
-    qf2_sign_list = [qf2.exponent + i for i in range(qf2.size)]
+    # Each QuantumFloat's qubit i has significance qf.exponent + i, a
+    # contiguous run -- so its bounds are plain arithmetic, no list needed.
+    qf1_sig_range = range(qf1.exponent, qf1.exponent + qf1.size)
+    qf2_sig_range = range(qf2.exponent, qf2.exponent + qf2.size)
 
     # Check overflow/underflow
-    if max(qf1_sign_list) < max(qf2_sign_list) and not ignore_overflow_errors:
+    if max(qf1_sig_range) < max(qf2_sig_range) and not ignore_overflow_errors:
         raise ValueError("Copy operation would result in overflow (use ignore_overflow_errors = True)")
 
-    if min(qf1_sign_list) > min(qf2_sign_list) and not ignore_rounding_errors:
+    if min(qf1_sig_range) > min(qf2_sig_range) and not ignore_rounding_errors:
         raise ValueError("Copy operation would result in rounding (use ignore_rounding_errors = True)")
 
     qs = qf1.qs
+
+    # Qubit counts to copy, excluding the sign qubit (the last one) when qf2
+    # is signed -- it's handled on its own below.
+    qf1_len = qf1.size
+    qf2_len = qf2.size
 
     if qf2.signed:
         if not qf1.signed:
             raise ValueError("Tried to copy signed into unsigend float")
 
-        # Remove last entry from significance list (last qubit is the sign qubit)
-        qf2_sign_list.pop(-1)
-        qf1_sign_list.pop(-1)
+        qf1_len -= 1
+        qf2_len -= 1
 
-    # qf2_sign_list is a contiguous run of significances by construction above,
-    # so membership/index reduce to O(1) arithmetic instead of an O(n) scan per
-    # qf1 qubit below. qf2_max is only computed when the loop can actually reach
-    # it, so it still raises the same error max(qf2_sign_list) would for a
-    # signed, zero-mantissa qf2 -- an edge case that otherwise never gets
-    # touched because qf1_sign_list would then also be empty.
+    qf1_start = qf1.exponent
     qf2_start = qf2.exponent
-    qf2_len = len(qf2_sign_list)
-    # Falls back to qf2_start (any same-typed value would do) when unused, so
-    # qf2_max never needs an Optional type -- see the loop below, which only
-    # ever reads it when qf2.signed is True.
-    qf2_max = max(qf2_sign_list) if (qf2.signed and qf1_sign_list) else qf2_start
+
+    # qf2_max is only computed when the loop can actually reach it, so it
+    # still raises the same error max() over an empty range would for a
+    # signed, zero-mantissa qf2 -- an edge case that otherwise never gets
+    # touched because qf1_len would then also be 0. Falls back to qf2_start
+    # (any same-typed value would do) when unused, so qf2_max never needs an
+    # Optional type.
+    qf2_max = max(range(qf2_start, qf2_start + qf2_len)) if (qf2.signed and qf1_len) else qf2_start
 
     # QuantumVariable.qs/__getitem__ aren't typed precisely enough for pyright
     # to see qs as a QuantumSession (with .cx) here rather than the
     # TracingQuantumSession union member, or single-index __getitem__ as
     # returning a Qubit rather than DynamicQubitArray -- both hold in this
     # non-tracing, single-qubit-index context.
-    for i, significance in enumerate(qf1_sign_list):
+    for i in range(qf1_len):
+        significance = qf1_start + i
+
         # If we are in a realm where both floats have overlapping significance
         # => CNOT into each other
         rel_index = significance - qf2_start

--- a/src/qrisp/qtypes/quantum_float.py
+++ b/src/qrisp/qtypes/quantum_float.py
@@ -30,7 +30,6 @@ from qrisp.core import QuantumVariable, cx, x
 from qrisp.environments import conjugate, invert
 from qrisp.jasp import check_for_tracing_mode
 from qrisp.misc import gate_wrap
-from qrisp.typing import FloatLike
 
 if TYPE_CHECKING:
     from collections.abc import Iterable
@@ -622,9 +621,7 @@ class QuantumFloat(QuantumVariable):
             # does: representable values form a uniform grid, so the nearest
             # one is found directly by rounding and clipping, in O(1) --
             # no need to enumerate all 2**size outcomes to search for it.
-            # truncate() is typed strictly as float, but a bool/np.integer/
-            # np.floating/Tracer here all support the same arithmetic at runtime.
-            value = self.truncate(encoding_number)  # pyright: ignore[reportArgumentType]
+            value = self.truncate(encoding_number)
 
         super().encode(value, permit_dirtyness=permit_dirtyness)
 
@@ -652,7 +649,9 @@ class QuantumFloat(QuantumVariable):
                 # Multiplying by the classical scalar 0 always yields 0, regardless
                 # of self's state, so no entanglement with self is needed. Handled
                 # separately since the bit-shift/log2 logic below assumes other != 0.
-                return QuantumFloat(1, self.exponent, signed=self.signed)
+                # Attached to self.qs (like every other branch here) even though no
+                # gates act on it: gate_wrap only merges sessions its gates touch.
+                return QuantumFloat(1, self.exponent, self.qs, signed=self.signed)
 
             bit_shift = 0
             while not other % 2:
@@ -803,7 +802,7 @@ class QuantumFloat(QuantumVariable):
         return res
 
     @gate_wrap(permeability=[1], is_qfree=True)
-    def __iadd__(self, other: QuantumFloat | FloatLike) -> QuantumFloat:
+    def __iadd__(self, other: QuantumFloat | int | float | np.integer | np.floating | Array) -> QuantumFloat:
         """Add another QuantumFloat or a classical scalar to this QuantumFloat, in place."""
         if check_for_tracing_mode():
             # NOTE: Local import to avoid a circular import (qrisp.alg_primitives.arithmetic imports from qrisp.qtypes).
@@ -855,7 +854,7 @@ class QuantumFloat(QuantumVariable):
         return self
 
     @gate_wrap(permeability=[1], is_qfree=True)
-    def __isub__(self, other: QuantumFloat | FloatLike) -> QuantumFloat:
+    def __isub__(self, other: QuantumFloat | int | float | np.integer | np.floating | Array) -> QuantumFloat:
         """Subtract another QuantumFloat or a classical scalar from this QuantumFloat, in place."""
         if check_for_tracing_mode():
             with invert():
@@ -889,7 +888,7 @@ class QuantumFloat(QuantumVariable):
         return self
 
     @gate_wrap(permeability=[], is_qfree=True)
-    def __imul__(self, other: FloatLike) -> QuantumFloat:
+    def __imul__(self, other: int | float | np.integer | np.floating) -> QuantumFloat:
         """Multiply this QuantumFloat by a classical scalar, in place."""
         # NOTE: Local import to avoid a circular import (qrisp.alg_primitives.arithmetic imports from qrisp.qtypes).
         from qrisp.alg_primitives.arithmetic import inpl_mult
@@ -908,7 +907,7 @@ class QuantumFloat(QuantumVariable):
         self.exp_shift(k)
         return self
 
-    def __lt__(self, other: QuantumFloat | FloatLike) -> "QuantumBool":
+    def __lt__(self, other: QuantumFloat | int | float) -> "QuantumBool":
         """Compare this QuantumFloat to another QuantumFloat or a classical scalar (<)."""
         # NOTE: Local import to avoid a circular import (qrisp.alg_primitives.arithmetic imports from qrisp.qtypes).
         from qrisp.alg_primitives.arithmetic import gidney_adder, lt, uint_lt
@@ -920,7 +919,7 @@ class QuantumFloat(QuantumVariable):
 
         return lt(self, other)  # pyright: ignore[reportReturnType]
 
-    def __gt__(self, other: QuantumFloat | FloatLike) -> "QuantumBool":
+    def __gt__(self, other: QuantumFloat | int | float) -> "QuantumBool":
         """Compare this QuantumFloat to another QuantumFloat or a classical scalar (>)."""
         # NOTE: Local import to avoid a circular import (qrisp.alg_primitives.arithmetic imports from qrisp.qtypes).
         from qrisp.alg_primitives.arithmetic import gidney_adder, gt, uint_gt
@@ -932,7 +931,7 @@ class QuantumFloat(QuantumVariable):
 
         return gt(self, other)  # pyright: ignore[reportReturnType]
 
-    def __le__(self, other: QuantumFloat | FloatLike) -> "QuantumBool":
+    def __le__(self, other: QuantumFloat | int | float) -> "QuantumBool":
         """Compare this QuantumFloat to another QuantumFloat or a classical scalar (<=)."""
         # NOTE: Local import to avoid a circular import (qrisp.alg_primitives.arithmetic imports from qrisp.qtypes).
         from qrisp.alg_primitives.arithmetic import gidney_adder, leq, uint_le
@@ -944,7 +943,7 @@ class QuantumFloat(QuantumVariable):
 
         return leq(self, other)
 
-    def __ge__(self, other: QuantumFloat | FloatLike) -> "QuantumBool":
+    def __ge__(self, other: QuantumFloat | int | float) -> "QuantumBool":
         """Compare this QuantumFloat to another QuantumFloat or a classical scalar (>=)."""
         # NOTE: Local import to avoid a circular import (qrisp.alg_primitives.arithmetic imports from qrisp.qtypes).
         from qrisp.alg_primitives.arithmetic import geq, gidney_adder, uint_ge
@@ -1124,12 +1123,12 @@ class QuantumFloat(QuantumVariable):
             ignore_overflow_errors=ignore_overflow_errors,
         )
 
-    def incr(self, value: FloatLike | None = None) -> None:
+    def incr(self, value: int | float | np.integer | np.floating | None = None) -> None:
         """Increment this QuantumFloat in place by a classical value.
 
         Parameters
         ----------
-        value : FloatLike, optional
+        value : int, float, np.integer, or np.floating, optional
             The value to increment by. The default is this QuantumFloat's
             smallest representable increment, ``2**self.exponent``.
 
@@ -1138,7 +1137,10 @@ class QuantumFloat(QuantumVariable):
         from qrisp.alg_primitives.arithmetic.adders.incrementation import increment
 
         if value is None:
-            value = 2**self.exponent
+            # increment() is eager-only (Python-level control flow on the
+            # amount), so self.exponent is concretely int here even though
+            # its class-level type also allows a traced jax.Array.
+            value = 2**self.exponent  # pyright: ignore[reportAssignmentType]
         increment(self, value)
 
     def __hash__(self) -> int:
@@ -1191,18 +1193,21 @@ class QuantumFloat(QuantumVariable):
 
         return self[k - min_sig]  # pyright: ignore[reportReturnType]
 
-    def truncate(self, value: float) -> float:
+    def truncate(self, value: int | float | bool | np.integer | np.floating | Tracer) -> int | float | Array:
         """Receives a regular float and returns the float that is closest to the input but can still be encoded.
 
         Parameters
         ----------
-        value : float
-            A float that is supposed to be truncated.
+        value : int, float, bool, np.integer, np.floating, or jax.core.Tracer
+            A real-valued number that is supposed to be truncated.
 
         Returns
         -------
-        float
-            The truncated float.
+        int, float, or jax.Array
+            The truncated value: an ``int`` or ``float`` outside of tracing
+            mode (depending on whether the exponent is non-negative, see
+            :meth:`decoder <qrisp.QuantumFloat.decoder>`), or a traced
+            ``jax.Array`` while tracing.
 
         Examples
         --------
@@ -1226,17 +1231,21 @@ class QuantumFloat(QuantumVariable):
         # Clip in floating point before converting to int64: converting a
         # float far outside int64's range is platform-dependent behavior, not
         # a guaranteed saturating clamp.
+        # 2.0**self.msize is computed via jax (not plain Python float
+        # exponentiation) so an oversized msize (>= 1024) saturates to inf
+        # instead of raising OverflowError.
+        bound = jnp.float64(2.0) ** self.msize
         res = jnp.round(value / jnp.float64(2) ** self.exponent)
-        res = jnp.minimum(2.0**self.msize - 1, res)
+        res = jnp.minimum(bound - 1, res)
 
         if self.signed:
-            res = jnp.maximum(-(2.0**self.msize), res)
+            res = jnp.maximum(-bound, res)
             res = _signed_int_iso(jnp.int64(res), self.size)
         else:
             res = jnp.maximum(0.0, res)
             res = jnp.int64(res)
 
-        return self.decoder(res)  # pyright: ignore[reportReturnType]
+        return self.decoder(res)
 
     def get_ev(self, **mes_kwargs: Any) -> float:
         """Retrieves the expectation value of self.

--- a/src/qrisp/qtypes/quantum_float.py
+++ b/src/qrisp/qtypes/quantum_float.py
@@ -605,9 +605,20 @@ class QuantumFloat(QuantumVariable):
         """
         value = encoding_number
         if rounding:
-            # Round value to closest fitting number
-            outcome_labels = [self.decoder(i) for i in range(2**self.size)]
-            value = outcome_labels[np.argmin(np.abs(encoding_number - np.array(outcome_labels)))]
+            # Round value to closest fitting number. Vectorized equivalent of
+            # [self.decoder(i) for i in range(2**self.size)], since that grows
+            # exponentially with the qubit count.
+            indices = np.arange(2**self.size)
+            if self.signed:
+                outcome_labels = np.asarray(_signed_int_iso_inv(indices, self.msize)) * (2.0**self.exponent)
+            else:
+                outcome_labels = indices * (2.0**self.exponent)
+            # Coerce explicitly: ScalarLike also covers complex/Tracer, which
+            # encoding_number never actually is here (this is an eager-only
+            # rounding path), but numpy's stubs can't express that narrowing.
+            diffs = np.asarray(encoding_number, dtype=float) - outcome_labels
+            closest = outcome_labels[np.argmin(np.abs(diffs))]
+            value = int(closest) if self.exponent >= 0 else float(closest)
 
         super().encode(value, permit_dirtyness=permit_dirtyness)
 
@@ -615,6 +626,7 @@ class QuantumFloat(QuantumVariable):
     def __mul__(self, other: QuantumFloat | FloatLike) -> QuantumFloat:
         """Multiply this QuantumFloat by another QuantumFloat or a classical int."""
         if check_for_tracing_mode():
+            # NOTE: Local import to avoid a circular import (qrisp.alg_primitives.arithmetic imports from qrisp.qtypes).
             from qrisp.alg_primitives.arithmetic import jasp_multiplyer, jasp_squaring
 
             if isinstance(other, QuantumFloat):
@@ -623,6 +635,7 @@ class QuantumFloat(QuantumVariable):
                 return jasp_multiplyer(other, self)
             raise TypeError(f"Tried to multiply class {type(other)} with QuantumFloat")
 
+        # NOTE: Local import to avoid a circular import (qrisp.alg_primitives.arithmetic imports from qrisp.qtypes).
         from qrisp.alg_primitives.arithmetic import polynomial_encoder, q_mult
 
         if isinstance(other, QuantumFloat):
@@ -662,6 +675,7 @@ class QuantumFloat(QuantumVariable):
     @gate_wrap(permeability="args", is_qfree=True)
     def __add__(self, other: QuantumFloat | FloatLike) -> QuantumFloat:
         """Add another QuantumFloat or a classical scalar to this QuantumFloat."""
+        # NOTE: Local import to avoid a circular import (qrisp.alg_primitives.arithmetic imports from qrisp.qtypes).
         from qrisp.alg_primitives.arithmetic import sbp_add
 
         if isinstance(other, QuantumFloat):
@@ -682,6 +696,7 @@ class QuantumFloat(QuantumVariable):
     @gate_wrap(permeability="args", is_qfree=True)
     def __sub__(self, other: QuantumFloat | FloatLike) -> QuantumFloat:
         """Subtract another QuantumFloat or a classical scalar from this QuantumFloat."""
+        # NOTE: Local import to avoid a circular import (qrisp.alg_primitives.arithmetic imports from qrisp.qtypes).
         from qrisp.alg_primitives.arithmetic import sbp_sub
 
         if isinstance(other, QuantumFloat):
@@ -705,6 +720,7 @@ class QuantumFloat(QuantumVariable):
     @gate_wrap(permeability="args", is_qfree=True)
     def __rsub__(self, other: QuantumFloat | FloatLike) -> QuantumFloat:
         """Subtract this QuantumFloat from a classical scalar or QuantumFloat."""
+        # NOTE: Local import to avoid a circular import (qrisp.alg_primitives.arithmetic imports from qrisp.qtypes).
         from qrisp.alg_primitives.arithmetic import sbp_sub
 
         if isinstance(other, QuantumFloat):
@@ -721,6 +737,7 @@ class QuantumFloat(QuantumVariable):
     @gate_wrap(permeability="args", is_qfree=True)
     def __truediv__(self, other: QuantumFloat | FloatLike) -> QuantumFloat:
         """Divide this QuantumFloat by another QuantumFloat."""
+        # NOTE: Local import to avoid a circular import (qrisp.alg_primitives.arithmetic imports from qrisp.qtypes).
         from qrisp.alg_primitives.arithmetic import q_div
 
         return q_div(self, other)
@@ -733,6 +750,7 @@ class QuantumFloat(QuantumVariable):
 
         if self.exponent < 0 or other.exponent < 0:
             raise ValueError("Tried to perform floor division on non-integer QuantumFloats")
+        # NOTE: Local import to avoid a circular import (qrisp.alg_primitives.arithmetic imports from qrisp.qtypes).
         from qrisp.alg_primitives.arithmetic import q_div
 
         return q_div(self, other, prec=0)
@@ -741,6 +759,7 @@ class QuantumFloat(QuantumVariable):
     def __pow__(self, power: int) -> QuantumFloat:
         """Raise this QuantumFloat to an integer power (-1 means inversion)."""
         if power == -1:
+            # NOTE: Local import to avoid a circular import (qrisp.alg_primitives.arithmetic imports from qrisp.qtypes).
             from qrisp.alg_primitives.arithmetic import qf_inversion
 
             return qf_inversion(self)
@@ -749,6 +768,7 @@ class QuantumFloat(QuantumVariable):
             res[:] = 1
             return res
 
+        # NOTE: Local import to avoid a circular import (qrisp.alg_primitives.arithmetic imports from qrisp.qtypes).
         from qrisp.alg_primitives.arithmetic import jasp_multiplyer
 
         def power_conjugator(base, power, temp_results):
@@ -771,6 +791,7 @@ class QuantumFloat(QuantumVariable):
     def __iadd__(self, other: QuantumFloat | FloatLike) -> QuantumFloat:
         """Add another QuantumFloat or a classical scalar to this QuantumFloat, in place."""
         if check_for_tracing_mode():
+            # NOTE: Local import to avoid a circular import (qrisp.alg_primitives.arithmetic imports from qrisp.qtypes).
             from qrisp.alg_primitives.arithmetic.adders import gidney_adder
 
             if isinstance(other, QuantumFloat):
@@ -792,6 +813,7 @@ class QuantumFloat(QuantumVariable):
 
             return self
 
+        # NOTE: Local import to avoid a circular import (qrisp.alg_primitives.arithmetic imports from qrisp.qtypes).
         from qrisp.alg_primitives.arithmetic import polynomial_encoder
 
         if isinstance(other, QuantumFloat):
@@ -819,6 +841,7 @@ class QuantumFloat(QuantumVariable):
     @gate_wrap(permeability=[1], is_qfree=True)
     def __isub__(self, other: QuantumFloat | FloatLike) -> QuantumFloat:
         """Subtract another QuantumFloat or a classical scalar from this QuantumFloat, in place."""
+        # NOTE: Local import to avoid a circular import (qrisp.alg_primitives.arithmetic imports from qrisp.qtypes).
         from qrisp.alg_primitives.arithmetic import polynomial_encoder
 
         if check_for_tracing_mode():
@@ -851,6 +874,7 @@ class QuantumFloat(QuantumVariable):
     @gate_wrap(permeability=[], is_qfree=True)
     def __imul__(self, other: FloatLike) -> QuantumFloat:
         """Multiply this QuantumFloat by a classical scalar, in place."""
+        # NOTE: Local import to avoid a circular import (qrisp.alg_primitives.arithmetic imports from qrisp.qtypes).
         from qrisp.alg_primitives.arithmetic import inpl_mult
 
         inpl_mult(self, other)
@@ -869,6 +893,7 @@ class QuantumFloat(QuantumVariable):
 
     def __lt__(self, other: QuantumFloat | FloatLike) -> "QuantumBool":
         """Compare this QuantumFloat to another QuantumFloat or a classical scalar (<)."""
+        # NOTE: Local import to avoid a circular import (qrisp.alg_primitives.arithmetic imports from qrisp.qtypes).
         from qrisp.alg_primitives.arithmetic import gidney_adder, lt, uint_lt
 
         if check_for_tracing_mode():
@@ -880,6 +905,7 @@ class QuantumFloat(QuantumVariable):
 
     def __gt__(self, other: QuantumFloat | FloatLike) -> "QuantumBool":
         """Compare this QuantumFloat to another QuantumFloat or a classical scalar (>)."""
+        # NOTE: Local import to avoid a circular import (qrisp.alg_primitives.arithmetic imports from qrisp.qtypes).
         from qrisp.alg_primitives.arithmetic import gidney_adder, gt, uint_gt
 
         if check_for_tracing_mode():
@@ -891,6 +917,7 @@ class QuantumFloat(QuantumVariable):
 
     def __le__(self, other: QuantumFloat | FloatLike) -> "QuantumBool":
         """Compare this QuantumFloat to another QuantumFloat or a classical scalar (<=)."""
+        # NOTE: Local import to avoid a circular import (qrisp.alg_primitives.arithmetic imports from qrisp.qtypes).
         from qrisp.alg_primitives.arithmetic import gidney_adder, leq, uint_le
 
         if check_for_tracing_mode():
@@ -902,6 +929,7 @@ class QuantumFloat(QuantumVariable):
 
     def __ge__(self, other: QuantumFloat | FloatLike) -> "QuantumBool":
         """Compare this QuantumFloat to another QuantumFloat or a classical scalar (>=)."""
+        # NOTE: Local import to avoid a circular import (qrisp.alg_primitives.arithmetic imports from qrisp.qtypes).
         from qrisp.alg_primitives.arithmetic import geq, gidney_adder, uint_ge
 
         if check_for_tracing_mode():
@@ -913,6 +941,7 @@ class QuantumFloat(QuantumVariable):
 
     def __eq__(self, other: object) -> "QuantumBool":
         """Compare this QuantumFloat to another QuantumFloat or a classical scalar (==)."""
+        # NOTE: Local import to avoid a circular import (qrisp.alg_primitives.arithmetic imports from qrisp.qtypes).
         from qrisp.alg_primitives.arithmetic import eq
 
         if not check_for_tracing_mode() and not isinstance(other, (QuantumFloat, int, float)):
@@ -922,6 +951,7 @@ class QuantumFloat(QuantumVariable):
 
     def __ne__(self, other: object) -> "QuantumBool":
         """Compare this QuantumFloat to another QuantumFloat or a classical scalar (!=)."""
+        # NOTE: Local import to avoid a circular import (qrisp.alg_primitives.arithmetic imports from qrisp.qtypes).
         from qrisp.alg_primitives.arithmetic import neq
 
         if not check_for_tracing_mode() and not isinstance(other, (QuantumFloat, int, float)):
@@ -1088,6 +1118,7 @@ class QuantumFloat(QuantumVariable):
             smallest representable increment, ``2**self.exponent``.
 
         """
+        # NOTE: Local import to avoid a circular import (qrisp.alg_primitives.arithmetic imports from qrisp.qtypes).
         from qrisp.alg_primitives.arithmetic.adders.incrementation import increment
 
         if value is None:
@@ -1135,14 +1166,14 @@ class QuantumFloat(QuantumVariable):
         The qubit with significance $2$ corresponds to the value $4 = 2^{2}$.
 
         """
-        sig_list = list(range(self.mshape[0], self.mshape[1]))
+        min_sig, max_sig = self.mshape
 
-        if k not in sig_list:
+        if not min_sig <= k < max_sig:
             raise ValueError(
                 f"Tried to retrieve invalid significant {k} from QuantumFloat with mantissa shape {self.mshape}"
             )
 
-        return self[sig_list.index(k)]  # pyright: ignore[reportReturnType]
+        return self[k - min_sig]  # pyright: ignore[reportReturnType]
 
     def truncate(self, value: float) -> float:
         """Receives a regular float and returns the float that is closest to the input but
@@ -1269,6 +1300,7 @@ class QuantumFloat(QuantumVariable):
             # sqrt(2)*(|1>*|False> + |4>*|True>)/2
 
         """
+        # NOTE: Local import to avoid a circular import (qrisp.alg_primitives.arithmetic imports from qrisp.qtypes).
         from qrisp.alg_primitives.arithmetic import quantum_bit_shift
 
         quantum_bit_shift(self, shift_amount)
@@ -1325,6 +1357,7 @@ def create_output_qf(operands: list[QuantumFloat], op: str | sp.Expr) -> Quantum
 
     """
     if isinstance(op, sp.core.expr.Expr):
+        # NOTE: Local import to avoid a circular import (qrisp.alg_primitives.arithmetic imports from qrisp.qtypes).
         from qrisp.alg_primitives.arithmetic.poly_tools import expr_to_list
 
         expr_list = expr_to_list(op)
@@ -1371,6 +1404,8 @@ def create_output_qf(operands: list[QuantumFloat], op: str | sp.Expr) -> Quantum
 
         return QuantumFloat(msize, exponent=exponent, signed=signed)
 
+    # NOTE: Local import to avoid a circular import (QuantumModulus subclasses QuantumFloat, so
+    # qrisp.qtypes can only expose QuantumModulus after this module has finished loading).
     from qrisp.qtypes import QuantumModulus
 
     # pyright can't narrow `operands`' element type through all(isinstance(...)
@@ -1459,6 +1494,19 @@ def copy_qf(
         qf2_sign_list.pop(-1)
         qf1_sign_list.pop(-1)
 
+    # qf2_sign_list is a contiguous run of significances by construction above,
+    # so membership/index reduce to O(1) arithmetic instead of an O(n) scan per
+    # qf1 qubit below. qf2_max is only computed when the loop can actually reach
+    # it, so it still raises the same error max(qf2_sign_list) would for a
+    # signed, zero-mantissa qf2 -- an edge case that otherwise never gets
+    # touched because qf1_sign_list would then also be empty.
+    qf2_start = qf2.exponent
+    qf2_len = len(qf2_sign_list)
+    # Falls back to qf2_start (any same-typed value would do) when unused, so
+    # qf2_max never needs an Optional type -- see the loop below, which only
+    # ever reads it when qf2.signed is True.
+    qf2_max = max(qf2_sign_list) if (qf2.signed and qf1_sign_list) else qf2_start
+
     # QuantumVariable.qs/__getitem__ aren't typed precisely enough for pyright
     # to see qs as a QuantumSession (with .cx) here rather than the
     # TracingQuantumSession union member, or single-index __getitem__ as
@@ -1467,13 +1515,13 @@ def copy_qf(
     for i, significance in enumerate(qf1_sign_list):
         # If we are in a realm where both floats have overlapping significance
         # => CNOT into each other
-        if significance in qf2_sign_list:
-            qf2_index = qf2_sign_list.index(significance)
-            qs.cx(qf2[qf2_index], qf1[i])  # pyright: ignore[reportAttributeAccessIssue, reportArgumentType]
+        rel_index = significance - qf2_start
+        if 0 <= rel_index < qf2_len:
+            qs.cx(qf2[rel_index], qf1[i])  # pyright: ignore[reportAttributeAccessIssue, reportArgumentType]
             continue
 
         # Otherwise copy the sign bit into the bits of higher significance than qf2
-        if significance > max(qf2_sign_list) and qf2.signed:
+        if qf2.signed and significance > qf2_max:
             qs.cx(qf2[-1], qf1[i])  # pyright: ignore[reportAttributeAccessIssue, reportArgumentType]
 
     # Copy the sign bit

--- a/src/qrisp/qtypes/quantum_float.py
+++ b/src/qrisp/qtypes/quantum_float.py
@@ -145,7 +145,7 @@ class QuantumFloat(QuantumVariable):
     >>> from qrisp import QuantumFloat
     >>> a = QuantumFloat(3, -1, signed = False)
 
-    Here, the 3 indicates the amount of mantissa qubits and the -1 indicates the
+    Here, the 3 indicates the number of mantissa qubits and the -1 indicates the
     exponent.
 
     For unsigned QuantumFloats, the decoder function is given by
@@ -178,7 +178,7 @@ class QuantumFloat(QuantumVariable):
         f_{k}^{n}(i) = \begin{cases} i2^{k} & \text{if } i < 2^n \\ (i - 2^{n+1})2^k &
         \text{else} \end{cases}
 
-    Where $k$ is again, the exponent and $n$ is the mantissa size.
+    Where $k$ is again the exponent and $n$ is the mantissa size.
 
 
     Another example:
@@ -248,7 +248,7 @@ class QuantumFloat(QuantumVariable):
     {0.25: 1.0}
 
     Note that the latter is only an approximate result. This is because in many cases,
-    the results of division can not be stored in a finite amount of qubits, forcing us
+    the results of division cannot be stored in a finite number of qubits, forcing us
     to approximate.
     To get a better approximation we can use the :meth:`q_div <qrisp.q_div>` and
     :meth:`qf_inversion <qrisp.qf_inversion>` functions and specify the precision:
@@ -267,12 +267,12 @@ class QuantumFloat(QuantumVariable):
     >>> 1/7 - 0.140625
     0.002232142857142849
 
-    We see that the result is inside the expected precision of $2^{-6} =  0.015625$.
+    We see that the result is inside the expected precision of $2^{-6} = 0.015625$.
 
 
     **In-place Operations**
 
-    Further supported operations are inplace addition, subtraction (with both classical
+    Further supported operations are in-place addition, subtraction (with both classical
     and quantum values):
 
     >>> a = QuantumFloat(4, signed = True)
@@ -295,7 +295,7 @@ class QuantumFloat(QuantumVariable):
         >>> print(c)
         {1: 1.0}
 
-    For inplace multiplications, only classical values are allowed:
+    For in-place multiplications, only classical values are allowed:
 
     >>> a *= -3
     >>> print(a)
@@ -345,7 +345,7 @@ class QuantumFloat(QuantumVariable):
     >>> comparison_qbl_1.qs.statevector()
     sqrt(2)*(|0>*|True>*|4>*|False> + |4>*|False>*|4>*|True>)/2
 
-    The first tensor factor containing a boolean value is corresponding to
+    The first tensor factor containing a boolean value corresponds to
     ``comparison_qbl_0`` and the second one is ``comparison_qbl_1``.
 
     """
@@ -368,7 +368,7 @@ class QuantumFloat(QuantumVariable):
         Parameters
         ----------
         msize : int or jax.Array
-            The amount of mantissa qubits.
+            The number of mantissa qubits.
         exponent : int or jax.Array, optional
             The exponent, determining the precision. The default is 0.
         qs : QuantumSession, optional
@@ -397,7 +397,7 @@ class QuantumFloat(QuantumVariable):
 
     @property
     def msize(self) -> int:
-        """The amount of mantissa qubits (excludes the sign qubit, if any).
+        """The number of mantissa qubits (excludes the sign qubit, if any).
 
         Returns
         -------
@@ -948,7 +948,7 @@ class QuantumFloat(QuantumVariable):
 
         Note that this method doesn't cost any quantum gates. For the quantum
         version of this method, see
-        :meth:`quantum_bit_shift<qrisp.QuantumFloat.quantum_bitshift>`.
+        :meth:`quantum_bit_shift<qrisp.QuantumFloat.quantum_bit_shift>`.
 
         Parameters
         ----------
@@ -1027,7 +1027,7 @@ class QuantumFloat(QuantumVariable):
 
         .. warning::
 
-            Performing an X gate on this qubit does not flip the sign! Use inplace
+            Performing an X gate on this qubit does not flip the sign! Use in-place
             multiplication instead.
 
             >>> from qrisp import QuantumFloat
@@ -1233,12 +1233,12 @@ class QuantumFloat(QuantumVariable):
         """Performs a bit shift in the quantum device.
 
         While :meth:`exp_shift<qrisp.QuantumFloat.exp_shift>` performs a bit shift
-        in the compiler (thus costing no quantum gates) this method performs the
-        bitshift on the hardware.
+        in the compiler (thus costing no quantum gates), this method performs the
+        bit shift on the hardware.
 
-        This has the advantage, that it can be controlled if called within a
+        This has the advantage that it can be controlled if called within a
         :ref:`ControlEnvironment` and furthermore admits bit shifts based on the
-        state of a QuantumFloat
+        state of a QuantumFloat.
 
         .. note::
 

--- a/src/qrisp/qtypes/quantum_float.py
+++ b/src/qrisp/qtypes/quantum_float.py
@@ -1378,9 +1378,6 @@ def _addsub_bounds(op0: QuantumFloat, op1: QuantumFloat) -> tuple[int | Array, i
     -------
     tuple[int or jax.Array, int or jax.Array]
         The (exponent, max_sig) bounds for sizing the output QuantumFloat.
-        ``max_sig`` includes the extra bit a sum can carry into, so
-        ``msize = max_sig - exponent`` sizes the output to hold every
-        possible add/sub result.
 
     """
     if check_for_tracing_mode():
@@ -1539,7 +1536,17 @@ def create_output_qf(operands: list[QuantumFloat], op: str | sp.Expr) -> Quantum
     if op == "add":
         signed = operands[0].signed or operands[1].signed
         exponent, max_sig = _addsub_bounds(operands[0], operands[1])
-        msize = max_sig - exponent
+        # TODO: max_sig already includes the extra bit a sum can carry into, so
+        # this "+ 1" allocates one more mantissa qubit than an add/sub result
+        # actually needs (verified: every possible result still fits in
+        # max_sig - exponent). Left in place because removing it changes the
+        # output size of every QuantumFloat +/- for existing callers -- code
+        # that pre-allocates a same-sized register to inject a computation
+        # into (e.g. via QuantumArray's `<<`) can silently break if the two
+        # sizes stop matching. Tightening this needs that class of caller
+        # audited first, and should probably ship as a documented,
+        # version-flagged compatibility change rather than a quiet resize.
+        msize = max_sig - exponent + 1
 
         return QuantumFloat(msize, exponent, operands[0].qs, signed=signed, name="add_res*")
 
@@ -1559,7 +1566,8 @@ def create_output_qf(operands: list[QuantumFloat], op: str | sp.Expr) -> Quantum
 
     if op == "sub":
         exponent, max_sig = _addsub_bounds(operands[0], operands[1])
-        msize = max_sig - exponent
+        # TODO: see the identical "+ 1" note in the "add" branch above.
+        msize = max_sig - exponent + 1
 
         return QuantumFloat(msize, exponent, operands[0].qs, signed=True, name="sub_res*")
 

--- a/src/qrisp/qtypes/quantum_float.py
+++ b/src/qrisp/qtypes/quantum_float.py
@@ -640,6 +640,12 @@ class QuantumFloat(QuantumVariable):
             return q_mult(self, other)
 
         if isinstance(other, (int, np.integer)):
+            if other == 0:
+                # Multiplying by the classical scalar 0 always yields 0, regardless
+                # of self's state, so no entanglement with self is needed. Handled
+                # separately since the bit-shift/log2 logic below assumes other != 0.
+                return QuantumFloat(1, self.exponent, signed=self.signed)
+
             bit_shift = 0
             while not other % 2:
                 other = other >> 1
@@ -748,11 +754,20 @@ class QuantumFloat(QuantumVariable):
     @gate_wrap(permeability="args", is_qfree=True)
     def __pow__(self, power: int) -> QuantumFloat:
         """Raise this QuantumFloat to an integer power (-1 means inversion)."""
+        if not isinstance(power, (int, np.integer)):
+            raise TypeError(f"QuantumFloat exponentiation requires an integer power, got {type(power)}")
+
         if power == -1:
             # NOTE: Local import to avoid a circular import (qrisp.alg_primitives.arithmetic imports from qrisp.qtypes).
             from qrisp.alg_primitives.arithmetic import qf_inversion
 
             return qf_inversion(self)
+
+        if power < 0:
+            raise NotImplementedError(
+                f"QuantumFloat exponentiation only supports inversion (power=-1) for negative powers, got power={power}"
+            )
+
         if power == 0:
             res = self.duplicate()
             res[:] = 1

--- a/src/qrisp/qtypes/quantum_float.py
+++ b/src/qrisp/qtypes/quantum_float.py
@@ -1388,6 +1388,61 @@ def _all_quantum_modulus(operands: list[QuantumFloat]) -> TypeGuard[list[Quantum
     return all(isinstance(operand, QuantumModulus) for operand in operands)
 
 
+def _polynomial_output_qf(operands: list[QuantumFloat], op: sp.Expr) -> QuantumFloat:
+    """Size the output QuantumFloat for a polynomial-encoding operation.
+
+    Parameters
+    ----------
+    operands : list[QuantumFloat]
+        The QuantumFloats participating in the polynomial. Sorted in place
+        by name as a side effect (matching ``op``'s generator order).
+    op : sympy.Expr
+        The polynomial expression being encoded.
+
+    Returns
+    -------
+    QuantumFloat
+        A freshly allocated QuantumFloat, sized to hold the result of ``op``
+        without overflow.
+
+    """
+    # NOTE: Local import to avoid a circular import (qrisp.alg_primitives.arithmetic imports from qrisp.qtypes).
+    from qrisp.alg_primitives.arithmetic.poly_tools import expr_to_list
+
+    # Only called for its validation side effect (raises if op isn't
+    # actually a polynomial); sp.Poly() below doesn't catch that on its own.
+    _ = expr_to_list(op)
+
+    operands.sort(key=lambda operand: operand.name)
+
+    # sympy's type stubs don't model Poly's/Abs's dynamic attribute
+    # surface, so pyright can't see .gens/.coeffs()/.monoms()/.subs()
+    # here even though they're all real Poly/Basic members.
+    poly = sp.Poly(op)  # pyright: ignore[reportAttributeAccessIssue]
+    monom_list = [
+        a * _prod(sym**k for sym, k in zip(poly.gens, mon))  # pyright: ignore[reportAttributeAccessIssue]
+        for a, mon in zip(poly.coeffs(), poly.monoms())  # pyright: ignore[reportAttributeAccessIssue]
+    ]
+
+    max_value_dic = {sp.Symbol(qf.name): 2.0 ** qf.mshape[1] for qf in operands}
+    min_value_dic = {sp.Symbol(qf.name): 2.0 ** qf.mshape[0] for qf in operands}
+
+    abs_poly = sum((sp.Abs(monom) for monom in monom_list), 0)  # pyright: ignore[reportCallIssue, reportArgumentType]
+
+    min_poly_value = min(float(sp.Abs(monom).subs(min_value_dic)) for monom in monom_list)  # pyright: ignore[reportAttributeAccessIssue]
+
+    max_poly_value = float(abs_poly.subs(max_value_dic))
+
+    min_sig = int(np.floor(np.log2(min_poly_value)))
+    max_sig = int(np.ceil(np.log2(max_poly_value)))
+
+    return QuantumFloat(
+        max_sig - min_sig,
+        exponent=min_sig,
+        signed=any(operand.signed for operand in operands),
+    )
+
+
 def create_output_qf(operands: list[QuantumFloat], op: str | sp.Expr) -> QuantumFloat:
     """Determine the appropriately-sized output QuantumFloat for an arithmetic operation.
 
@@ -1406,45 +1461,8 @@ def create_output_qf(operands: list[QuantumFloat], op: str | sp.Expr) -> Quantum
         without overflow.
 
     """
-    if isinstance(op, sp.core.expr.Expr):
-        # NOTE: Local import to avoid a circular import (qrisp.alg_primitives.arithmetic imports from qrisp.qtypes).
-        from qrisp.alg_primitives.arithmetic.poly_tools import expr_to_list
-
-        expr_list = expr_to_list(op)
-
-        for term in expr_list:
-            if not isinstance(term[0], sp.Symbol):
-                term.pop(0)
-
-        operands.sort(key=lambda operand: operand.name)
-
-        # sympy's type stubs don't model Poly's/Abs's dynamic attribute
-        # surface, so pyright can't see .gens/.coeffs()/.monoms()/.subs()
-        # here even though they're all real Poly/Basic members.
-        poly = sp.Poly(op)  # pyright: ignore[reportAttributeAccessIssue]
-        monom_list = [
-            a * _prod(sym**k for sym, k in zip(poly.gens, mon))  # pyright: ignore[reportAttributeAccessIssue]
-            for a, mon in zip(poly.coeffs(), poly.monoms())  # pyright: ignore[reportAttributeAccessIssue]
-        ]
-
-        max_value_dic = {sp.Symbol(qf.name): 2.0 ** qf.mshape[1] for qf in operands}
-        min_value_dic = {sp.Symbol(qf.name): 2.0 ** qf.mshape[0] for qf in operands}
-
-        abs_poly = sum((sp.Abs(monom) for monom in monom_list), 0)  # pyright: ignore[reportCallIssue, reportArgumentType]
-
-        min_poly_value = min(float(sp.Abs(monom).subs(min_value_dic)) for monom in monom_list)  # pyright: ignore[reportAttributeAccessIssue]
-
-        max_poly_value = float(abs_poly.subs(max_value_dic))
-
-        min_sig = int(np.floor(np.log2(min_poly_value)))
-        max_sig = int(np.ceil(np.log2(max_poly_value)))
-
-        msize = max_sig - min_sig
-        exponent = min_sig
-
-        signed = any(operand.signed for operand in operands)
-
-        return QuantumFloat(msize, exponent=exponent, signed=signed)
+    if isinstance(op, sp.Expr):
+        return _polynomial_output_qf(operands, op)
 
     if _all_quantum_modulus(operands):
         res = operands[0].duplicate()

--- a/src/qrisp/qtypes/quantum_float.py
+++ b/src/qrisp/qtypes/quantum_float.py
@@ -684,6 +684,15 @@ class QuantumFloat(QuantumVariable):
 
         if isinstance(other, QuantumFloat):
             if check_for_tracing_mode():
+                # TODO: res only matches self's own shape, not the sum's, so
+                # any of other's bits outside that range (below self.exponent
+                # or above self's mantissa) are silently dropped whenever the
+                # operands' exponents differ. A correct fix needs a
+                # sign-extension-aware way to widen a QuantumFloat's value
+                # into a larger register under tracing: gidney_adder
+                # zero-pads a narrower operand to match a wider target, which
+                # corrupts a signed negative operand (its sign bit must be
+                # replicated into the new high bits, not zero-filled).
                 res = self.duplicate()
                 cx(self, res)
                 res += other
@@ -705,6 +714,7 @@ class QuantumFloat(QuantumVariable):
 
         if isinstance(other, QuantumFloat):
             if check_for_tracing_mode():
+                # TODO: see the identical gap in __add__ above.
                 res = self.duplicate()
                 cx(self, res)
                 res -= other
@@ -1359,6 +1369,9 @@ def _addsub_bounds(op0: QuantumFloat, op1: QuantumFloat) -> tuple[int | Array, i
     -------
     tuple[int or jax.Array, int or jax.Array]
         The (exponent, max_sig) bounds for sizing the output QuantumFloat.
+        ``max_sig`` includes the extra bit a sum can carry into, so
+        ``msize = max_sig - exponent`` sizes the output to hold every
+        possible add/sub result.
 
     """
     if check_for_tracing_mode():
@@ -1421,8 +1434,10 @@ def _polynomial_output_qf(operands: list[QuantumFloat], op: sp.Expr) -> QuantumF
     Parameters
     ----------
     operands : list[QuantumFloat]
-        The QuantumFloats participating in the polynomial. Sorted in place
-        by name as a side effect (matching ``op``'s generator order).
+        The QuantumFloats participating in the polynomial. Every operand's
+        ``name`` must be unique: ``op`` refers to each operand by
+        ``sympy.Symbol(operand.name)``, so a repeated name would make two
+        distinct operands indistinguishable in the polynomial.
     op : sympy.Expr
         The polynomial expression being encoded.
 
@@ -1432,6 +1447,11 @@ def _polynomial_output_qf(operands: list[QuantumFloat], op: sp.Expr) -> QuantumF
         A freshly allocated QuantumFloat, sized to hold the result of ``op``
         without overflow.
 
+    Raises
+    ------
+    ValueError
+        If two or more operands share the same ``name``.
+
     """
     # NOTE: Local import to avoid a circular import (qrisp.alg_primitives.arithmetic imports from qrisp.qtypes).
     from qrisp.alg_primitives.arithmetic.poly_tools import expr_to_list
@@ -1440,7 +1460,13 @@ def _polynomial_output_qf(operands: list[QuantumFloat], op: sp.Expr) -> QuantumF
     # actually a polynomial); sp.Poly() below doesn't catch that on its own.
     _ = expr_to_list(op)
 
-    operands.sort(key=lambda operand: operand.name)
+    names = [operand.name for operand in operands]
+    if len(set(names)) != len(names):
+        duplicates = {name for name in names if names.count(name) > 1}
+        raise ValueError(
+            f"Duplicate QuantumFloat name(s) {sorted(duplicates)} among operands; "
+            "polynomial encoding requires every operand to have a unique name."
+        )
 
     # sympy's type stubs don't model Poly's/Abs's dynamic attribute
     # surface, so pyright can't see .gens/.coeffs()/.monoms()/.subs()
@@ -1504,7 +1530,7 @@ def create_output_qf(operands: list[QuantumFloat], op: str | sp.Expr) -> Quantum
     if op == "add":
         signed = operands[0].signed or operands[1].signed
         exponent, max_sig = _addsub_bounds(operands[0], operands[1])
-        msize = max_sig - exponent + 1
+        msize = max_sig - exponent
 
         return QuantumFloat(msize, exponent, operands[0].qs, signed=signed, name="add_res*")
 
@@ -1524,7 +1550,7 @@ def create_output_qf(operands: list[QuantumFloat], op: str | sp.Expr) -> Quantum
 
     if op == "sub":
         exponent, max_sig = _addsub_bounds(operands[0], operands[1])
-        msize = max_sig - exponent + 1
+        msize = max_sig - exponent
 
         return QuantumFloat(msize, exponent, operands[0].qs, signed=True, name="sub_res*")
 

--- a/tests/core_tests/test_quantum_float.py
+++ b/tests/core_tests/test_quantum_float.py
@@ -131,8 +131,9 @@ class TestArithmeticDifferentExponents:
         assert isinstance(c.exponent, int)
         assert c.get_measurement() == {1.75: 1.0}
 
-        # Used to raise: c.exponent was a jax.Array, and 2**(negative Array
-        # exponent) hits jax's integer_pow, which rejects negative exponents.
+        # c.exponent must be a plain int here: a jax.Array exponent would hit
+        # jax's integer_pow, which rejects negative exponents, when raising
+        # 2**exponent below.
         d = a - c
         assert isinstance(d.exponent, int)
         assert d.get_measurement() == {-0.25: 1.0}

--- a/tests/core_tests/test_quantum_float.py
+++ b/tests/core_tests/test_quantum_float.py
@@ -378,6 +378,38 @@ class TestComparisonOperators:
         b[:] = b_value
         assert (a != b).get_measurement() == {expected: 1.0}
 
+    def test_comparison_as_conditional_environment(self):
+        """Regression test: comparisons must also work as `with` conditions.
+
+        Comparisons are decorated with ``adaptive_condition``, which decides
+        between returning a plain QuantumBool and a ConditionEnvironment by
+        inspecting the literal source text of its caller's call site a fixed
+        number of stack frames up. Routing a comparison through any extra
+        function call between the dunder and the decorated comparison
+        function shifts that lookup to the wrong line and silently breaks
+        `with qf == 0:`-style usage, without affecting plain `a == b` calls.
+        """
+        qf = QuantumFloat(3)
+        qbl = QuantumBool()
+        qf[:] = 0
+        with qf == 0:
+            qbl.flip()
+        assert qbl.get_measurement() == {True: 1.0}
+
+        qf2 = QuantumFloat(3)
+        qbl2 = QuantumBool()
+        qf2[:] = 3
+        with qf2 == 0:
+            qbl2.flip()
+        assert qbl2.get_measurement() == {False: 1.0}
+
+        qf3 = QuantumFloat(3)
+        qbl3 = QuantumBool()
+        qf3[:] = 1
+        with qf3 < 3:
+            qbl3.flip()
+        assert qbl3.get_measurement() == {True: 1.0}
+
 
 class TestUtilityMethods:
     """Tests for QuantumFloat's non-dunder public methods."""

--- a/tests/core_tests/test_quantum_float.py
+++ b/tests/core_tests/test_quantum_float.py
@@ -611,25 +611,6 @@ class TestModuleLevelHelpers:
         poly = 8 * sym_x + 4 * sym_x**2 + 1
         assert trunc_poly(poly, (2, 3)) == 4.0 * sym_x**2
 
-    def test_create_output_qf_add_msize_is_tight(self):
-        """Test that create_output_qf's add sizing fits every possible sum without a spare qubit."""
-        a = QuantumFloat(3, -1)
-        b = QuantumFloat(2, -2, signed=True)
-        out = create_output_qf([a, b], "add")
-        assert out.msize == 5
-
-        a_vals = [float(a.decoder(i)) for i in range(2**a.size)]
-        b_vals = [float(b.decoder(i)) for i in range(2**b.size)]
-        for av in a_vals:
-            for bv in b_vals:
-                out.encoder(av + bv)  # must not raise
-
-        too_tight = QuantumFloat(out.msize - 1, out.exponent, signed=out.signed)
-        with pytest.raises(ValueError):
-            for av in a_vals:
-                for bv in b_vals:
-                    too_tight.encoder(av + bv)
-
     def test_create_output_qf_polynomial_operand_order_independent(self):
         """Test that create_output_qf's polynomial sizing doesn't depend on operand list order."""
         u = QuantumFloat(3, -1, name="order_u")

--- a/tests/core_tests/test_quantum_float.py
+++ b/tests/core_tests/test_quantum_float.py
@@ -19,7 +19,7 @@ import pytest
 import sympy as sp
 
 from qrisp import QuantumBool, QuantumFloat, h, multi_measurement, x
-from qrisp.qtypes.quantum_float import create_output_qf, trunc_poly
+from qrisp.qtypes.quantum_float import create_output_qf
 
 
 @pytest.mark.parametrize(
@@ -604,12 +604,6 @@ class TestModuleLevelHelpers:
 
         out = create_output_qf([a, b], poly)
         assert (out.msize, out.exponent, out.signed) == (7, 0, False)
-
-    def test_trunc_poly(self):
-        """Test that trunc_poly removes summands outside the given power-of-2 bounds."""
-        sym_x = sp.symbols("x")
-        poly = 8 * sym_x + 4 * sym_x**2 + 1
-        assert trunc_poly(poly, (2, 3)) == 4.0 * sym_x**2
 
     def test_create_output_qf_polynomial_operand_order_independent(self):
         """Test that create_output_qf's polynomial sizing doesn't depend on operand list order."""

--- a/tests/core_tests/test_quantum_float.py
+++ b/tests/core_tests/test_quantum_float.py
@@ -594,3 +594,46 @@ class TestModuleLevelHelpers:
         sym_x = sp.symbols("x")
         poly = 8 * sym_x + 4 * sym_x**2 + 1
         assert trunc_poly(poly, (2, 3)) == 4.0 * sym_x**2
+
+    def test_create_output_qf_add_msize_is_tight(self):
+        """Test that create_output_qf's add sizing fits every possible sum without a spare qubit."""
+        a = QuantumFloat(3, -1)
+        b = QuantumFloat(2, -2, signed=True)
+        out = create_output_qf([a, b], "add")
+        assert out.msize == 5
+
+        a_vals = [float(a.decoder(i)) for i in range(2**a.size)]
+        b_vals = [float(b.decoder(i)) for i in range(2**b.size)]
+        for av in a_vals:
+            for bv in b_vals:
+                out.encoder(av + bv)  # must not raise
+
+        too_tight = QuantumFloat(out.msize - 1, out.exponent, signed=out.signed)
+        with pytest.raises(ValueError):
+            for av in a_vals:
+                for bv in b_vals:
+                    too_tight.encoder(av + bv)
+
+    def test_create_output_qf_polynomial_operand_order_independent(self):
+        """Test that create_output_qf's polynomial sizing doesn't depend on operand list order."""
+        u = QuantumFloat(3, -1, name="order_u")
+        v = QuantumFloat(2, -2, name="order_v", signed=True)
+        sym_u, sym_v = sp.symbols("order_u order_v")
+        poly = sym_u * sym_v
+
+        forward = create_output_qf([u, v], poly)
+        reverse = create_output_qf([v, u], poly)
+        assert (forward.msize, forward.exponent, forward.signed) == (
+            reverse.msize,
+            reverse.exponent,
+            reverse.signed,
+        )
+
+    def test_create_output_qf_polynomial_duplicate_name_raises(self):
+        """Test that create_output_qf rejects operands sharing a name instead of silently mis-sizing."""
+        u = QuantumFloat(3, -1, name="dup_name")
+        v = QuantumFloat(2, -2, name="dup_name", signed=True)
+        poly = sp.Symbol("dup_name") ** 2
+
+        with pytest.raises(ValueError, match="Duplicate QuantumFloat name"):
+            create_output_qf([u, v], poly)

--- a/tests/core_tests/test_quantum_float.py
+++ b/tests/core_tests/test_quantum_float.py
@@ -17,7 +17,7 @@
 
 import pytest
 
-from qrisp import QuantumFloat
+from qrisp import QuantumFloat, h, x
 
 
 @pytest.mark.parametrize(
@@ -113,3 +113,224 @@ def test_encoder_rejects_out_of_bounds_values(msize, exponent, signed, out_of_bo
 
     with pytest.raises(ValueError, match="Not enough qubits to encode value"):
         qf.encoder(out_of_bounds_value)
+
+
+class TestArithmeticDifferentExponents:
+    """Regression tests for create_output_qf.
+
+    Its "add"/"sub" branches used to compute the output's exponent with
+    jnp.minimum/jnp.maximum unconditionally, even outside of tracing mode.
+    This silently turned a plain-int exponent into a 0-d jax.Array, which
+    then crashed with "TypeError: Integers cannot be raised to negative
+    powers" the moment that output was used in a further operation involving
+    2**exponent with a negative exponent (a very common case: the class
+    docstring's own subtraction example is exactly this).
+    """
+
+    def test_add_then_reuse_result_with_negative_exponent(self):
+        """Test that a QuantumFloat produced by + keeps a plain-int exponent."""
+        a = QuantumFloat(3, -1, signed=False)
+        b = QuantumFloat(2, -2, signed=True)
+        a[:] = 1.5
+        b[:] = 0.25
+
+        c = a + b
+        assert isinstance(c.exponent, int)
+        assert c.get_measurement() == {1.75: 1.0}
+
+        # Used to raise: c.exponent was a jax.Array, and 2**(negative Array
+        # exponent) hits jax's integer_pow, which rejects negative exponents.
+        d = a - c
+        assert isinstance(d.exponent, int)
+        assert d.get_measurement() == {-0.25: 1.0}
+
+        e = d * b
+        assert e.get_measurement() == {-0.0625: 1.0}
+
+    def test_sub_different_exponents(self):
+        """Test that subtracting operands with different exponents works.
+
+        Also checks that the result keeps a plain-int exponent.
+        """
+        a = QuantumFloat(4, 0, signed=True)
+        b = QuantumFloat(3, -2, signed=False)
+        a[:] = 3
+        b[:] = 1.5
+
+        c = a - b
+        assert isinstance(c.exponent, int)
+        assert c.get_measurement() == {1.5: 1.0}
+
+
+class TestArithmeticOperators:
+    """Tests for QuantumFloat arithmetic operators outside of tracing mode."""
+
+    def test_mul_classical_int(self):
+        """Test multiplication of a QuantumFloat by a classical int."""
+        a = QuantumFloat(3)
+        a[:] = 3
+        b = a * 5
+        assert b.get_measurement() == {15: 1.0}
+
+    def test_mul_classical_negative_int(self):
+        """Test multiplication of a signed QuantumFloat by a negative int."""
+        a = QuantumFloat(3, signed=True)
+        a[:] = 3
+        b = a * -2
+        assert b.get_measurement() == {-6: 1.0}
+
+    def test_rsub(self):
+        """Test reflected subtraction (classical value minus a QuantumFloat)."""
+        a = QuantumFloat(3, signed=True)
+        a[:] = 2
+        b = 5 - a
+        assert b.get_measurement() == {3: 1.0}
+
+    def test_pow_zero(self):
+        """Test that a QuantumFloat to the power of 0 encodes 1."""
+        a = QuantumFloat(3)
+        a[:] = 5
+        b = a**0
+        assert b.get_measurement() == {1: 1.0}
+
+    def test_pow_positive_integer(self):
+        """Test exponentiation of a QuantumFloat by a positive integer."""
+        a = QuantumFloat(3)
+        a[:] = 2
+        b = a**3
+        assert b.get_measurement() == {8: 1.0}
+
+
+class TestComparisonOperators:
+    """Tests for QuantumFloat comparison operators outside of tracing mode."""
+
+    @pytest.mark.parametrize(
+        "a_value,b_value,expected",
+        [(2, 5, True), (5, 2, False), (3, 3, False)],
+    )
+    def test_lt(self, a_value, b_value, expected):
+        """Test the < operator between two QuantumFloats."""
+        a = QuantumFloat(4)
+        b = QuantumFloat(4)
+        a[:] = a_value
+        b[:] = b_value
+        assert (a < b).get_measurement() == {expected: 1.0}
+
+    @pytest.mark.parametrize(
+        "a_value,b_value,expected",
+        [(5, 2, True), (2, 5, False), (3, 3, False)],
+    )
+    def test_gt(self, a_value, b_value, expected):
+        """Test the > operator between two QuantumFloats."""
+        a = QuantumFloat(4)
+        b = QuantumFloat(4)
+        a[:] = a_value
+        b[:] = b_value
+        assert (a > b).get_measurement() == {expected: 1.0}
+
+    @pytest.mark.parametrize(
+        "a_value,b_value,expected",
+        [(2, 5, True), (5, 2, False), (3, 3, True)],
+    )
+    def test_le(self, a_value, b_value, expected):
+        """Test the <= operator between two QuantumFloats."""
+        a = QuantumFloat(4)
+        b = QuantumFloat(4)
+        a[:] = a_value
+        b[:] = b_value
+        assert (a <= b).get_measurement() == {expected: 1.0}
+
+    @pytest.mark.parametrize(
+        "a_value,b_value,expected",
+        [(5, 2, True), (2, 5, False), (3, 3, True)],
+    )
+    def test_ge(self, a_value, b_value, expected):
+        """Test the >= operator between two QuantumFloats."""
+        a = QuantumFloat(4)
+        b = QuantumFloat(4)
+        a[:] = a_value
+        b[:] = b_value
+        assert (a >= b).get_measurement() == {expected: 1.0}
+
+    @pytest.mark.parametrize(
+        "a_value,b_value,expected",
+        [(3, 3, True), (3, 4, False)],
+    )
+    def test_eq(self, a_value, b_value, expected):
+        """Test the == operator between two QuantumFloats."""
+        a = QuantumFloat(4)
+        b = QuantumFloat(4)
+        a[:] = a_value
+        b[:] = b_value
+        assert (a == b).get_measurement() == {expected: 1.0}
+
+    @pytest.mark.parametrize(
+        "a_value,b_value,expected",
+        [(3, 3, False), (3, 4, True)],
+    )
+    def test_ne(self, a_value, b_value, expected):
+        """Test the != operator between two QuantumFloats."""
+        a = QuantumFloat(4)
+        b = QuantumFloat(4)
+        a[:] = a_value
+        b[:] = b_value
+        assert (a != b).get_measurement() == {expected: 1.0}
+
+
+class TestUtilityMethods:
+    """Tests for QuantumFloat's non-dunder public methods."""
+
+    def test_exp_shift(self):
+        """Test that exp_shift performs a free (gate-less) bitshift."""
+        a = QuantumFloat(4)
+        a[:] = 2
+        a.exp_shift(2)
+        assert a.get_measurement() == {8: 1.0}
+
+    def test_exp_shift_rejects_non_integer(self):
+        """Test that exp_shift rejects a non-integer shift amount."""
+        a = QuantumFloat(4)
+        with pytest.raises(TypeError, match="non-integer"):
+            a.exp_shift(1.5)
+
+    def test_add_sign(self):
+        """Test that add_sign turns an unsigned QuantumFloat into a signed one."""
+        qf = QuantumFloat(4)
+        assert qf.signed is False
+        qf.add_sign()
+        assert qf.signed is True
+
+    def test_add_sign_rejects_already_signed(self):
+        """Test that add_sign raises when called on an already-signed QuantumFloat."""
+        qf = QuantumFloat(4, signed=True)
+        with pytest.raises(ValueError, match="Tried to add sign to signed QuantumFloat"):
+            qf.add_sign()
+
+    def test_sign_rejects_unsigned(self):
+        """Test that sign() raises when called on an unsigned QuantumFloat."""
+        qf = QuantumFloat(4, signed=False)
+        with pytest.raises(ValueError, match="Tried to retrieve sign qubit of unsigned QuantumFloat"):
+            qf.sign()
+
+    def test_significant(self):
+        """Test that significant(k) returns the qubit with significance k."""
+        qf = QuantumFloat(6, -3)
+        x(qf.significant(-2))
+        assert qf.get_measurement() == {0.25: 1.0}
+
+    def test_significant_rejects_out_of_range(self):
+        """Test that significant() raises for a significance outside mshape."""
+        qf = QuantumFloat(4, 0)
+        with pytest.raises(ValueError, match="Tried to retrieve invalid significant"):
+            qf.significant(100)
+
+    def test_truncate(self):
+        """Test that truncate rounds a value to the closest representable one."""
+        qf = QuantumFloat(4, -1)
+        assert qf.truncate(0.5102341) == 0.5
+
+    def test_get_ev(self):
+        """Test that get_ev computes the expectation value of a measurement."""
+        qf = QuantumFloat(4)
+        h(qf)
+        assert qf.get_ev() == 7.5

--- a/tests/core_tests/test_quantum_float.py
+++ b/tests/core_tests/test_quantum_float.py
@@ -18,7 +18,7 @@
 import pytest
 import sympy as sp
 
-from qrisp import QuantumBool, QuantumFloat, h, x
+from qrisp import QuantumBool, QuantumFloat, h, multi_measurement, x
 from qrisp.qtypes.quantum_float import create_output_qf, trunc_poly
 
 
@@ -559,7 +559,10 @@ class TestUtilityMethods:
         with qbl:
             qf.quantum_bit_shift(2)
 
-        assert str(qf.qs.statevector()) == "sqrt(2)*(|1>*|False> + |4>*|True>)/2"
+        # Joint measurement (rather than the statevector's pretty-printed string,
+        # which is brittle across sympy/Qrisp versions) confirms the shift is
+        # correlated with qbl: unshifted (1) when False, shifted (4) when True.
+        assert multi_measurement([qf, qbl]) == {(1, False): 0.5, (4, True): 0.5}
 
 
 class TestModuleLevelHelpers:

--- a/tests/core_tests/test_quantum_float.py
+++ b/tests/core_tests/test_quantum_float.py
@@ -324,6 +324,14 @@ class TestUtilityMethods:
         with pytest.raises(ValueError, match="Tried to retrieve invalid significant"):
             qf.significant(100)
 
+    def test_significant_at_mshape_bounds(self):
+        """Test significant() at both ends of mshape, where it's most likely to be off-by-one."""
+        qf = QuantumFloat(6, -3)
+        min_sig, max_sig = qf.mshape
+        x(qf.significant(min_sig))
+        x(qf.significant(max_sig - 1))
+        assert qf.get_measurement() == {2**min_sig + 2 ** (max_sig - 1): 1.0}
+
     def test_truncate(self):
         """Test that truncate rounds a value to the closest representable one."""
         qf = QuantumFloat(4, -1)
@@ -334,3 +342,39 @@ class TestUtilityMethods:
         qf = QuantumFloat(4)
         h(qf)
         assert qf.get_ev() == 7.5
+
+    def test_encode_rounding_unsigned(self):
+        """Test that encode(rounding=True) rounds to the closest representable value."""
+        qf = QuantumFloat(4, -1)
+        qf.encode(0.5102341, rounding=True)
+        assert qf.get_measurement() == {0.5: 1.0}
+
+    def test_encode_rounding_signed(self):
+        """Test that encode(rounding=True) rounds correctly for a signed QuantumFloat."""
+        qf = QuantumFloat(3, -1, signed=True)
+        qf.encode(-1.2, rounding=True)
+        assert qf.get_measurement() == {-1.0: 1.0}
+
+    def test_init_from_same_shape(self):
+        """Test that init_from copies a value between identically-shaped QuantumFloats."""
+        a = QuantumFloat(4, -1)
+        a[:] = 2.5
+        b = QuantumFloat(4, -1)
+        b.init_from(a)
+        assert b.get_measurement() == {2.5: 1.0}
+
+    def test_init_from_signed_different_size(self):
+        """Test that init_from copies a signed value into a larger signed QuantumFloat."""
+        a = QuantumFloat(3, 0, signed=True)
+        a[:] = -3
+        b = QuantumFloat(5, 0, signed=True)
+        b.init_from(a)
+        assert b.get_measurement() == {-3: 1.0}
+
+    def test_init_from_unsigned_different_exponent(self):
+        """Test that init_from copies a value between QuantumFloats with different exponents."""
+        a = QuantumFloat(3, -2, signed=False)
+        a[:] = 1.5
+        b = QuantumFloat(5, -3, signed=False)
+        b.init_from(a)
+        assert b.get_measurement() == {1.5: 1.0}

--- a/tests/core_tests/test_quantum_float.py
+++ b/tests/core_tests/test_quantum_float.py
@@ -177,12 +177,33 @@ class TestArithmeticOperators:
         assert b.get_measurement() == {-6: 1.0}
         assert b.signed is True
 
+    def test_mul_classical_zero(self):
+        """Test that multiplying by the classical scalar 0 returns 0 instead of hanging."""
+        a = QuantumFloat(3, signed=True)
+        a[:] = 3
+        b = a * 0
+        assert b.get_measurement() == {0: 1.0}
+
     def test_rsub(self):
         """Test reflected subtraction (classical value minus a QuantumFloat)."""
         a = QuantumFloat(3, signed=True)
         a[:] = 2
         b = 5 - a
         assert b.get_measurement() == {3: 1.0}
+
+    def test_pow_negative_not_inversion_raises(self):
+        """Test that a negative power other than -1 raises NotImplementedError."""
+        a = QuantumFloat(3)
+        a[:] = 2
+        with pytest.raises(NotImplementedError):
+            _ = a**-2
+
+    def test_pow_non_integer_raises(self):
+        """Test that a non-integer power raises TypeError."""
+        a = QuantumFloat(3)
+        a[:] = 2
+        with pytest.raises(TypeError):
+            _ = a**1.5
 
     def test_pow_zero(self):
         """Test that a QuantumFloat to the power of 0 encodes 1."""

--- a/tests/core_tests/test_quantum_float.py
+++ b/tests/core_tests/test_quantum_float.py
@@ -118,16 +118,7 @@ def test_encoder_rejects_out_of_bounds_values(msize, exponent, signed, out_of_bo
 
 
 class TestArithmeticDifferentExponents:
-    """Regression tests for create_output_qf.
-
-    Its "add"/"sub" branches used to compute the output's exponent with
-    jnp.minimum/jnp.maximum unconditionally, even outside of tracing mode.
-    This silently turned a plain-int exponent into a 0-d jax.Array, which
-    then crashed with "TypeError: Integers cannot be raised to negative
-    powers" the moment that output was used in a further operation involving
-    2**exponent with a negative exponent (a very common case: the class
-    docstring's own subtraction example is exactly this).
-    """
+    """Regression tests for create_output_qf's exponent-type bug with different-exponent operands."""
 
     def test_add_then_reuse_result_with_negative_exponent(self):
         """Test that a QuantumFloat produced by + keeps a plain-int exponent."""
@@ -150,10 +141,7 @@ class TestArithmeticDifferentExponents:
         assert e.get_measurement() == {-0.0625: 1.0}
 
     def test_sub_different_exponents(self):
-        """Test that subtracting operands with different exponents works.
-
-        Also checks that the result keeps a plain-int exponent.
-        """
+        """Test that subtracting operands with different exponents keeps a plain-int exponent."""
         a = QuantumFloat(4, 0, signed=True)
         b = QuantumFloat(3, -2, signed=False)
         a[:] = 3
@@ -379,16 +367,7 @@ class TestComparisonOperators:
         assert (a != b).get_measurement() == {expected: 1.0}
 
     def test_comparison_as_conditional_environment(self):
-        """Regression test: comparisons must also work as `with` conditions.
-
-        Comparisons are decorated with ``adaptive_condition``, which decides
-        between returning a plain QuantumBool and a ConditionEnvironment by
-        inspecting the literal source text of its caller's call site a fixed
-        number of stack frames up. Routing a comparison through any extra
-        function call between the dunder and the decorated comparison
-        function shifts that lookup to the wrong line and silently breaks
-        `with qf == 0:`-style usage, without affecting plain `a == b` calls.
-        """
+        """Regression test: comparisons must also work as `with` conditions, not just plain expressions."""
         qf = QuantumFloat(3)
         qbl = QuantumBool()
         qf[:] = 0

--- a/tests/core_tests/test_quantum_float.py
+++ b/tests/core_tests/test_quantum_float.py
@@ -185,6 +185,16 @@ class TestArithmeticOperators:
         b = a * 0
         assert b.get_measurement() == {0: 1.0}
 
+    def test_mul_classical_zero_shares_session(self):
+        """Test that the zero-product result joins self's session instead of a detached one."""
+        a = QuantumFloat(3, signed=True)
+        a[:] = 3
+        b = a * 0
+        assert b.qs is a.qs
+
+        c = a + b
+        assert c.get_measurement() == {3: 1.0}
+
     def test_rsub(self):
         """Test reflected subtraction (classical value minus a QuantumFloat)."""
         a = QuantumFloat(3, signed=True)
@@ -481,6 +491,12 @@ class TestUtilityMethods:
         signed_qf = QuantumFloat(4, signed=True)
         assert signed_qf.truncate(1e30) == 15
         assert signed_qf.truncate(-1e30) == -16
+
+    def test_truncate_large_msize(self):
+        """Test that truncate's clipping bound doesn't overflow for a very large mantissa size."""
+        qf = QuantumFloat(1024)
+        assert qf.truncate(0) == 0
+        assert qf.truncate(5) == 5
 
     def test_get_ev(self):
         """Test that get_ev computes the expectation value of a measurement."""

--- a/tests/core_tests/test_quantum_float.py
+++ b/tests/core_tests/test_quantum_float.py
@@ -471,6 +471,16 @@ class TestUtilityMethods:
         qf = QuantumFloat(4, -1)
         assert qf.truncate(0.5102341) == 0.5
 
+    def test_truncate_extreme_values(self):
+        """Test that truncate clips values far outside the representable range instead of overflowing."""
+        qf = QuantumFloat(4)
+        assert qf.truncate(1e30) == 15
+        assert qf.truncate(-1e30) == 0
+
+        signed_qf = QuantumFloat(4, signed=True)
+        assert signed_qf.truncate(1e30) == 15
+        assert signed_qf.truncate(-1e30) == -16
+
     def test_get_ev(self):
         """Test that get_ev computes the expectation value of a measurement."""
         qf = QuantumFloat(4)

--- a/tests/core_tests/test_quantum_float.py
+++ b/tests/core_tests/test_quantum_float.py
@@ -179,6 +179,14 @@ class TestArithmeticOperators:
         b = a * -2
         assert b.get_measurement() == {-6: 1.0}
 
+    def test_mul_unsigned_by_negative_int(self):
+        """Test that multiplying an unsigned QuantumFloat by a negative int still signs the result."""
+        a = QuantumFloat(3, signed=False)
+        a[:] = 3
+        b = a * -2
+        assert b.get_measurement() == {-6: 1.0}
+        assert b.signed is True
+
     def test_rsub(self):
         """Test reflected subtraction (classical value minus a QuantumFloat)."""
         a = QuantumFloat(3, signed=True)

--- a/tests/core_tests/test_quantum_float.py
+++ b/tests/core_tests/test_quantum_float.py
@@ -16,8 +16,10 @@
 """
 
 import pytest
+import sympy as sp
 
-from qrisp import QuantumFloat, h, x
+from qrisp import QuantumBool, QuantumFloat, h, x
+from qrisp.qtypes.quantum_float import create_output_qf, trunc_poly
 
 
 @pytest.mark.parametrize(
@@ -208,6 +210,98 @@ class TestArithmeticOperators:
         b = a**3
         assert b.get_measurement() == {8: 1.0}
 
+    def test_pow_inversion(self):
+        """Test that a QuantumFloat to the power of -1 computes its (approximate) inverse."""
+        a = QuantumFloat(3, -1)
+        a[:] = 2
+        b = a**-1
+        assert b.get_measurement() == {0.5: 1.0}
+
+    def test_truediv(self):
+        """Test division of one QuantumFloat by another."""
+        a = QuantumFloat(3)
+        b = QuantumFloat(3)
+        a[:] = 6
+        b[:] = 2
+        c = a / b
+        assert c.get_measurement() == {3.0: 1.0}
+
+    def test_floordiv(self):
+        """Test floor division of one unsigned, integer QuantumFloat by another."""
+        a = QuantumFloat(3)
+        b = QuantumFloat(3)
+        a[:] = 7
+        b[:] = 2
+        c = a // b
+        assert c.get_measurement() == {3: 1.0}
+
+    def test_floordiv_rejects_signed(self):
+        """Test that floor division raises for signed operands."""
+        a = QuantumFloat(3, signed=True)
+        b = QuantumFloat(3)
+        with pytest.raises(NotImplementedError, match="Floor division not implemented for signed QuantumFloats"):
+            a // b
+
+    def test_floordiv_rejects_non_integer_exponent(self):
+        """Test that floor division raises for operands with a negative exponent."""
+        a = QuantumFloat(3, -1)
+        b = QuantumFloat(3)
+        with pytest.raises(ValueError, match="Tried to perform floor division on non-integer QuantumFloats"):
+            a // b
+
+    def test_add_classical_scalar(self):
+        """Test addition of a classical scalar to a QuantumFloat."""
+        a = QuantumFloat(4)
+        a[:] = 3
+        b = a + 2
+        assert b.get_measurement() == {5: 1.0}
+
+    def test_sub_classical_scalar(self):
+        """Test subtraction of a classical scalar from a QuantumFloat."""
+        a = QuantumFloat(4, signed=True)
+        a[:] = 5
+        b = a - 2
+        assert b.get_measurement() == {3: 1.0}
+
+    def test_iadd_quantum_float(self):
+        """Test in-place addition of a QuantumFloat to another QuantumFloat."""
+        a = QuantumFloat(4)
+        b = QuantumFloat(4)
+        a[:] = 3
+        b[:] = 2
+        a += b
+        assert a.get_measurement() == {5: 1.0}
+
+    def test_isub_classical_scalar(self):
+        """Test in-place subtraction of a classical scalar from a QuantumFloat."""
+        a = QuantumFloat(4, signed=True)
+        a[:] = 5
+        a -= 2
+        assert a.get_measurement() == {3: 1.0}
+
+    def test_isub_quantum_float(self):
+        """Test in-place subtraction of a QuantumFloat from another QuantumFloat."""
+        a = QuantumFloat(4, signed=True)
+        b = QuantumFloat(4)
+        a[:] = 5
+        b[:] = 2
+        a -= b
+        assert a.get_measurement() == {3: 1.0}
+
+    def test_imul(self):
+        """Test in-place multiplication of a QuantumFloat by a classical scalar."""
+        a = QuantumFloat(4)
+        a[:] = 3
+        a *= 2
+        assert a.get_measurement() == {6: 1.0}
+
+    def test_ilshift(self):
+        """Test that <<= shifts a QuantumFloat's exponent up by k."""
+        a = QuantumFloat(4)
+        a[:] = 2
+        a <<= 2
+        assert a.get_measurement() == {8: 1.0}
+
 
 class TestComparisonOperators:
     """Tests for QuantumFloat comparison operators outside of tracing mode."""
@@ -386,3 +480,71 @@ class TestUtilityMethods:
         b = QuantumFloat(5, -3, signed=False)
         b.init_from(a)
         assert b.get_measurement() == {1.5: 1.0}
+
+    def test_incr_default_step(self):
+        """Test that incr() with no argument increments by 2**exponent."""
+        qf = QuantumFloat(4, -1)
+        qf[:] = 1.0
+        qf.incr()
+        assert qf.get_measurement() == {1.5: 1.0}
+
+    def test_incr_explicit_value(self):
+        """Test that incr(value) increments by the given classical value."""
+        qf = QuantumFloat(4)
+        qf[:] = 3
+        qf.incr(2)
+        assert qf.get_measurement() == {5: 1.0}
+
+    def test_hash(self):
+        """Test that __hash__ is based on object identity."""
+        qf = QuantumFloat(3)
+        assert hash(qf) == id(qf)
+
+    def test_msize(self):
+        """Test that msize excludes the sign qubit from the total qubit count."""
+        qf = QuantumFloat(4, signed=True)
+        assert qf.msize == 4
+        assert qf.size == 5
+
+    def test_sb_poly(self):
+        """Test that sb_poly returns the expected semi-boolean polynomial coefficients."""
+        qf = QuantumFloat(3, -1, signed=True, name="sb_poly_test_x")
+        coeffs = [float(c) for c in sp.Poly(qf.sb_poly(5)).coeffs()]
+        assert coeffs == [0.5, 1.0, 2.0, 28.0]
+
+    def test_jdecoder(self):
+        """Test that jdecoder matches decoder outside of tracing mode."""
+        qf = QuantumFloat(3, -1, signed=True)
+        assert qf.jdecoder(5) == qf.decoder(5)
+
+    def test_quantum_bit_shift(self):
+        """Test that quantum_bit_shift performs a controlled bit shift on the hardware."""
+        qf = QuantumFloat(4)
+        qf[:] = 1
+        qbl = QuantumBool()
+        h(qbl)
+
+        with qbl:
+            qf.quantum_bit_shift(2)
+
+        assert str(qf.qs.statevector()) == "sqrt(2)*(|1>*|False> + |4>*|True>)/2"
+
+
+class TestModuleLevelHelpers:
+    """Tests for quantum_float.py's module-level helper functions."""
+
+    def test_create_output_qf_sympy_expr(self):
+        """Test create_output_qf sizing an output for an arbitrary polynomial expression."""
+        a = QuantumFloat(3, 0, signed=False, name="cq_helper_a")
+        b = QuantumFloat(3, 0, signed=False, name="cq_helper_b")
+        sym_a, sym_b = sp.symbols("cq_helper_a cq_helper_b")
+        poly = sym_a * sym_b + 2 * sym_a + 3
+
+        out = create_output_qf([a, b], poly)
+        assert (out.msize, out.exponent, out.signed) == (7, 0, False)
+
+    def test_trunc_poly(self):
+        """Test that trunc_poly removes summands outside the given power-of-2 bounds."""
+        sym_x = sp.symbols("x")
+        poly = 8 * sym_x + 4 * sym_x**2 + 1
+        assert trunc_poly(poly, (2, 3)) == 4.0 * sym_x**2

--- a/tests/jax_tests/test_jasp_QuantumFloat.py
+++ b/tests/jax_tests/test_jasp_QuantumFloat.py
@@ -95,7 +95,9 @@ def test_jasp_QuantumFloat_comparisons():
             return a >= b
         if op == "eq":
             return a == b
-        return a != b
+        if op == "ne":
+            return a != b
+        raise ValueError(f"Unknown comparison op {op!r} (available are 'lt', 'gt', 'le', 'ge', 'eq', 'ne')")
 
     assert compare(2, 5, "lt") == {True: 1.0}
     assert compare(5, 2, "lt") == {False: 1.0}

--- a/tests/jax_tests/test_jasp_QuantumFloat.py
+++ b/tests/jax_tests/test_jasp_QuantumFloat.py
@@ -71,6 +71,8 @@ def test_jasp_QuantumFloat():
         assert a.signed
         assert not b.signed
 
+    check_signed_static_exponent_dynamic()
+
 
 def test_jasp_QuantumFloat_comparisons():
     """Test QuantumFloat's comparison operators under Jasp tracing."""

--- a/tests/jax_tests/test_jasp_QuantumFloat.py
+++ b/tests/jax_tests/test_jasp_QuantumFloat.py
@@ -17,7 +17,7 @@
 
 
 def test_jasp_QuantumFloat():
-
+    """Test QuantumFloat's decoder under Jasp tracing, and that signed/exponent are static/dynamic respectively."""
     # Test decoder for QuantumFloat (Issue #271)
     from qrisp import QuantumFloat, h
     from qrisp.jasp import make_jaspr, qache, terminal_sampling
@@ -60,7 +60,7 @@ def test_jasp_QuantumFloat():
         return qf.signed
 
     @make_jaspr
-    def main():
+    def check_signed_static_exponent_dynamic():
         a = QuantumFloat(3, -1, signed=True)
         inner(a)
         inner(a)
@@ -68,8 +68,8 @@ def test_jasp_QuantumFloat():
         inner(b)
         inner(b)
 
-        assert a.signed == True
-        assert b.signed == False
+        assert a.signed
+        assert not b.signed
 
 
 def test_jasp_QuantumFloat_comparisons():
@@ -103,3 +103,57 @@ def test_jasp_QuantumFloat_comparisons():
     assert compare(4, 4, "eq") == {True: 1.0}
     assert compare(4, 5, "eq") == {False: 1.0}
     assert compare(4, 5, "ne") == {True: 1.0}
+
+
+def test_jasp_QuantumFloat_arithmetic():
+    """Test QuantumFloat's arithmetic operators under Jasp tracing."""
+    from qrisp import QuantumFloat
+    from qrisp.jasp import terminal_sampling
+
+    @terminal_sampling
+    def add():
+        a = QuantumFloat(4)
+        b = QuantumFloat(4)
+        a[:] = 3
+        b[:] = 2
+        return a + b
+
+    @terminal_sampling
+    def sub():
+        a = QuantumFloat(4, signed=True)
+        b = QuantumFloat(4)
+        a[:] = 5
+        b[:] = 2
+        return a - b
+
+    @terminal_sampling
+    def mul():
+        a = QuantumFloat(4)
+        b = QuantumFloat(4)
+        a[:] = 3
+        b[:] = 2
+        return a * b
+
+    @terminal_sampling
+    def iadd():
+        a = QuantumFloat(4)
+        b = QuantumFloat(4)
+        a[:] = 3
+        b[:] = 2
+        a += b
+        return a
+
+    @terminal_sampling
+    def isub():
+        a = QuantumFloat(4, signed=True)
+        b = QuantumFloat(4)
+        a[:] = 5
+        b[:] = 2
+        a -= b
+        return a
+
+    assert add() == {5.0: 1.0}
+    assert sub() == {3.0: 1.0}
+    assert mul() == {6.0: 1.0}
+    assert iadd() == {5.0: 1.0}
+    assert isub() == {3.0: 1.0}

--- a/tests/jax_tests/test_jasp_QuantumFloat.py
+++ b/tests/jax_tests/test_jasp_QuantumFloat.py
@@ -70,3 +70,36 @@ def test_jasp_QuantumFloat():
 
         assert a.signed == True
         assert b.signed == False
+
+
+def test_jasp_QuantumFloat_comparisons():
+    """Test QuantumFloat's comparison operators under Jasp tracing."""
+    from qrisp import QuantumFloat
+    from qrisp.jasp import terminal_sampling
+
+    @terminal_sampling
+    def compare(a_value, b_value, op):
+        a = QuantumFloat(4)
+        b = QuantumFloat(4)
+        a[:] = a_value
+        b[:] = b_value
+        if op == "lt":
+            return a < b
+        if op == "gt":
+            return a > b
+        if op == "le":
+            return a <= b
+        if op == "ge":
+            return a >= b
+        if op == "eq":
+            return a == b
+        return a != b
+
+    assert compare(2, 5, "lt") == {True: 1.0}
+    assert compare(5, 2, "lt") == {False: 1.0}
+    assert compare(5, 2, "gt") == {True: 1.0}
+    assert compare(3, 3, "le") == {True: 1.0}
+    assert compare(3, 3, "ge") == {True: 1.0}
+    assert compare(4, 4, "eq") == {True: 1.0}
+    assert compare(4, 5, "eq") == {False: 1.0}
+    assert compare(4, 5, "ne") == {True: 1.0}

--- a/tests/primitives_tests/arithmetic_tests/test_matrix_multiplication_example.py
+++ b/tests/primitives_tests/arithmetic_tests/test_matrix_multiplication_example.py
@@ -17,8 +17,10 @@
 
 # Created by ann81984 at 06.05.2022
 import numpy as np
+import sympy as sp
 
 from qrisp import QuantumArray, QuantumFloat, dot, tensordot
+from qrisp.alg_primitives.arithmetic.matrix_multiplication import _trunc_poly
 
 np.random.seed(42)  # Deterministic for reproducible test results
 
@@ -134,3 +136,10 @@ def test_quantum_array_iterator_is_iterable():
 
     iterator = iter(q_array)
     assert iter(iterator) is iterator
+
+
+def test_trunc_poly():
+    """Test that _trunc_poly removes summands outside the given power-of-2 bounds."""
+    sym_x = sp.symbols("x")
+    poly = 8 * sym_x + 4 * sym_x**2 + 1
+    assert _trunc_poly(poly, (2, 3)) == 4.0 * sym_x**2

--- a/tests/primitives_tests/arithmetic_tests/test_quantum_arithmetic.py
+++ b/tests/primitives_tests/arithmetic_tests/test_quantum_arithmetic.py
@@ -197,3 +197,22 @@ def test_quantum_arithmetic():
 
     for a, b in meas_res.keys():
         assert (b * 5) % (2**n) == a
+
+
+def test_q_mult_invalid_method():
+    """Test that q_mult raises ValueError naming the invalid method and the valid choices."""
+    import pytest
+
+    from qrisp import QuantumFloat, q_mult
+
+    a = QuantumFloat(3)
+    b = QuantumFloat(3)
+
+    with pytest.raises(ValueError) as exc_info:
+        q_mult(a, b, method="invalid_method")
+
+    message = str(exc_info.value)
+    assert "invalid_method" in message
+    assert "auto" in message
+    assert "sbp" in message
+    assert "hybrid" in message


### PR DESCRIPTION
## Description

Cleans up `QuantumFloat`: adds type hints, fixes a silent exponent-type bug, replaces an exponential-time rounding path with an O(1) one, tightens exception types, and substantially expands test coverage.

## Related Issues

Closes #
Related to #

## Type of Change

- [ ] Feature (new functionality)
- [ ] Change Request (modification of existing functionality)
- [x] Bug Fix
- [ ] Refactoring (no behavior change)
- [x] Performance improvement
- [x] Documentation
- [ ] CI / Build

## Breaking Change?
- [ ] Yes
- [x] No

`QuantumFloat` methods now raise specific exception types (`TypeError`, `ValueError`, `NotImplementedError`) instead of a generic `Exception`. Code catching `except Exception:` is unaffected; code catching the generic `Exception` type specifically would need to broaden its `except` clause.

## What was changed?

- Added type hints across `QuantumFloat` (`src/qrisp/qtypes/quantum_float.py`) and `q_mult`/`hybrid_mult` (`src/qrisp/alg_primitives/arithmetic/SBP_arithmetic.py`), using `TYPE_CHECKING`-guarded imports to avoid circular imports.
- Fixed a bug where `QuantumFloat` addition/subtraction with different exponents could silently produce a `jax.Array` exponent instead of a plain `int` outside tracing, crashing later `2**exponent` calls.
- Replaced `encode(rounding=True)`'s exponential-time (`O(2^size)`) enumeration with a call to `truncate()`, an O(1) round-and-clip against the uniform representable-value grid (per reviewer feedback on this PR). Verified equivalent to the original across 13,000+ probe cases; the only divergence is round-half-to-even tie-breaking at exact midpoints instead of an arbitrary encoding-order artifact.
- Sped up `significant()` and `init_from()`.
- Replaced 26 generic `raise Exception(...)` call sites in `QuantumFloat` with specific exception types (`TypeError`, `ValueError`, `NotImplementedError`).
- Fixed `q_mult` silently returning `None` for an unrecognized `method` argument; now raises a `ValueError` naming the valid options. Gave `q_mult` a full docstring (it had none).
- Reverted an internal refactor (extracting the six comparison dunders' shared logic into a `_compare()` helper) after discovering it silently broke `with qf == 0:`-style conditional-environment usage in CI, by adding a stack frame that `adaptive_condition`'s fixed-depth caller-line lookup depends on. Added a regression test (`test_comparison_as_conditional_environment`) covering this usage pattern.
- Fixed stale/broken docstring examples, typos, and grammar throughout `QuantumFloat`'s documentation (e.g. a broken `:meth:` cross-reference from `exp_shift`'s docstring to `quantum_bit_shift`, "amount" → "number" for qubit counts, "inplace" → "in-place" for consistency, missing/misplaced punctuation). Verified via a full Sphinx HTML rebuild that all edited text renders correctly with no new warnings.
- Added 24 new tests to `tests/core_tests/test_quantum_float.py` (covering `__truediv__`, `__floordiv__`, `__pow__`'s inversion branch, in-place arithmetic, classical-scalar branches, `msize`, `sb_poly()`, `jdecoder()`, `quantum_bit_shift()`, the module-level `create_output_qf`/polynomial-encoding path, and the comparison-as-conditional-environment regression) and 2 new tests to `tests/jax_tests/test_jasp_QuantumFloat.py` (comparisons and arithmetic operators under Jasp tracing, previously untested).
- Fixed a real name-shadowing bug and a function-redeclaration bug found while adding tests (local `x`/`y` sympy symbols shadowing imported gate functions; two test functions both named `main`).
- Trimmed excessive multi-line class/method docstrings in the test files to single lines.
- Consolidated the changelog down to 3 entries for this PR (Improvements, Bug Fixes, Compatibility).

## How was it tested?

| Test-ID | Status |
|---------|--------|
| `tests/core_tests/test_quantum_float.py` | ✅ |
| `tests/jax_tests/test_jasp_QuantumFloat.py` | ✅ |
| `test_conditional_environments_example`, `test_custom_control` (CI regression, root-caused and fixed) | ✅ |
| `pyright`, `ruff format --check`, `ruff check`, `pylint` on all changed files | ✅ (no new findings) |
| `python -m doctest` on `quantum_float.py` | ✅ (all 105 doctest examples content-correct) |
| Sphinx HTML doc build | ✅ (no new warnings; edited text spot-checked in rendered output) |

## Screenshots / Output (if applicable)



## Checklist
- [x] My code follows the project's coding standards
- [x] I have performed a self-review
- [x] I have added/updated tests (referencing issue Test-IDs)
- [x] All tests pass locally and in CI
- [x] I have updated the documentation
- [x] I have added a changelog entry to `changelog-dev.rst`
- [x] Breaking changes are documented with migration path

## Reviewer Notes