### PR TITLE
Cuccaro adder compatibility with all possible inputs

### DIFF
--- a/documentation/source/general/changelog/changelog-dev.rst
+++ b/documentation/source/general/changelog/changelog-dev.rst
@@ -69,6 +69,15 @@ Other New Features
 Bug Fixes
 ---------
 
+* Fixed :func:`cuccaro_adder <qrisp.cuccaro_adder>` to support arbitrary
+  quantum inputs, in particular ``list[Qubit]`` and ``DynamicQubitArray``
+  targets. Previously, a classical addend with a ``list[Qubit]`` target raised
+  ``AttributeError: 'list' object has no attribute 'duplicate'``, so
+  ``QuantumModulus(..., inpl_adder=cuccaro_adder)`` failed. Classical addends
+  larger than the target register are now truncated modulo ``2**len(b)``
+  (`PR #848 <https://github.com/eclipse-qrisp/Qrisp/pull/848>`_,
+  `issue #839 <https://github.com/eclipse-qrisp/Qrisp/issues/839>`_).
+
 * Fixed the precision of :meth:`get_unitary <qrisp.QuantumCircuit.get_unitary>`.
   Unitary matrices are now computed in ``complex128`` precision, removing the
   spurious ~1e-7 off-diagonal entries that previously appeared where a

--- a/src/qrisp/alg_primitives/arithmetic/adders/adder_utilities.py
+++ b/src/qrisp/alg_primitives/arithmetic/adders/adder_utilities.py
@@ -1,0 +1,34 @@
+# ********************************************************************************
+# * Copyright (c) 2026 the Qrisp authors
+# *
+# * This program and the accompanying materials are made available under the
+# * terms of the Eclipse Public License 2.0 which is available at
+# * http://www.eclipse.org/legal/epl-2.0.
+# *
+# * This Source Code may also be made available under the following Secondary
+# * Licenses when the conditions for such availability set forth in the Eclipse
+# * Public License, v. 2.0 are satisfied: GNU General Public License, version 2
+# * with the GNU Classpath Exception which is
+# * available at https://www.gnu.org/software/classpath/license.html.
+# *
+# * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+# ********************************************************************************
+
+"""Shared helpers for all the Qrisp adder implementations."""
+
+from qrisp.circuit import Qubit
+from qrisp.core import QuantumVariable
+from qrisp.jasp import DynamicQubitArray
+
+
+def _is_quantum_register(obj):
+    """Return True if ``obj`` is a quantum register.
+
+    A quantum register is a QuantumVariable (or subclass thereof), a
+    DynamicQubitArray or a list of Qubits.
+    """
+    if isinstance(obj, (QuantumVariable, DynamicQubitArray)):
+        return True
+    if isinstance(obj, list):
+        return all(isinstance(qb, Qubit) for qb in obj)
+    return False

--- a/src/qrisp/alg_primitives/arithmetic/adders/cuccaro_adder.py
+++ b/src/qrisp/alg_primitives/arithmetic/adders/cuccaro_adder.py
@@ -70,7 +70,10 @@ def cuccaro_adder(
     TypeError
         If carry in or carry out is not of type QuantumBool or Qubit in static mode.
     ValueError
-        If the inputs are not valid quantum or classical types.
+        If the second argument is not a quantum register, i.e. if ``b`` is not a
+        QuantumVariable, DynamicQubitArray or a non-empty ``list[Qubit]``.
+    ValueError
+        If the first argument is a ``list`` that does not contain only Qubits.
 
     Returns
     -------
@@ -79,7 +82,14 @@ def cuccaro_adder(
 
     Examples
     --------
-    Static mode with both quantum inputs:
+
+    The examples below show how to use
+    :func:`~qrisp.alg_primitives.arithmetic.adders.cuccaro_adder`. Because ``a``
+    and ``b`` are generic quantum variables, the adder works with any quantum
+    type that can store a value, e.g. ``QuantumFloat``, ``QuantumVariable`` or
+    ``QuantumModulus``.
+
+    Static mode with both quantum inputs of equal size:
 
     >>> from qrisp import QuantumFloat, cuccaro_adder
     >>> a = QuantumFloat(4)
@@ -89,6 +99,131 @@ def cuccaro_adder(
     >>> cuccaro_adder(a,b)
     >>> print(b)
     {9: 1.0}
+
+    Static mode with a classical first input:
+
+    >>> from qrisp import QuantumFloat, cuccaro_adder
+    >>> b = QuantumFloat(4)
+    >>> b[:] = 3
+    >>> cuccaro_adder(5, b)
+    >>> print(b)
+    {8: 1.0}
+
+    If the classical input is larger than the second input, it is truncated
+    modulo ``2**len(b)``. Here, the 4-qubit `QuantumFloat` ``b`` can only hold
+    values from 0 to 15, so the sum value 16 cannot be represented. Since 16
+    wraps around to 0 in this `QuantumFloat`, adding 16 is equivalent to adding
+    0:
+
+    >>> b = QuantumFloat(4)
+    >>> b[:] = 5
+    >>> cuccaro_adder(16, b)
+    >>> print(b)
+    {5: 1.0}
+
+    Static mode with a quantum first input larger than the second input. The
+    first input is truncated to the size of the second input (i.e. addition is
+    performed modulo ``2**len(b)``) by slicing off its high-order qubits. No
+    qubits are added or removed, so ``a`` keeps its value and size:
+
+    >>> a = QuantumFloat(4)
+    >>> b = QuantumFloat(2)
+    >>> a[:] = 9
+    >>> b[:] = 2
+    >>> cuccaro_adder(a, b)
+    >>> print(a)
+    {9: 1.0}
+    >>> print(a.size)
+    4
+    >>> print(b)
+    {3: 1.0}
+
+    Static mode with a quantum first input smaller than the second input. The
+    first input is temporarily padded with additional (ancilla) qubits. The
+    helper ancillas are created in the ``|0>`` state and appended to ``a`` so
+    that the adder can process a register as large as ``b``. They are deleted
+    once the addition is done, so no extra qubits are left over. ``a`` itself is
+    not modified:
+
+    >>> a = QuantumFloat(2)
+    >>> b = QuantumFloat(4)
+    >>> a[:] = 3
+    >>> b[:] = 2
+    >>> cuccaro_adder(a, b)
+    >>> print(a.size)
+    2
+    >>> print(b)
+    {5: 1.0}
+
+    Lists of :class:`~qrisp.circuit.Qubit` objects are supported as well. The
+    slices ``a[:]`` and ``b[:]`` return the qubit registers of ``a`` and ``b``
+    as plain lists of Qubits, which are passed to the adder instead of the
+    QuantumFloat objects:
+
+    >>> a = QuantumFloat(5)
+    >>> b = QuantumFloat(4)
+    >>> a[:] = 10
+    >>> b[:] = 5
+    >>> cuccaro_adder(a[:], b[:])
+    >>> print(b)
+    {15: 1.0}
+
+    Addition with a carry-in and a carry-out qubit. ``c_in`` is an optional
+    carry-in bit, flipped to ``|1>`` here with ``x``, so it adds an extra 1 to
+    the sum. ``c_out`` records the overflow: it is set to ``True`` whenever the sum
+    does not fit in ``b``. The total sum is 6 + 3 + 1 = 10, which wraps around
+    in the 3-qubit ``b``, so ``b`` ends up with 10 mod 8 = 2 and ``c_out``
+    holds the overflow:
+
+    >>> from qrisp import QuantumBool, x
+    >>> b = QuantumFloat(3)
+    >>> b[:] = 6
+    >>> c_in = QuantumBool()
+    >>> x(c_in[0])
+    >>> c_out = QuantumBool()
+    >>> cuccaro_adder(3, b, c_in=c_in, c_out=c_out)
+    >>> print(b)
+    {2: 1.0}
+    >>> print(c_out)
+    {True: 1.0}
+
+    Controlled addition. ``ctrl`` is an optional control qubit, flipped to ``|1>``
+    here with ``x``. When ``ctrl`` is in the ``|1>`` state the addition is
+    applied; otherwise ``b`` stays unchanged. Here the sum 5 + 3 = 8 wraps
+    around in the 3-qubit ``b``, leaving 8 mod 8 = 0:
+
+    >>> a = QuantumFloat(5)
+    >>> b = QuantumFloat(5)
+    >>> a[:] = 3
+    >>> b[:] = 5
+    >>> ctrl = QuantumBool()
+    >>> x(ctrl[0])
+    >>> cuccaro_adder(a, b, ctrl=ctrl)
+    >>> print(b)
+    {8: 1.0}
+
+    Dynamic mode (inside a :func:`~qrisp.jasp.jaspify` decorated function):
+
+    The examples above can also be run inside a :func:`~qrisp.jasp.jaspify`
+    function. As ``b`` holds the result, ``measure`` is used to read it out. In
+    static mode ``print(b)`` already simulates and shows the outcome, so no
+    explicit measurement is needed. Inside a jaspified function, however, the
+    result is a quantum state that has to be collapsed with ``measure`` before
+    it can be returned as a classical value:
+
+    >>> from qrisp import QuantumFloat, cuccaro_adder, measure
+    >>> from qrisp.jasp import jaspify
+    >>> @jaspify
+    ... def main():
+    ...     a = QuantumFloat(4)
+    ...     b = QuantumFloat(4)
+    ...     a[:] = 4
+    ...     b[:] = 5
+    ...     cuccaro_adder(a, b)
+    ...     return measure(b)
+    >>> result = main()
+    >>> result  # result is 9 (4 + 5 = 9)
+    Array(9., dtype=float64)
 
     """
     # The second argument is required to be a (non-empty) quantum register
@@ -105,7 +240,7 @@ def cuccaro_adder(
     # convert the classical input to a quantum input
     if not _is_quantum_register(a):
         # truncate the classical value modulo 2**len(b) so that values larger than the
-        # target register are handled via modulo addition (as documented above)
+        # target register are handled via modulo addition
         a = a % (1 << jlen(b))
 
         # create a quantum variable of the same size as the other quantum input
@@ -119,7 +254,7 @@ def cuccaro_adder(
         q_a.delete()
         return
 
-    # when the inputs are of unequal length
+    # when the quantum inputs are of unequal length
     # pad the size of the input with the smaller size
     dim_a = jlen(a)
     dim_b = jlen(b)
@@ -136,6 +271,7 @@ def cuccaro_adder(
     extended_a = a[:] + extension_anc_a[:]
     a = extended_a
 
+    # redefine the dimensions of a and b after the size adjustments
     dim_a = jlen(a)
     dim_b = jlen(b)
 

--- a/src/qrisp/alg_primitives/arithmetic/adders/cuccaro_adder.py
+++ b/src/qrisp/alg_primitives/arithmetic/adders/cuccaro_adder.py
@@ -27,6 +27,130 @@ from qrisp.misc import int_encoder
 from qrisp.qtypes import QuantumBool, QuantumFloat
 
 
+def _resolve_c_in(c_in, ancilla):
+    """Resolve the carry-in qubit and apply the initial c_in-controlled cx.
+
+    The carry-in may be passed as a QuantumBool or a bare Qubit. This helper
+    normalizes it to a Qubit (raising a TypeError for any other type in static
+    mode) and then seeds the carry ancilla with the carry-in value via
+    CNOT gate. The resolved qubit is returned so the caller can
+    uncompute it after the addition.
+    """
+    if c_in is None:
+        return None
+
+    if isinstance(c_in, QuantumBool):
+        c_in = c_in[0]
+    elif not check_for_tracing_mode() and not isinstance(c_in, Qubit):
+        raise TypeError(f"c_in must be of type QuantumBool or Qubit, not {type(c_in)}")
+
+    cx(c_in, ancilla[0])
+    return c_in
+
+
+def _resolve_c_out(c_out):
+    """Return the carry-out qubit.
+
+    The carry-out may be passed as a QuantumBool or a bare Qubit. This helper
+    normalizes it to a Qubit and raises a TypeError for any other type in
+    static mode. It does not apply any gates itself.
+    """
+    if c_out is None:
+        return None
+
+    if isinstance(c_out, QuantumBool):
+        return c_out[0]
+
+    if not check_for_tracing_mode() and not isinstance(c_out, Qubit):
+        raise TypeError(f"c_out must be of type QuantumBool or Qubit, not {type(c_out)}")
+
+    return c_out
+
+
+def _apply_maj_gates(a, b, ancilla, dim_a):
+    """Apply the majority (maj) gate chain of the Cuccaro adder.
+
+    The maj gates compute the carry bits into the ``ancilla`` (reusing the
+    ``a`` qubits as scratch space) while leaving the sum bits of ``b``
+    untouched. The first few gates set up the carry at the least significant
+    bit, and the loop then propagates it upward across the remaining ``dim_a``
+    bits.
+    """
+    cx(a[0], b[0])
+    cx(a[0], ancilla[0])
+    mcx([ancilla[0], b[0]], a[0])
+
+    for i in jrange(1, dim_a):
+        cx(a[i], b[i])
+        cx(a[i], a[i - 1])
+        mcx([a[i - 1], b[i]], a[i])
+
+
+def _apply_uma_gates(a, b, ancilla, ctrl, dim_a):
+    """Apply the unmajority (uma) gate chain of the Cuccaro adder.
+
+    The uma gates run in reverse over the qubits and use the carries stored in
+    the previous phase to write the result of the addition back into ``b``.
+    There are two variants: the uncontrolled version toggles qubits with ``x``
+    to save an ancilla, while the controlled version (``ctrl`` given) replaces
+    those X gates with Toffolis controlled on ``ctrl`` so the addition only
+    happens when the control is |1>. 
+    """
+    if ctrl is None:
+        for j in jrange(dim_a - 1):
+            i = dim_a - j - 1
+
+            x(b[i])
+            cx(a[i - 1], b[i])
+            mcx([a[i - 1], b[i]], a[i])
+            x(b[i])
+            cx(a[i], a[i - 1])
+            cx(a[i], b[i])
+
+        x(b[0])
+        cx(ancilla[0], b[0])
+        mcx([ancilla[0], b[0]], a[0])
+        x(b[0])
+        cx(a[0], ancilla[0])
+        cx(a[0], b[0])
+
+    else:
+        for j in jrange(dim_a - 1):
+            i = dim_a - j - 1
+
+            mcx([a[i - 1], b[i]], a[i])
+            mcx([ctrl, a[i - 1]], b[i])
+            cx(a[i], a[i - 1])
+            cx(a[i], b[i])
+
+        mcx([ancilla[0], b[0]], a[0])
+        mcx([ctrl, ancilla[0]], b[0])
+        cx(a[0], ancilla[0])
+        cx(a[0], b[0])
+
+
+def _apply_c_out(c_out, a):
+    """Copy the final carry into the carry-out qubit.
+
+    After the maj phase the most significant carry still sits in the top ``a``
+    qubit. If a carry-out qubit was requested, this helper copies it over with
+    ``cx(a[-1], c_out)`` before the uma phase uncomputes the carries. 
+    """
+    if c_out is not None:
+        cx(a[-1], c_out)
+
+
+def _uncompute_c_in(c_in, ancilla):
+    """Uncompute the carry-in seeding from the carry ancilla.
+
+    ``_resolve_c_in`` seeded the ancilla with the carry-in value at the start
+    of the addition. After the full adder has run, the same cnot is applied
+    again to clear the ancilla so it can be safely deleted.
+    """
+    if c_in is not None:
+        cx(c_in, ancilla[0])
+
+
 @custom_control
 def cuccaro_adder(
     a: int | QuantumVariable | DynamicQubitArray | list,
@@ -82,7 +206,6 @@ def cuccaro_adder(
 
     Examples
     --------
-
     The examples below show how to use
     :func:`~qrisp.alg_primitives.arithmetic.adders.cuccaro_adder`. Because ``a``
     and ``b`` are generic quantum variables, the adder works with any quantum
@@ -240,7 +363,7 @@ def cuccaro_adder(
     # convert the classical input to a quantum input
     if not _is_quantum_register(a):
         # truncate the classical value modulo 2**len(b) so that values larger than the
-        # target register are handled via modulo addition
+        # target register are handled via modulo addition (as documented above)
         a = a % (1 << jlen(b))
 
         # create a quantum variable of the same size as the other quantum input
@@ -277,77 +400,19 @@ def cuccaro_adder(
 
     ancilla = QuantumFloat(max_size)
 
-    if c_in is not None:
-        if isinstance(c_in, QuantumBool):
-            c_in = c_in[0]
-        elif not check_for_tracing_mode() and not isinstance(c_in, Qubit):
-            raise TypeError(f"c_in must be of type QuantumBool or Qubit, not {type(c_in)}")
-        cx(c_in, ancilla[0])
+    c_in = _resolve_c_in(c_in, ancilla)
+    c_out = _resolve_c_out(c_out)
 
-    if c_out is not None:
-        if isinstance(c_out, QuantumBool):
-            ancilla2 = c_out[0]
-        elif not check_for_tracing_mode() and not isinstance(c_out, Qubit):
-            raise TypeError(f"c_out must be of type QuantumBool or Qubit, not {type(c_out)}")
-        else:
-            ancilla2 = c_out
-
-    # first maj gate application
-    cx(a[0], b[0])
-    cx(a[0], ancilla[0])
-    mcx([ancilla[0], b[0]], a[0])
-
-    # iterator maj gate application
-
-    for i in jrange(1, dim_a):
-        cx(a[i], b[i])
-        cx(a[i], a[i - 1])
-        mcx([a[i - 1], b[i]], a[i])
+    # first maj gate application + iterator maj gate application
+    _apply_maj_gates(a, b, ancilla, dim_a)
 
     # cnot
-    if c_out is not None:
-        cx(a[-1], ancilla2)
+    _apply_c_out(c_out, a)
 
-    if ctrl is None:
-        # iterator uma gate application
-        for j in jrange(dim_a - 1):
-            # reverse the iteration
-            i = dim_a - j - 1
+    # iterator + last uma gate application
+    _apply_uma_gates(a, b, ancilla, ctrl, dim_a)
 
-            x(b[i])
-            cx(a[i - 1], b[i])
-            mcx([a[i - 1], b[i]], a[i])
-            x(b[i])
-            cx(a[i], a[i - 1])
-            cx(a[i], b[i])
-
-        # last uma gate application
-        x(b[0])
-        cx(ancilla[0], b[0])
-        mcx([ancilla[0], b[0]], a[0])
-        x(b[0])
-        cx(a[0], ancilla[0])
-        cx(a[0], b[0])
-
-    else:
-        # iterator uma gate application
-        for j in jrange(dim_a - 1):
-            # reverse the iteration
-            i = dim_a - j - 1
-
-            mcx([a[i - 1], b[i]], a[i])
-            mcx([ctrl, a[i - 1]], b[i])
-            cx(a[i], a[i - 1])
-            cx(a[i], b[i])
-
-        # last uma gate application
-        mcx([ancilla[0], b[0]], a[0])
-        mcx([ctrl, ancilla[0]], b[0])
-        cx(a[0], ancilla[0])
-        cx(a[0], b[0])
-
-    if c_in is not None:
-        cx(c_in, ancilla[0])
+    _uncompute_c_in(c_in, ancilla)
 
     # delete the ancilla used for carry bits
     ancilla.delete()

--- a/src/qrisp/alg_primitives/arithmetic/adders/cuccaro_adder.py
+++ b/src/qrisp/alg_primitives/arithmetic/adders/cuccaro_adder.py
@@ -27,8 +27,11 @@ from qrisp.qtypes import QuantumBool, QuantumFloat
 
 
 def _is_quantum_register(obj):
-    """Return True if ``obj`` is a quantum register, i.e. a QuantumVariable
-    (or subclass thereof), a DynamicQubitArray or a list of Qubits."""
+    """Return True if ``obj`` is a quantum register.
+
+    A quantum register is a QuantumVariable (or subclass thereof), a
+    DynamicQubitArray or a list of Qubits.
+    """
     if isinstance(obj, (QuantumVariable, DynamicQubitArray)):
         return True
     if isinstance(obj, list):
@@ -70,6 +73,9 @@ def cuccaro_adder(
         An optional carry in value. The default is None.
     c_out : QuantumBool or Qubit, optional
         An optional carry out value. The default is None.
+    ctrl : QuantumBool, optional
+        An optional control qubit. If provided, the addition is only applied
+        when the control qubit is in the ``|1>`` state. The default is None.
 
     Raises
     ------

--- a/src/qrisp/alg_primitives/arithmetic/adders/cuccaro_adder.py
+++ b/src/qrisp/alg_primitives/arithmetic/adders/cuccaro_adder.py
@@ -94,7 +94,7 @@ def _apply_uma_gates(a, b, ancilla, ctrl, dim_a):
     There are two variants: the uncontrolled version toggles qubits with ``x``
     to save an ancilla, while the controlled version (``ctrl`` given) replaces
     those X gates with Toffolis controlled on ``ctrl`` so the addition only
-    happens when the control is |1>. 
+    happens when the control is |1>.
     """
     if ctrl is None:
         for j in jrange(dim_a - 1):
@@ -134,7 +134,7 @@ def _apply_c_out(c_out, a):
 
     After the maj phase the most significant carry still sits in the top ``a``
     qubit. If a carry-out qubit was requested, this helper copies it over with
-    ``cx(a[-1], c_out)`` before the uma phase uncomputes the carries. 
+    ``cx(a[-1], c_out)`` before the uma phase uncomputes the carries.
     """
     if c_out is not None:
         cx(a[-1], c_out)

--- a/src/qrisp/alg_primitives/arithmetic/adders/cuccaro_adder.py
+++ b/src/qrisp/alg_primitives/arithmetic/adders/cuccaro_adder.py
@@ -312,8 +312,8 @@ def cuccaro_adder(
 
     Controlled addition. ``ctrl`` is an optional control qubit, flipped to ``|1>``
     here with ``x``. When ``ctrl`` is in the ``|1>`` state the addition is
-    applied; otherwise ``b`` stays unchanged. Here the sum 5 + 3 = 8 wraps
-    around in the 3-qubit ``b``, leaving 8 mod 8 = 0:
+    applied; otherwise ``b`` stays unchanged. Here the sum 5 + 3 = 8 fits into
+    the 5-qubit ``b`` without wrap-around, so ``b`` ends up holding the sum 8:
 
     >>> a = QuantumFloat(5)
     >>> b = QuantumFloat(5)

--- a/src/qrisp/alg_primitives/arithmetic/adders/cuccaro_adder.py
+++ b/src/qrisp/alg_primitives/arithmetic/adders/cuccaro_adder.py
@@ -21,15 +21,25 @@ import jax.numpy as jnp
 from qrisp.circuit import Qubit
 from qrisp.core import QuantumVariable, cx, mcx, x
 from qrisp.environments import conjugate, custom_control
-from qrisp.jasp import check_for_tracing_mode, jlen, jrange
+from qrisp.jasp import DynamicQubitArray, check_for_tracing_mode, jlen, jrange
 from qrisp.misc import int_encoder
 from qrisp.qtypes import QuantumBool, QuantumFloat
 
 
+def _is_quantum_register(obj):
+    """Return True if ``obj`` is a quantum register, i.e. a QuantumVariable
+    (or subclass thereof), a DynamicQubitArray or a list of Qubits."""
+    if isinstance(obj, (QuantumVariable, DynamicQubitArray)):
+        return True
+    if isinstance(obj, list):
+        return all(isinstance(qb, Qubit) for qb in obj)
+    return False
+
+
 @custom_control
 def cuccaro_adder(
-    a: int | QuantumVariable,
-    b: QuantumVariable,
+    a: int | QuantumVariable | DynamicQubitArray | list,
+    b: QuantumVariable | DynamicQubitArray | list,
     c_in: QuantumBool | Qubit | None = None,
     c_out: QuantumBool | Qubit | None = None,
     ctrl: QuantumBool | None = None,
@@ -37,9 +47,10 @@ def cuccaro_adder(
     """In-place adder as introduced in https://arxiv.org/abs/quant-ph/0410184
 
     This function works in both static and dynamic modes. The allowed inputs are both quantum types or one classical
-    type and one quantum type. Note that when the first input is larger than the second input, the function will perform
-    modulo addition (relative to the size of the second input) after the first input is truncated to be the same size as
-    the second input.
+    type and one quantum type. All :ref:`QuantumTypes <QuantumTypes>` (e.g. QuantumFloat, QuantumBool, QuantumModulus,
+    ...), as well as lists of Qubits and DynamicQubitArrays, are supported as quantum inputs. Note that when the first
+    input is larger than the second input, the function will perform modulo addition (relative to the size of the second
+    input) after the first input is truncated to be the same size as the second input.
 
     The custom control implementation is based on Theorem 2.12 of https://arxiv.org/abs/2407.20167
 
@@ -51,9 +62,9 @@ def cuccaro_adder(
 
     Parameters
     ----------
-    a : int or QuantumVariable
+    a : int or QuantumVariable or list[Qubit] or DynamicQubitArray
         The value that should be added.
-    b : QuantumVariable or list[Qubit]
+    b : QuantumVariable or list[Qubit] or DynamicQubitArray
         The value that should be modified in the in-place addition.
     c_in : QuantumBool or Qubit, optional
         An optional carry in value. The default is None.
@@ -86,10 +97,25 @@ def cuccaro_adder(
     {9: 1.0}
 
     """
+    # The second argument is required to be a (non-empty) quantum register
+    if not _is_quantum_register(b) or (isinstance(b, list) and len(b) == 0):
+        raise ValueError(
+            "The second argument must be of type QuantumVariable, DynamicQubitArray or a non-empty list[Qubit]."
+        )
+
+    # A list that does not contain only Qubits is neither a valid quantum register
+    # nor a valid classical input.
+    if isinstance(a, list) and not _is_quantum_register(a):
+        raise ValueError("If the first argument is a list, it must contain only Qubits.")
+
     # convert the classical input to a quantum input
-    if not isinstance(a, QuantumVariable):
-        # create a QuantumFloat of the same size as the other quantum input
-        q_a = b.duplicate()
+    if not _is_quantum_register(a):
+        # truncate the classical value modulo 2**len(b) so that values larger than the
+        # target register are handled via modulo addition (as documented above)
+        a = a % (1 << jlen(b))
+
+        # create a quantum variable of the same size as the other quantum input
+        q_a = QuantumVariable(jlen(b))
 
         with conjugate(int_encoder)(q_a, a):
             cuccaro_adder(q_a, b, c_in=c_in, c_out=c_out, ctrl=ctrl)
@@ -99,13 +125,10 @@ def cuccaro_adder(
         q_a.delete()
         return
 
-    if not isinstance(b, QuantumVariable):
-        raise ValueError("The second argument must be of type QuantumVariable.")
-
     # when the inputs are of unequal length
     # pad the size of the input with the smaller size
-    dim_a = a.size
-    dim_b = b.size
+    dim_a = jlen(a)
+    dim_b = jlen(b)
 
     max_size = jnp.maximum(dim_a, dim_b)
 

--- a/src/qrisp/alg_primitives/arithmetic/adders/cuccaro_adder.py
+++ b/src/qrisp/alg_primitives/arithmetic/adders/cuccaro_adder.py
@@ -18,25 +18,13 @@
 
 import jax.numpy as jnp
 
+from qrisp.alg_primitives.arithmetic.adders.adder_utilities import _is_quantum_register
 from qrisp.circuit import Qubit
 from qrisp.core import QuantumVariable, cx, mcx, x
 from qrisp.environments import conjugate, custom_control
 from qrisp.jasp import DynamicQubitArray, check_for_tracing_mode, jlen, jrange
 from qrisp.misc import int_encoder
 from qrisp.qtypes import QuantumBool, QuantumFloat
-
-
-def _is_quantum_register(obj):
-    """Return True if ``obj`` is a quantum register.
-
-    A quantum register is a QuantumVariable (or subclass thereof), a
-    DynamicQubitArray or a list of Qubits.
-    """
-    if isinstance(obj, (QuantumVariable, DynamicQubitArray)):
-        return True
-    if isinstance(obj, list):
-        return all(isinstance(qb, Qubit) for qb in obj)
-    return False
 
 
 @custom_control

--- a/tests/primitives_tests/arithmetic_tests/test_cuccaro_adder.py
+++ b/tests/primitives_tests/arithmetic_tests/test_cuccaro_adder.py
@@ -16,6 +16,8 @@
 
 """Tests for the Cuccaro ripple-carry in-place adder."""
 
+import re
+
 import pytest
 
 from qrisp import (
@@ -286,11 +288,14 @@ def test_cuccaro_adder_static_invalid_inputs_raise_value_error():
     b = QuantumFloat(3)
     b[:] = 1
 
-    with pytest.raises(ValueError, match="second argument"):
+    b_msg = "The second argument must be of type QuantumVariable, DynamicQubitArray or a non-empty list[Qubit]."
+    a_msg = "If the first argument is a list, it must contain only Qubits."
+
+    with pytest.raises(ValueError, match=re.escape(b_msg)):
         cuccaro_adder(a, 7)
-    with pytest.raises(ValueError, match="second argument"):
+    with pytest.raises(ValueError, match=re.escape(b_msg)):
         cuccaro_adder(a, [])
-    with pytest.raises(ValueError, match="first argument"):
+    with pytest.raises(ValueError, match=re.escape(a_msg)):
         cuccaro_adder([1, 0], b)
 
 

--- a/tests/primitives_tests/arithmetic_tests/test_cuccaro_adder.py
+++ b/tests/primitives_tests/arithmetic_tests/test_cuccaro_adder.py
@@ -20,6 +20,7 @@ import pytest
 from qrisp import (
     QuantumBool,
     QuantumFloat,
+    QuantumModulus,
     QuantumVariable,
     boolean_simulation,
     control,
@@ -28,6 +29,7 @@ from qrisp import (
     x,
 )
 from qrisp.circuit import Qubit
+from qrisp.misc import int_encoder
 
 # ---------------------------------------------------------------------------
 # Static smoke tests — just a few representative cases with small registers
@@ -495,3 +497,339 @@ def _run_cout_ctrl_exhaustive():
 
 def test_cuccaro_adder_cout_ctrl_dynamic():
     _run_cout_ctrl_exhaustive()
+
+
+# ---------------------------------------------------------------------------
+# Type-compatibility tests.
+#
+# The in-place-adder interface (see ``inpl_adder_test``) allows ``a`` to be a
+# QuantumVariable, a list of Qubits or a classical int, and ``b`` to be a
+# QuantumVariable or a list of Qubits. In addition to QuantumFloat, all quantum
+# types (QuantumVariable, QuantumBool, QuantumModulus, ...) must be accepted as
+# inputs. These tests lock in that contract.
+#
+# See https://github.com/eclipse-qrisp/Qrisp/issues/839 (QuantumModulus passes a
+# raw list[Qubit] to the configured in-place adder).
+# ---------------------------------------------------------------------------
+
+
+def _measure_int(qv):
+    """Return the single-shot integer outcome of ``qv``.
+
+    Works regardless of the decoder of the concrete quantum type (int, bool or
+    little-endian bit string keys).
+    """
+    (key, _), = qv.get_measurement().items()
+    if isinstance(key, bool):
+        return int(key)
+    if isinstance(key, str):
+        return int(key[::-1], 2) if key else 0
+    return key
+
+
+# -- static smoke tests: list[Qubit] targets and addends --------------------
+
+
+def test_cuccaro_adder_static_smoke_classical_a_list_b():
+    """Classical a + list[Qubit] target (the addend passed by QuantumModulus)."""
+    b = QuantumFloat(3)
+    b[:] = 3
+    cuccaro_adder(5, b[:])
+    assert b.get_measurement() == {0: 1.0}  # (3 + 5) % 8
+
+
+def test_cuccaro_adder_static_smoke_quantum_a_list_b():
+    """Quantum a + list[Qubit] target."""
+    a = QuantumFloat(3)
+    a[:] = 5
+    b = QuantumFloat(3)
+    b[:] = 3
+    cuccaro_adder(a, b[:])
+    assert a.get_measurement() == {5: 1.0}
+    assert b.get_measurement() == {0: 1.0}  # (3 + 5) % 8
+
+
+def test_cuccaro_adder_static_smoke_list_a_quantum_b():
+    """list[Qubit] addend a + QuantumVariable target b."""
+    a = QuantumFloat(3)
+    a[:] = 5
+    b = QuantumFloat(3)
+    b[:] = 3
+    cuccaro_adder(a[:], b)
+    assert a.get_measurement() == {5: 1.0}
+    assert b.get_measurement() == {0: 1.0}  # (3 + 5) % 8
+
+
+def test_cuccaro_adder_static_smoke_list_a_list_b():
+    """list[Qubit] addend a + list[Qubit] target b."""
+    a = QuantumFloat(3)
+    a[:] = 5
+    b = QuantumFloat(3)
+    b[:] = 3
+    cuccaro_adder(a[:], b[:])
+    assert a.get_measurement() == {5: 1.0}
+    assert b.get_measurement() == {0: 1.0}  # (3 + 5) % 8
+
+
+def test_cuccaro_adder_static_smoke_list_unequal_sizes():
+    """list[Qubit] inputs of unequal size (truncation + extension ancillas)."""
+    a = QuantumFloat(5)
+    a[:] = 3
+    b = QuantumFloat(3)
+    b[:] = 7
+    cuccaro_adder(a[:], b[:])
+    assert b.get_measurement() == {2: 1.0}  # (7 + 3) % 8
+
+    a = QuantumFloat(3)
+    a[:] = 3
+    b = QuantumFloat(5)
+    b[:] = 7
+    cuccaro_adder(a[:], b[:])
+    assert b.get_measurement() == {10: 1.0}  # 7 + 3
+
+
+def test_cuccaro_adder_static_smoke_classical_a_larger_than_b():
+    """Classical a wider than the target register wraps modulo 2**len(b)."""
+    b = QuantumFloat(3)
+    b[:] = 5
+    cuccaro_adder(10, b)
+    assert b.get_measurement() == {7: 1.0}  # (5 + 10) % 8
+
+    b = QuantumFloat(3)
+    b[:] = 5
+    cuccaro_adder(10, b[:])
+    assert b.get_measurement() == {7: 1.0}
+
+
+def test_cuccaro_adder_static_smoke_quantum_variable():
+    """Base QuantumVariable registers as a and b."""
+    a = QuantumVariable(3)
+    b = QuantumVariable(3)
+    int_encoder(a, 5)
+    int_encoder(b, 3)
+    cuccaro_adder(a, b)
+    assert _measure_int(a) == 5
+    assert _measure_int(b) == 0  # (3 + 5) % 8
+
+    b = QuantumVariable(3)
+    int_encoder(b, 3)
+    cuccaro_adder(5, b)
+    assert _measure_int(b) == 0  # (3 + 5) % 8
+
+
+def test_cuccaro_adder_static_smoke_quantum_bool():
+    """QuantumBool (single-qubit) registers as a and b."""
+    a = QuantumBool()
+    b = QuantumBool()
+    a.flip()  # a = 1
+    b.flip()  # b = 1
+    cuccaro_adder(a, b)
+    assert b.get_measurement() == {False: 1.0}  # (1 + 1) % 2
+
+    b = QuantumBool()
+    cuccaro_adder(1, b)
+    assert b.get_measurement() == {True: 1.0}
+
+
+def test_cuccaro_adder_static_smoke_quantum_modulus():
+    """QuantumModulus registers as a and b (sum stays below the modulus)."""
+    a = QuantumModulus(13)
+    b = QuantumModulus(13)
+    a[:] = 5
+    b[:] = 3
+    cuccaro_adder(a, b)
+    assert a.get_measurement() == {5: 1.0}
+    assert b.get_measurement() == {8: 1.0}
+
+    b = QuantumModulus(13)
+    b[:] = 3
+    cuccaro_adder(5, b)
+    assert b.get_measurement() == {8: 1.0}
+
+
+def test_cuccaro_adder_static_invalid_inputs_raise_value_error():
+    """Non-quantum b and non-qubit lists are rejected with ValueError."""
+    a = QuantumFloat(3)
+    a[:] = 1
+    b = QuantumFloat(3)
+    b[:] = 1
+
+    with pytest.raises(ValueError, match="second argument"):
+        cuccaro_adder(a, 7)
+    with pytest.raises(ValueError, match="second argument"):
+        cuccaro_adder(a, [])
+    with pytest.raises(ValueError, match="first argument"):
+        cuccaro_adder([1, 0], b)
+
+
+def test_cuccaro_adder_quantum_modulus_issue_839():
+    """QuantumModulus with cuccaro_adder as inpl_adder (regression for #839).
+
+    QuantumModulus hands the configured adder a raw ``list[Qubit]`` target (the
+    auxiliary register of the Montgomery multiplication). Before the fix this
+    raised ``AttributeError: 'list' object has no attribute 'duplicate'`` while
+    the circuit was being constructed.
+    """
+    a = QuantumModulus(13, inpl_adder=cuccaro_adder)
+    a[:] = 5
+    a *= 10
+    a.qs.compile()
+
+    @boolean_simulation
+    def montgomery_multiply(N, value, factor):
+        qm = QuantumModulus(N, inpl_adder=cuccaro_adder)
+        qm[:] = value
+        qm *= factor
+        return measure(qm)
+
+    assert montgomery_multiply(13, 5, 10) == 11  # 5 * 10 % 13
+
+
+# -- dynamic (boolean_simulation) exhaustive tests --------------------------
+
+
+def test_cuccaro_adder_list_target_dynamic():
+    """Exhaustive classical-quantum and quantum-quantum addition on list[Qubit]."""
+
+    @boolean_simulation
+    def add_cq(N, j, k):
+        B = QuantumFloat(N)
+        B[:] = k
+        cuccaro_adder(j, B[:])
+        return measure(B)
+
+    @boolean_simulation
+    def add_qq_list_a(N, L, j, k):
+        A = QuantumFloat(N)
+        B = QuantumFloat(L)
+        A[:] = j
+        B[:] = k
+        cuccaro_adder(A[:], B[:])
+        return measure(A), measure(B)
+
+    for N in range(2, 5):
+        for j in range(1 << N):
+            for k in range(1 << N):
+                assert add_cq(N, j, k) == (k + j) % (1 << N)
+
+    for N in range(2, 5):
+        for L in range(2, 5):
+            for j in range(1 << N):
+                for k in range(1 << L):
+                    A, B = add_qq_list_a(N, L, j, k)
+                    assert A == j
+                    assert B == (k + j) % (1 << L)
+
+
+def test_cuccaro_adder_classical_a_wider_than_b_dynamic():
+    """Classical a wider than the target wraps modulo 2**len(b) in dynamic mode."""
+
+    @boolean_simulation
+    def add(N, j, k):
+        B = QuantumFloat(N)
+        B[:] = k
+        cuccaro_adder(j, B)
+        return measure(B)
+
+    for N in range(2, 6):
+        # sweep classical a far beyond the register width
+        for j in range(0, 1 << (N + 3)):
+            for k in range(1 << N):
+                assert add(N, j, k) == (k + j) % (1 << N)
+
+
+def test_cuccaro_adder_quantum_variable_dynamic():
+    """Base QuantumVariable registers as a and b (quantum & classical a)."""
+
+    @boolean_simulation
+    def add_qq(N, L, j, k):
+        A = QuantumVariable(N)
+        B = QuantumVariable(L)
+        int_encoder(A, j)
+        int_encoder(B, k)
+        cuccaro_adder(A, B)
+        return measure(A), measure(B)
+
+    @boolean_simulation
+    def add_cq(N, j, k):
+        B = QuantumVariable(N)
+        int_encoder(B, k)
+        cuccaro_adder(j, B)
+        return measure(B)
+
+    for N in range(2, 5):
+        for L in range(2, 5):
+            for j in range(1 << N):
+                for k in range(1 << L):
+                    A, B = add_qq(N, L, j, k)
+                    assert A == j
+                    assert B == (k + j) % (1 << L)
+
+    for N in range(2, 5):
+        for j in range(1 << N):
+            for k in range(1 << N):
+                assert add_cq(N, j, k) == (k + j) % (1 << N)
+
+
+def test_cuccaro_adder_quantum_bool_dynamic():
+    """Single-qubit QuantumBool registers as a and b."""
+
+    @boolean_simulation
+    def add_qq(j, k):
+        A = QuantumBool()
+        B = QuantumBool()
+        int_encoder(A, j)
+        int_encoder(B, k)
+        cuccaro_adder(A, B)
+        return measure(A), measure(B)
+
+    @boolean_simulation
+    def add_cq(j, k):
+        B = QuantumBool()
+        int_encoder(B, k)
+        cuccaro_adder(j, B)
+        return measure(B)
+
+    for j in range(2):
+        for k in range(2):
+            A, B = add_qq(j, k)
+            assert A == j
+            assert B == (k + j) % 2
+            assert add_cq(j, k) == (k + j) % 2
+
+
+def test_cuccaro_adder_quantum_modulus_dynamic():
+    """QuantumModulus registers as a and b.
+
+    The Cuccaro adder operates on the raw qubits, so the measurement outcome
+    corresponds to the raw modulo-2**size addition, which the QuantumModulus
+    decoder reports modulo the modulus (default Montgomery shift is 0).
+    """
+
+    @boolean_simulation
+    def add_qq(N, j, k):
+        A = QuantumModulus(N)
+        B = QuantumModulus(N)
+        A[:] = j
+        B[:] = k
+        cuccaro_adder(A, B)
+        return measure(A), measure(B)
+
+    @boolean_simulation
+    def add_cq(N, j, k):
+        B = QuantumModulus(N)
+        B[:] = k
+        cuccaro_adder(j, B)
+        return measure(B)
+
+    for j in range(13):
+        for k in range(13):
+            A, B = add_qq(13, j, k)
+            assert A == j
+            # raw addition is modulo 2**4 = 16, decoded modulo 13
+            assert B == ((j + k) % 16) % 13
+
+    for j in range(13):
+        for k in range(13):
+            assert add_cq(13, j, k) == ((j + k) % 16) % 13
+

--- a/tests/primitives_tests/arithmetic_tests/test_cuccaro_adder.py
+++ b/tests/primitives_tests/arithmetic_tests/test_cuccaro_adder.py
@@ -43,20 +43,20 @@ from qrisp.misc import int_encoder
 
 def test_cuccaro_adder_static_quantum_a():
     """Quantum a + quantum b, equal size, no optional args."""
-    a = QuantumFloat(3)
-    b = QuantumFloat(3)
+    a = QuantumFloat(4)
+    b = QuantumFloat(4)
     a[:] = 5
     b[:] = 3
     cuccaro_adder(a, b)
-    assert b.get_measurement() == {0: 1.0}  # (5 + 3) % 8
+    assert b.get_measurement() == {8: 1.0}  # 5 + 3
 
 
 def test_cuccaro_adder_static_classical_a():
     """Classical a + quantum b."""
-    b = QuantumFloat(3)
+    b = QuantumFloat(4)
     b[:] = 3
     cuccaro_adder(5, b)
-    assert b.get_measurement() == {0: 1.0}
+    assert b.get_measurement() == {8: 1.0}  # 5 + 3
 
 
 def test_cuccaro_adder_static_cin():
@@ -78,7 +78,7 @@ def test_cuccaro_adder_static_cin_qubit():
     assert isinstance(c_in, Qubit)
     x(c_in)
     cuccaro_adder(3, b, c_in=c_in)
-    assert b.get_measurement() == {6: 1.0}
+    assert b.get_measurement() == {6: 1.0}  # 2 + 3 + 1
 
 
 def test_cuccaro_adder_static_c_in_type_error():
@@ -96,20 +96,33 @@ def test_cuccaro_adder_static_cout_overflow():
     b[:] = 6
     c_out = QuantumBool()
     cuccaro_adder(3, b, c_out=c_out)
+    # 6 + 3 = 9 = 8 + 1: the 8 cannot be stored on a 3-qubit QuantumFloat,
+    # so it spills out as the carry (c_out = True) and the leftover 1 stays in b
     assert b.get_measurement() == {1: 1.0}  # (6 + 3) % 8
     assert c_out.get_measurement() == {True: 1.0}
 
 
 def test_cuccaro_adder_static_ctrl():
     """Controlled addition (ctrl kwarg)."""
-    a = QuantumFloat(3)
-    b = QuantumFloat(3)
+    a = QuantumFloat(4)
+    b = QuantumFloat(4)
     a[:] = 3
     b[:] = 5
     ctrl = QuantumBool()
     x(ctrl[0])
     cuccaro_adder(a, b, ctrl=ctrl)
-    assert b.get_measurement() == {0: 1.0}  # (5 + 3) % 8
+    assert b.get_measurement() == {8: 1.0}  # 5 + 3
+
+
+def test_cuccaro_adder_static_no_addition_ctrl():
+    """No addition when ctrl is off."""
+    a = QuantumFloat(3)
+    b = QuantumFloat(3)
+    a[:] = 3
+    b[:] = 5
+    ctrl = QuantumBool()
+    cuccaro_adder(a, b, ctrl=ctrl)
+    assert b.get_measurement() == {5: 1.0}
 
 
 def test_cuccaro_adder_static_cin_cout():
@@ -157,8 +170,8 @@ def test_cuccaro_adder_static_inputs_unmodified():
     a = QuantumFloat(5)
     b = QuantumFloat(7)
     orig_a, orig_b = a.size, b.size
-    a[:] = 3
-    b[:] = 4
+    a[:] = 13
+    b[:] = 41
     cuccaro_adder(a, b)
     assert a.size == orig_a
     assert b.size == orig_b
@@ -171,19 +184,19 @@ def test_cuccaro_adder_static_inputs_unmodified():
 @pytest.mark.parametrize("b_spec", ["variable", "list"])
 def test_cuccaro_adder_static_list_combinations(a_spec, b_spec):
     """QuantumVariable and list[Qubit] inputs in all a/b combinations."""
-    b = QuantumFloat(3)
+    b = QuantumFloat(4)
     b[:] = 3
     if a_spec == "classical":
         a_arg = 5
     else:
-        a = QuantumFloat(3)
+        a = QuantumFloat(4)
         a[:] = 5
         a_arg = a[:] if a_spec == "list" else a
     b_arg = b[:] if b_spec == "list" else b
 
     cuccaro_adder(a_arg, b_arg)
 
-    assert b.get_measurement() == {0: 1.0}  # (3 + 5) % 8
+    assert b.get_measurement() == {8: 1.0}  # 3 + 5
     if a_spec == "quantum":
         assert a.get_measurement() == {5: 1.0}
 
@@ -191,11 +204,11 @@ def test_cuccaro_adder_static_list_combinations(a_spec, b_spec):
 def test_cuccaro_adder_static_list_unequal_sizes():
     """list[Qubit] inputs of unequal size (truncation + extension ancillas)."""
     a = QuantumFloat(5)
-    a[:] = 3
-    b = QuantumFloat(3)
-    b[:] = 7
+    a[:] = 20
+    b = QuantumFloat(4)
+    b[:] = 5
     cuccaro_adder(a[:], b[:])
-    assert b.get_measurement() == {2: 1.0}  # (7 + 3) % 8
+    assert b.get_measurement() == {9: 1.0}  # 5 + (20 % 16)
 
     a = QuantumFloat(3)
     a[:] = 3
@@ -217,39 +230,33 @@ def test_cuccaro_adder_static_classical_a_larger_than_b(b_is_list):
 # -- other quantum types ------------------------------------------------------
 
 
-def _measure_int(qv):
-    """Return the single-shot integer outcome of ``qv``.
-
-    Works regardless of the decoder of the concrete quantum type (int, bool or
-    little-endian bit string keys).
-    """
-    ((key, _),) = qv.get_measurement().items()
-    if isinstance(key, bool):
-        return int(key)
-    if isinstance(key, str):
-        return int(key[::-1], 2) if key else 0
-    return key
-
-
 def test_cuccaro_adder_static_quantum_variable():
     """Base QuantumVariable registers as a and b."""
     a_val, b_val = 5, 3
-    a = QuantumVariable(3)
-    b = QuantumVariable(3)
+
+    # quantum a + quantum b: both inputs are QuantumVariables
+    a = QuantumVariable(4)
+    b = QuantumVariable(4)
     int_encoder(a, a_val)
     int_encoder(b, b_val)
     cuccaro_adder(a, b)
-    assert _measure_int(a) == a_val
-    assert _measure_int(b) == 0  # (3 + 5) % 8
+    # base QuantumVariable measurements use little-endian bit-string keys,
+    # e.g. the value 5 (binary 0101) is reported as "1010" and 8 (1000) as "0001"
+    assert a.get_measurement() == {"1010": 1.0}  # a = 5 is unchanged
+    assert b.get_measurement() == {"0001": 1.0}  # b = 3 + 5 = 8
 
-    b = QuantumVariable(3)
+    # classical a + quantum b: a_val is a plain integer, exercising the
+    # classical-input path; the result must be the same as above
+    b = QuantumVariable(4)
     int_encoder(b, b_val)
     cuccaro_adder(a_val, b)
-    assert _measure_int(b) == 0  # (3 + 5) % 8
+    assert b.get_measurement() == {"0001": 1.0}  # b = 3 + 5 = 8
 
 
 def test_cuccaro_adder_static_quantum_bool():
     """QuantumBool (single-qubit) registers as a and b."""
+    # quantum a + quantum b: a QuantumBool is always a single qubit, so
+    # 1 + 1 = 2 cannot be represented and wraps around modulo 2 to False
     a = QuantumBool()
     b = QuantumBool()
     a.flip()  # a = 1
@@ -257,6 +264,7 @@ def test_cuccaro_adder_static_quantum_bool():
     cuccaro_adder(a, b)
     assert b.get_measurement() == {False: 1.0}  # (1 + 1) % 2
 
+    # classical a + quantum b: 0 + 1 = 1, which fits on the single qubit
     b = QuantumBool()
     cuccaro_adder(1, b)
     assert b.get_measurement() == {True: 1.0}
@@ -264,18 +272,21 @@ def test_cuccaro_adder_static_quantum_bool():
 
 def test_cuccaro_adder_static_quantum_modulus():
     """QuantumModulus registers as a and b (sum stays below the modulus)."""
+    # quantum a + quantum b: 5 + 3 = 8 < 13, so the sum fits without wrap-around
     a = QuantumModulus(13)
     b = QuantumModulus(13)
     a[:] = 5
     b[:] = 3
     cuccaro_adder(a, b)
-    assert a.get_measurement() == {5: 1.0}
-    assert b.get_measurement() == {8: 1.0}
+    assert a.get_measurement() == {5: 1.0}  # a = 5 is unchanged
+    assert b.get_measurement() == {8: 1.0}  # b = 3 + 5 = 8
 
+    # classical a + quantum b: exercises the classical-input path,
+    # the result must be the same as above
     b = QuantumModulus(13)
     b[:] = 3
     cuccaro_adder(5, b)
-    assert b.get_measurement() == {8: 1.0}
+    assert b.get_measurement() == {8: 1.0}  # b = 3 + 5 = 8
 
 
 # -- input validation and issue #839 regression -------------------------------
@@ -299,18 +310,20 @@ def test_cuccaro_adder_static_invalid_inputs_raise_value_error():
         cuccaro_adder([1, 0], b)
 
 
-def test_cuccaro_adder_quantum_modulus_issue_839():
-    """QuantumModulus with cuccaro_adder as inpl_adder (regression for #839).
+def test_cuccaro_adder_quantum_modulus_multiply():
+    """QuantumModulus with cuccaro_adder as inpl_adder.
 
     QuantumModulus hands the configured adder a raw ``list[Qubit]`` target (the
-    auxiliary register of the Montgomery multiplication). Before the fix this
-    raised ``AttributeError: 'list' object has no attribute 'duplicate'`` while
-    the circuit was being constructed.
+    auxiliary register of the Montgomery multiplication), so this verifies the
+    adder works when the target is passed as a plain qubit list. The modular
+    multiplication 5 * 10 mod 13 = 11 is checked at compile time, via a static
+    measurement and via @boolean_simulation.
     """
     a = QuantumModulus(13, inpl_adder=cuccaro_adder)
     a[:] = 5
     a *= 10
     a.qs.compile()
+    assert a.get_measurement() == {11: 1.0}  # (5 * 10) % 13
 
     @boolean_simulation
     def montgomery_multiply(N, value, factor):

--- a/tests/primitives_tests/arithmetic_tests/test_cuccaro_adder.py
+++ b/tests/primitives_tests/arithmetic_tests/test_cuccaro_adder.py
@@ -1,19 +1,20 @@
-"""********************************************************************************
-* Copyright (c) 2026 the Qrisp authors
-*
-* This program and the accompanying materials are made available under the
-* terms of the Eclipse Public License 2.0 which is available at
-* http://www.eclipse.org/legal/epl-2.0.
-*
-* This Source Code may also be made available under the following Secondary
-* Licenses when the conditions for such availability set forth in the Eclipse
-* Public License, v. 2.0 are satisfied: GNU General Public License, version 2
-* with the GNU Classpath Exception which is
-* available at https://www.gnu.org/software/classpath/license.html.
-*
-* SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
-********************************************************************************
-"""
+# ********************************************************************************
+# * Copyright (c) 2026 the Qrisp authors
+# *
+# * This program and the accompanying materials are made available under the
+# * terms of the Eclipse Public License 2.0 which is available at
+# * http://www.eclipse.org/legal/epl-2.0.
+# *
+# * This Source Code may also be made available under the following Secondary
+# * Licenses when the conditions for such availability set forth in the Eclipse
+# * Public License, v. 2.0 are satisfied: GNU General Public License, version 2
+# * with the GNU Classpath Exception which is
+# * available at https://www.gnu.org/software/classpath/license.html.
+# *
+# * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+# ********************************************************************************
+
+"""Tests for the Cuccaro ripple-carry in-place adder."""
 
 import pytest
 
@@ -366,6 +367,7 @@ def _run_basic_exhaustive():
 
 
 def test_cuccaro_adder_basic_dynamic():
+    """Exhaustive quantum-quantum addition over small register sizes."""
     _run_basic_exhaustive()
 
 
@@ -381,6 +383,7 @@ def _run_cin_exhaustive():
 
 
 def test_cuccaro_adder_cin_dynamic():
+    """Exhaustive addition with a carry-in qubit."""
     _run_cin_exhaustive()
 
 
@@ -396,6 +399,7 @@ def _run_cin_qubit_exhaustive():
 
 
 def test_cuccaro_adder_cin_qubit_dynamic():
+    """Exhaustive addition with a bare Qubit carry-in."""
     _run_cin_qubit_exhaustive()
 
 
@@ -412,6 +416,7 @@ def _run_cout_exhaustive():
 
 
 def test_cuccaro_adder_cout_dynamic():
+    """Exhaustive addition capturing the carry-out overflow."""
     _run_cout_exhaustive()
 
 
@@ -428,6 +433,7 @@ def _run_cout_qubit_exhaustive():
 
 
 def test_cuccaro_adder_cout_qubit_dynamic():
+    """Exhaustive addition with a bare Qubit carry-out."""
     _run_cout_qubit_exhaustive()
 
 
@@ -445,6 +451,7 @@ def _run_cout_equal_sizes_exhaustive():
 
 
 def test_cuccaro_adder_cout_equal_sizes_dynamic():
+    """Exhaustive equal-size addition with carry-out."""
     _run_cout_equal_sizes_exhaustive()
 
 
@@ -462,6 +469,7 @@ def _run_ctrl_exhaustive():
 
 
 def test_cuccaro_adder_ctrl_dynamic():
+    """Exhaustive controlled addition via ctrl kwarg and control environment."""
     _run_ctrl_exhaustive()
 
 
@@ -479,6 +487,7 @@ def _run_ctrl_qubit_exhaustive():
 
 
 def test_cuccaro_adder_ctrl_qubit_dynamic():
+    """Exhaustive controlled addition with a bare Qubit carry-in."""
     _run_ctrl_qubit_exhaustive()
 
 
@@ -496,6 +505,7 @@ def _run_cout_ctrl_exhaustive():
 
 
 def test_cuccaro_adder_cout_ctrl_dynamic():
+    """Exhaustive addition with carry-out and control combined."""
     _run_cout_ctrl_exhaustive()
 
 
@@ -603,12 +613,13 @@ def test_cuccaro_adder_static_smoke_classical_a_larger_than_b():
 
 def test_cuccaro_adder_static_smoke_quantum_variable():
     """Base QuantumVariable registers as a and b."""
+    A_VAL, B_VAL = 5, 3
     a = QuantumVariable(3)
     b = QuantumVariable(3)
-    int_encoder(a, 5)
-    int_encoder(b, 3)
+    int_encoder(a, A_VAL)
+    int_encoder(b, B_VAL)
     cuccaro_adder(a, b)
-    assert _measure_int(a) == 5
+    assert _measure_int(a) == A_VAL
     assert _measure_int(b) == 0  # (3 + 5) % 8
 
     b = QuantumVariable(3)
@@ -682,7 +693,7 @@ def test_cuccaro_adder_quantum_modulus_issue_839():
         qm *= factor
         return measure(qm)
 
-    assert montgomery_multiply(13, 5, 10) == 11  # 5 * 10 % 13
+    assert montgomery_multiply(13, 5, 10) == (5 * 10) % 13  # 5 * 10 % 13
 
 
 # -- dynamic (boolean_simulation) exhaustive tests --------------------------

--- a/tests/primitives_tests/arithmetic_tests/test_cuccaro_adder.py
+++ b/tests/primitives_tests/arithmetic_tests/test_cuccaro_adder.py
@@ -519,7 +519,7 @@ def _measure_int(qv):
     Works regardless of the decoder of the concrete quantum type (int, bool or
     little-endian bit string keys).
     """
-    (key, _), = qv.get_measurement().items()
+    ((key, _),) = qv.get_measurement().items()
     if isinstance(key, bool):
         return int(key)
     if isinstance(key, str):
@@ -832,4 +832,3 @@ def test_cuccaro_adder_quantum_modulus_dynamic():
     for j in range(13):
         for k in range(13):
             assert add_cq(13, j, k) == ((j + k) % 16) % 13
-

--- a/tests/primitives_tests/arithmetic_tests/test_cuccaro_adder.py
+++ b/tests/primitives_tests/arithmetic_tests/test_cuccaro_adder.py
@@ -33,23 +33,23 @@ from qrisp.circuit import Qubit
 from qrisp.misc import int_encoder
 
 # ---------------------------------------------------------------------------
-# Static smoke tests — just a few representative cases with small registers
-# to catch gross regressions without the full statevector-simulation cost.
-# Exhaustive coverage lives in the boolean_simulation tests below.
+# Static smoke tests — a few representative cases with small registers to catch
+# gross regressions without the full statevector-simulation cost. Exhaustive
+# coverage lives in the boolean_simulation tests further down.
 # ---------------------------------------------------------------------------
 
 
-def test_cuccaro_adder_static_smoke_quantum_a():
+def test_cuccaro_adder_static_quantum_a():
     """Quantum a + quantum b, equal size, no optional args."""
     a = QuantumFloat(3)
     b = QuantumFloat(3)
     a[:] = 5
     b[:] = 3
     cuccaro_adder(a, b)
-    assert b.get_measurement() == {0: 1.0}  # (5+3) % 8
+    assert b.get_measurement() == {0: 1.0}  # (5 + 3) % 8
 
 
-def test_cuccaro_adder_static_smoke_classical_a():
+def test_cuccaro_adder_static_classical_a():
     """Classical a + quantum b."""
     b = QuantumFloat(3)
     b[:] = 3
@@ -57,7 +57,7 @@ def test_cuccaro_adder_static_smoke_classical_a():
     assert b.get_measurement() == {0: 1.0}
 
 
-def test_cuccaro_adder_static_smoke_cin():
+def test_cuccaro_adder_static_cin():
     """c_in with classical a."""
     b = QuantumFloat(3)
     b[:] = 2
@@ -67,7 +67,7 @@ def test_cuccaro_adder_static_smoke_cin():
     assert b.get_measurement() == {6: 1.0}  # 2 + 3 + 1
 
 
-def test_cuccaro_adder_static_smoke_cin_qubit():
+def test_cuccaro_adder_static_cin_qubit():
     """c_in of type Qubit."""
     b = QuantumFloat(3)
     b[:] = 2
@@ -76,32 +76,29 @@ def test_cuccaro_adder_static_smoke_cin_qubit():
     assert isinstance(c_in, Qubit)
     x(c_in)
     cuccaro_adder(3, b, c_in=c_in)
-    assert b.get_measurement() == {6: 1.0}  # 2 + 3 + 1
+    assert b.get_measurement() == {6: 1.0}
 
 
-def test_cuccaro_adder_static_smoke_c_in_type_error():
+def test_cuccaro_adder_static_c_in_type_error():
     """TypeError when c_in is neither QuantumBool nor Qubit."""
     b = QuantumFloat(4)
     b[:] = 3
-    with pytest.raises(TypeError, match="c_in must be of type QuantumBool or Qubit"):
-        cuccaro_adder(1, b, c_in=QuantumFloat(2))
-    with pytest.raises(TypeError, match="c_in must be of type QuantumBool or Qubit"):
-        cuccaro_adder(1, b, c_in="invalid")
-    with pytest.raises(TypeError, match="c_in must be of type QuantumBool or Qubit"):
-        cuccaro_adder(1, b, c_in=42)
+    for bad_c_in in (QuantumFloat(2), "invalid", 42):
+        with pytest.raises(TypeError, match="c_in must be of type QuantumBool or Qubit"):
+            cuccaro_adder(1, b, c_in=bad_c_in)
 
 
-def test_cuccaro_adder_static_smoke_cout_overflow():
+def test_cuccaro_adder_static_cout_overflow():
     """c_out captures overflow."""
     b = QuantumFloat(3)
     b[:] = 6
     c_out = QuantumBool()
     cuccaro_adder(3, b, c_out=c_out)
-    assert b.get_measurement() == {1: 1.0}  # (6+3) % 8
+    assert b.get_measurement() == {1: 1.0}  # (6 + 3) % 8
     assert c_out.get_measurement() == {True: 1.0}
 
 
-def test_cuccaro_adder_static_smoke_ctrl():
+def test_cuccaro_adder_static_ctrl():
     """Controlled addition (ctrl kwarg)."""
     a = QuantumFloat(3)
     b = QuantumFloat(3)
@@ -110,10 +107,10 @@ def test_cuccaro_adder_static_smoke_ctrl():
     ctrl = QuantumBool()
     x(ctrl[0])
     cuccaro_adder(a, b, ctrl=ctrl)
-    assert b.get_measurement() == {0: 1.0}  # (5+3)%8
+    assert b.get_measurement() == {0: 1.0}  # (5 + 3) % 8
 
 
-def test_cuccaro_adder_static_smoke_cin_and_cout():
+def test_cuccaro_adder_static_cin_cout():
     """c_in + c_out together."""
     b = QuantumFloat(3)
     b[:] = 6
@@ -125,7 +122,7 @@ def test_cuccaro_adder_static_smoke_cin_and_cout():
     assert c_out.get_measurement() == {True: 1.0}
 
 
-def test_cuccaro_adder_static_smoke_cin_qubit_and_cout():
+def test_cuccaro_adder_static_cin_qubit_cout():
     """c_in of type Qubit with c_out together."""
     b = QuantumFloat(3)
     b[:] = 6
@@ -139,7 +136,7 @@ def test_cuccaro_adder_static_smoke_cin_qubit_and_cout():
     assert c_out.get_measurement() == {True: 1.0}
 
 
-def test_cuccaro_adder_static_smoke_cout_and_ctrl():
+def test_cuccaro_adder_static_cout_ctrl():
     """c_out + ctrl (ctrl=on) — exercises the MAJ-phase cx(a[-1], c_out) path."""
     a = QuantumFloat(3)
     b = QuantumFloat(3)
@@ -149,11 +146,11 @@ def test_cuccaro_adder_static_smoke_cout_and_ctrl():
     ctrl = QuantumBool()
     x(ctrl[0])
     cuccaro_adder(a, b, c_out=c_out, ctrl=ctrl)
-    assert b.get_measurement() == {4: 1.0}  # (6+6)%8
+    assert b.get_measurement() == {4: 1.0}  # (6 + 6) % 8
     assert c_out.get_measurement() == {True: 1.0}
 
 
-def test_cuccaro_adder_static_smoke_inputs_unmodified():
+def test_cuccaro_adder_static_inputs_unmodified():
     """Input QuantumFloat sizes are unchanged after addition."""
     a = QuantumFloat(5)
     b = QuantumFloat(7)
@@ -165,423 +162,31 @@ def test_cuccaro_adder_static_smoke_inputs_unmodified():
     assert b.size == orig_b
 
 
-# ---------------------------------------------------------------------------
-# Fast exhaustive tests via @boolean_simulation.
-# Each helper factory captures configuration as CLOSURE variables (not function
-# parameters) so JAX treats them as compile-time constants during @jit tracing.
-# Loops live in plain Python outer functions to keep the JAX cache warm.
-# ---------------------------------------------------------------------------
+# -- list[Qubit] compatibility -----------------------------------------------
 
 
-# -- helpers that create @boolean_simulation functions for each config --------
-
-
-def _mk_add_basic():
-    """No optional args."""
-
-    @boolean_simulation
-    def add(N, L, j, k):
-        A = QuantumFloat(N)
-        B = QuantumFloat(L)
-        A[:] = j
-        B[:] = k
-        cuccaro_adder(A, B)
-        return measure(A), measure(B)
-
-    return add
-
-
-def _mk_add_cin(c_in_val):
-    """c_in_val: 0 or 1."""
-
-    @boolean_simulation
-    def add(N, L, j, k):
-        A = QuantumFloat(N)
-        B = QuantumFloat(L)
-        A[:] = j
-        B[:] = k
-        c_in = QuantumBool()
-        if c_in_val:
-            c_in.flip()
-        cuccaro_adder(A, B, c_in=c_in)
-        return measure(B)
-
-    return add
-
-
-def _mk_add_cin_qubit(c_in_val):
-    """c_in_val: 0 or 1; c_in is a bare Qubit."""
-
-    @boolean_simulation
-    def add(N, L, j, k):
-        A = QuantumFloat(N)
-        B = QuantumFloat(L)
-        A[:] = j
-        B[:] = k
-        qv = QuantumVariable(1)
-        c_in = qv[0]
-        if c_in_val:
-            x(c_in)
-        cuccaro_adder(A, B, c_in=c_in)
-        return measure(B)
-
-    return add
-
-
-def _mk_add_cout(c_in_val):
-    """c_in_val: 0 or 1; c_out always present.  Classical a."""
-
-    @boolean_simulation
-    def add(L, j, k):
-        B = QuantumFloat(L)
-        B[:] = k
-        c_in = QuantumBool()
-        if c_in_val:
-            c_in.flip()
-        c_out = QuantumBool()
-        cuccaro_adder(j, B, c_in=c_in, c_out=c_out)
-        return measure(B), measure(c_out)
-
-    return add
-
-
-def _mk_add_cout_qubit(c_in_val):
-    """c_in_val: 0 or 1; c_out always present; c_in is a bare Qubit.  Classical a."""
-
-    @boolean_simulation
-    def add(L, j, k):
-        B = QuantumFloat(L)
-        B[:] = k
-        qv = QuantumVariable(1)
-        c_in = qv[0]
-        if c_in_val:
-            x(c_in)
-        c_out = QuantumBool()
-        cuccaro_adder(j, B, c_in=c_in, c_out=c_out)
-        return measure(B), measure(c_out)
-
-    return add
-
-
-def _mk_add_cout_qq(c_in_val):
-    """c_in_val: 0 or 1; c_out always present.  Quantum a, equal sizes."""
-
-    @boolean_simulation
-    def add(L, j, k):
-        A = QuantumFloat(L)
-        B = QuantumFloat(L)
-        A[:] = j
-        B[:] = k
-        c_in = QuantumBool()
-        if c_in_val:
-            c_in.flip()
-        c_out = QuantumBool()
-        cuccaro_adder(A, B, c_in=c_in, c_out=c_out)
-        return measure(A), measure(B), measure(c_out)
-
-    return add
-
-
-def _mk_add_ctrl(c_in_val, use_kwarg):
-    """c_in_val: 0 or 1.  use_kwarg: bool — ctrl= vs with control()."""
-
-    @boolean_simulation
-    def add(N, L, j, k):
-        A = QuantumFloat(N)
-        B = QuantumFloat(L)
-        A[:] = j
-        B[:] = k
-        qbl = QuantumBool()
-        qbl.flip()  # ctrl is always |1>
-        c_in = QuantumBool()
-        if c_in_val:
-            c_in.flip()
-        if use_kwarg:
-            cuccaro_adder(A, B, c_in=c_in, ctrl=qbl)
-        else:
-            with control(qbl):
-                cuccaro_adder(A, B, c_in=c_in)
-        return measure(A), measure(B)
-
-    return add
-
-
-def _mk_add_ctrl_qubit(c_in_val, use_kwarg):
-    """c_in_val: 0 or 1; c_in is a bare Qubit.  use_kwarg: bool — ctrl= vs with control()."""
-
-    @boolean_simulation
-    def add(N, L, j, k):
-        A = QuantumFloat(N)
-        B = QuantumFloat(L)
-        A[:] = j
-        B[:] = k
-        qbl = QuantumBool()
-        qbl.flip()  # ctrl is always |1>
-        qv = QuantumVariable(1)
-        c_in = qv[0]
-        if c_in_val:
-            x(c_in)
-        if use_kwarg:
-            cuccaro_adder(A, B, c_in=c_in, ctrl=qbl)
-        else:
-            with control(qbl):
-                cuccaro_adder(A, B, c_in=c_in)
-        return measure(A), measure(B)
-
-    return add
-
-
-def _mk_add_cout_ctrl(c_in_val):
-    """c_in_val: 0 or 1.  c_out and ctrl together, ctrl is always |1>."""
-
-    @boolean_simulation
-    def add(L, j, k):
-        A = QuantumFloat(L)
-        B = QuantumFloat(L)
-        A[:] = j
-        B[:] = k
-        c_in = QuantumBool()
-        if c_in_val:
-            c_in.flip()
-        c_out = QuantumBool()
-        ctrl = QuantumBool()
-        ctrl.flip()
-        cuccaro_adder(A, B, c_in=c_in, c_out=c_out, ctrl=ctrl)
-        return measure(A), measure(B), measure(c_out)
-
-    return add
-
-
-# -- exhaustive test runners -------------------------------------------------
-
-
-def _run_basic_exhaustive():
-    add = _mk_add_basic()
-    for N in range(2, 6):
-        for L in range(2, 6):
-            for j in range(1 << N):
-                for k in range(1 << L):
-                    A, B = add(N, L, j, k)
-                    assert A == j
-                    assert B == (k + j) % (1 << L)
-
-
-def test_cuccaro_adder_basic_dynamic():
-    """Exhaustive quantum-quantum addition over small register sizes."""
-    _run_basic_exhaustive()
-
-
-def _run_cin_exhaustive():
-    for c_in_val in (0, 1):
-        add = _mk_add_cin(c_in_val)
-        for N in range(2, 6):
-            for L in range(2, 6):
-                for j in range(1 << N):
-                    for k in range(1 << L):
-                        B = add(N, L, j, k)
-                        assert B == (k + j + c_in_val) % (1 << L)
-
-
-def test_cuccaro_adder_cin_dynamic():
-    """Exhaustive addition with a carry-in qubit."""
-    _run_cin_exhaustive()
-
-
-def _run_cin_qubit_exhaustive():
-    for c_in_val in (0, 1):
-        add = _mk_add_cin_qubit(c_in_val)
-        for N in range(2, 6):
-            for L in range(2, 6):
-                for j in range(1 << N):
-                    for k in range(1 << L):
-                        B = add(N, L, j, k)
-                        assert B == (k + j + c_in_val) % (1 << L)
-
-
-def test_cuccaro_adder_cin_qubit_dynamic():
-    """Exhaustive addition with a bare Qubit carry-in."""
-    _run_cin_qubit_exhaustive()
-
-
-def _run_cout_exhaustive():
-    for c_in_val in (0, 1):
-        add = _mk_add_cout(c_in_val)
-        for L in range(2, 6):
-            for j in range(1 << L):
-                for k in range(1 << L):
-                    total = k + j + c_in_val
-                    B, cout = add(L, j, k)
-                    assert B == total % (1 << L)
-                    assert cout == (total >= (1 << L))
-
-
-def test_cuccaro_adder_cout_dynamic():
-    """Exhaustive addition capturing the carry-out overflow."""
-    _run_cout_exhaustive()
-
-
-def _run_cout_qubit_exhaustive():
-    for c_in_val in (0, 1):
-        add = _mk_add_cout_qubit(c_in_val)
-        for L in range(2, 6):
-            for j in range(1 << L):
-                for k in range(1 << L):
-                    total = k + j + c_in_val
-                    B, cout = add(L, j, k)
-                    assert B == total % (1 << L)
-                    assert cout == (total >= (1 << L))
-
-
-def test_cuccaro_adder_cout_qubit_dynamic():
-    """Exhaustive addition with a bare Qubit carry-out."""
-    _run_cout_qubit_exhaustive()
-
-
-def _run_cout_equal_sizes_exhaustive():
-    for c_in_val in (0, 1):
-        add = _mk_add_cout_qq(c_in_val)
-        for L in range(2, 6):
-            for j in range(1 << L):
-                for k in range(1 << L):
-                    total = k + j + c_in_val
-                    A_res, B_res, cout = add(L, j, k)
-                    assert A_res == j
-                    assert B_res == total % (1 << L)
-                    assert cout == (total >= (1 << L))
-
-
-def test_cuccaro_adder_cout_equal_sizes_dynamic():
-    """Exhaustive equal-size addition with carry-out."""
-    _run_cout_equal_sizes_exhaustive()
-
-
-def _run_ctrl_exhaustive():
-    for c_in_val in (0, 1):
-        for use_kwarg in (False, True):
-            add = _mk_add_ctrl(c_in_val, use_kwarg)
-            for N in range(2, 5):
-                for L in range(2, 5):
-                    for j in range(1 << N):
-                        for k in range(1 << L):
-                            A, B = add(N, L, j, k)
-                            assert A == j
-                            assert B == (k + j + c_in_val) % (1 << L)
-
-
-def test_cuccaro_adder_ctrl_dynamic():
-    """Exhaustive controlled addition via ctrl kwarg and control environment."""
-    _run_ctrl_exhaustive()
-
-
-def _run_ctrl_qubit_exhaustive():
-    for c_in_val in (0, 1):
-        for use_kwarg in (False, True):
-            add = _mk_add_ctrl_qubit(c_in_val, use_kwarg)
-            for N in range(2, 5):
-                for L in range(2, 5):
-                    for j in range(1 << N):
-                        for k in range(1 << L):
-                            A, B = add(N, L, j, k)
-                            assert A == j
-                            assert B == (k + j + c_in_val) % (1 << L)
-
-
-def test_cuccaro_adder_ctrl_qubit_dynamic():
-    """Exhaustive controlled addition with a bare Qubit carry-in."""
-    _run_ctrl_qubit_exhaustive()
-
-
-def _run_cout_ctrl_exhaustive():
-    for c_in_val in (0, 1):
-        add = _mk_add_cout_ctrl(c_in_val)
-        for L in range(2, 5):
-            for j in range(1 << L):
-                for k in range(1 << L):
-                    total = k + j + c_in_val
-                    A_res, B_res, cout = add(L, j, k)
-                    assert A_res == j
-                    assert B_res == total % (1 << L)
-                    assert cout == (total >= (1 << L))
-
-
-def test_cuccaro_adder_cout_ctrl_dynamic():
-    """Exhaustive addition with carry-out and control combined."""
-    _run_cout_ctrl_exhaustive()
-
-
-# ---------------------------------------------------------------------------
-# Type-compatibility tests.
-#
-# The in-place-adder interface (see ``inpl_adder_test``) allows ``a`` to be a
-# QuantumVariable, a list of Qubits or a classical int, and ``b`` to be a
-# QuantumVariable or a list of Qubits. In addition to QuantumFloat, all quantum
-# types (QuantumVariable, QuantumBool, QuantumModulus, ...) must be accepted as
-# inputs. These tests lock in that contract.
-#
-# See https://github.com/eclipse-qrisp/Qrisp/issues/839 (QuantumModulus passes a
-# raw list[Qubit] to the configured in-place adder).
-# ---------------------------------------------------------------------------
-
-
-def _measure_int(qv):
-    """Return the single-shot integer outcome of ``qv``.
-
-    Works regardless of the decoder of the concrete quantum type (int, bool or
-    little-endian bit string keys).
-    """
-    ((key, _),) = qv.get_measurement().items()
-    if isinstance(key, bool):
-        return int(key)
-    if isinstance(key, str):
-        return int(key[::-1], 2) if key else 0
-    return key
-
-
-# -- static smoke tests: list[Qubit] targets and addends --------------------
-
-
-def test_cuccaro_adder_static_smoke_classical_a_list_b():
-    """Classical a + list[Qubit] target (the addend passed by QuantumModulus)."""
+@pytest.mark.parametrize("a_spec", ["quantum", "classical", "list"])
+@pytest.mark.parametrize("b_spec", ["variable", "list"])
+def test_cuccaro_adder_static_list_combinations(a_spec, b_spec):
+    """QuantumVariable and list[Qubit] inputs in all a/b combinations."""
     b = QuantumFloat(3)
     b[:] = 3
-    cuccaro_adder(5, b[:])
+    if a_spec == "classical":
+        a_arg = 5
+    else:
+        a = QuantumFloat(3)
+        a[:] = 5
+        a_arg = a[:] if a_spec == "list" else a
+    b_arg = b[:] if b_spec == "list" else b
+
+    cuccaro_adder(a_arg, b_arg)
+
     assert b.get_measurement() == {0: 1.0}  # (3 + 5) % 8
+    if a_spec == "quantum":
+        assert a.get_measurement() == {5: 1.0}
 
 
-def test_cuccaro_adder_static_smoke_quantum_a_list_b():
-    """Quantum a + list[Qubit] target."""
-    a = QuantumFloat(3)
-    a[:] = 5
-    b = QuantumFloat(3)
-    b[:] = 3
-    cuccaro_adder(a, b[:])
-    assert a.get_measurement() == {5: 1.0}
-    assert b.get_measurement() == {0: 1.0}  # (3 + 5) % 8
-
-
-def test_cuccaro_adder_static_smoke_list_a_quantum_b():
-    """list[Qubit] addend a + QuantumVariable target b."""
-    a = QuantumFloat(3)
-    a[:] = 5
-    b = QuantumFloat(3)
-    b[:] = 3
-    cuccaro_adder(a[:], b)
-    assert a.get_measurement() == {5: 1.0}
-    assert b.get_measurement() == {0: 1.0}  # (3 + 5) % 8
-
-
-def test_cuccaro_adder_static_smoke_list_a_list_b():
-    """list[Qubit] addend a + list[Qubit] target b."""
-    a = QuantumFloat(3)
-    a[:] = 5
-    b = QuantumFloat(3)
-    b[:] = 3
-    cuccaro_adder(a[:], b[:])
-    assert a.get_measurement() == {5: 1.0}
-    assert b.get_measurement() == {0: 1.0}  # (3 + 5) % 8
-
-
-def test_cuccaro_adder_static_smoke_list_unequal_sizes():
+def test_cuccaro_adder_static_list_unequal_sizes():
     """list[Qubit] inputs of unequal size (truncation + extension ancillas)."""
     a = QuantumFloat(5)
     a[:] = 3
@@ -598,37 +203,50 @@ def test_cuccaro_adder_static_smoke_list_unequal_sizes():
     assert b.get_measurement() == {10: 1.0}  # 7 + 3
 
 
-def test_cuccaro_adder_static_smoke_classical_a_larger_than_b():
+@pytest.mark.parametrize("b_is_list", [False, True])
+def test_cuccaro_adder_static_classical_a_larger_than_b(b_is_list):
     """Classical a wider than the target register wraps modulo 2**len(b)."""
     b = QuantumFloat(3)
     b[:] = 5
-    cuccaro_adder(10, b)
+    cuccaro_adder(10, b[:] if b_is_list else b)
     assert b.get_measurement() == {7: 1.0}  # (5 + 10) % 8
 
-    b = QuantumFloat(3)
-    b[:] = 5
-    cuccaro_adder(10, b[:])
-    assert b.get_measurement() == {7: 1.0}
+
+# -- other quantum types ------------------------------------------------------
 
 
-def test_cuccaro_adder_static_smoke_quantum_variable():
+def _measure_int(qv):
+    """Return the single-shot integer outcome of ``qv``.
+
+    Works regardless of the decoder of the concrete quantum type (int, bool or
+    little-endian bit string keys).
+    """
+    ((key, _),) = qv.get_measurement().items()
+    if isinstance(key, bool):
+        return int(key)
+    if isinstance(key, str):
+        return int(key[::-1], 2) if key else 0
+    return key
+
+
+def test_cuccaro_adder_static_quantum_variable():
     """Base QuantumVariable registers as a and b."""
-    A_VAL, B_VAL = 5, 3
+    a_val, b_val = 5, 3
     a = QuantumVariable(3)
     b = QuantumVariable(3)
-    int_encoder(a, A_VAL)
-    int_encoder(b, B_VAL)
+    int_encoder(a, a_val)
+    int_encoder(b, b_val)
     cuccaro_adder(a, b)
-    assert _measure_int(a) == A_VAL
+    assert _measure_int(a) == a_val
     assert _measure_int(b) == 0  # (3 + 5) % 8
 
     b = QuantumVariable(3)
-    int_encoder(b, 3)
-    cuccaro_adder(5, b)
+    int_encoder(b, b_val)
+    cuccaro_adder(a_val, b)
     assert _measure_int(b) == 0  # (3 + 5) % 8
 
 
-def test_cuccaro_adder_static_smoke_quantum_bool():
+def test_cuccaro_adder_static_quantum_bool():
     """QuantumBool (single-qubit) registers as a and b."""
     a = QuantumBool()
     b = QuantumBool()
@@ -642,7 +260,7 @@ def test_cuccaro_adder_static_smoke_quantum_bool():
     assert b.get_measurement() == {True: 1.0}
 
 
-def test_cuccaro_adder_static_smoke_quantum_modulus():
+def test_cuccaro_adder_static_quantum_modulus():
     """QuantumModulus registers as a and b (sum stays below the modulus)."""
     a = QuantumModulus(13)
     b = QuantumModulus(13)
@@ -656,6 +274,9 @@ def test_cuccaro_adder_static_smoke_quantum_modulus():
     b[:] = 3
     cuccaro_adder(5, b)
     assert b.get_measurement() == {8: 1.0}
+
+
+# -- input validation and issue #839 regression -------------------------------
 
 
 def test_cuccaro_adder_static_invalid_inputs_raise_value_error():
@@ -693,153 +314,295 @@ def test_cuccaro_adder_quantum_modulus_issue_839():
         qm *= factor
         return measure(qm)
 
-    assert montgomery_multiply(13, 5, 10) == (5 * 10) % 13  # 5 * 10 % 13
+    assert montgomery_multiply(13, 5, 10) == (5 * 10) % 13
 
 
-# -- dynamic (boolean_simulation) exhaustive tests --------------------------
+# ---------------------------------------------------------------------------
+# Exhaustive tests via @boolean_simulation.
+#
+# Configuration is captured as CLOSURE variables (not function parameters) so
+# JAX treats them as compile-time constants during tracing. Sweeps run in plain
+# Python outer functions to keep the JAX cache warm.
+# ---------------------------------------------------------------------------
 
 
-def test_cuccaro_adder_list_target_dynamic():
-    """Exhaustive classical-quantum and quantum-quantum addition on list[Qubit]."""
+def _mk_add(inputs, c_in_kind=None, c_out=False, ctrl_kind=None, c_in_val=0):
+    """Factory for a ``@boolean_simulation`` ``cuccaro_adder`` wrapper.
 
-    @boolean_simulation
-    def add_cq(N, j, k):
-        B = QuantumFloat(N)
-        B[:] = k
-        cuccaro_adder(j, B[:])
-        return measure(B)
-
-    @boolean_simulation
-    def add_qq_list_a(N, L, j, k):
-        A = QuantumFloat(N)
-        B = QuantumFloat(L)
-        A[:] = j
-        B[:] = k
-        cuccaro_adder(A[:], B[:])
-        return measure(A), measure(B)
-
-    for N in range(2, 5):
-        for j in range(1 << N):
-            for k in range(1 << N):
-                assert add_cq(N, j, k) == (k + j) % (1 << N)
-
-    for N in range(2, 5):
-        for L in range(2, 5):
-            for j in range(1 << N):
-                for k in range(1 << L):
-                    A, B = add_qq_list_a(N, L, j, k)
-                    assert A == j
-                    assert B == (k + j) % (1 << L)
-
-
-def test_cuccaro_adder_classical_a_wider_than_b_dynamic():
-    """Classical a wider than the target wraps modulo 2**len(b) in dynamic mode."""
-
-    @boolean_simulation
-    def add(N, j, k):
-        B = QuantumFloat(N)
-        B[:] = k
-        cuccaro_adder(j, B)
-        return measure(B)
-
-    for N in range(2, 6):
-        # sweep classical a far beyond the register width
-        for j in range(0, 1 << (N + 3)):
-            for k in range(1 << N):
-                assert add(N, j, k) == (k + j) % (1 << N)
-
-
-def test_cuccaro_adder_quantum_variable_dynamic():
-    """Base QuantumVariable registers as a and b (quantum & classical a)."""
-
-    @boolean_simulation
-    def add_qq(N, L, j, k):
-        A = QuantumVariable(N)
-        B = QuantumVariable(L)
-        int_encoder(A, j)
-        int_encoder(B, k)
-        cuccaro_adder(A, B)
-        return measure(A), measure(B)
-
-    @boolean_simulation
-    def add_cq(N, j, k):
-        B = QuantumVariable(N)
-        int_encoder(B, k)
-        cuccaro_adder(j, B)
-        return measure(B)
-
-    for N in range(2, 5):
-        for L in range(2, 5):
-            for j in range(1 << N):
-                for k in range(1 << L):
-                    A, B = add_qq(N, L, j, k)
-                    assert A == j
-                    assert B == (k + j) % (1 << L)
-
-    for N in range(2, 5):
-        for j in range(1 << N):
-            for k in range(1 << N):
-                assert add_cq(N, j, k) == (k + j) % (1 << N)
-
-
-def test_cuccaro_adder_quantum_bool_dynamic():
-    """Single-qubit QuantumBool registers as a and b."""
-
-    @boolean_simulation
-    def add_qq(j, k):
-        A = QuantumBool()
-        B = QuantumBool()
-        int_encoder(A, j)
-        int_encoder(B, k)
-        cuccaro_adder(A, B)
-        return measure(A), measure(B)
-
-    @boolean_simulation
-    def add_cq(j, k):
-        B = QuantumBool()
-        int_encoder(B, k)
-        cuccaro_adder(j, B)
-        return measure(B)
-
-    for j in range(2):
-        for k in range(2):
-            A, B = add_qq(j, k)
-            assert A == j
-            assert B == (k + j) % 2
-            assert add_cq(j, k) == (k + j) % 2
-
-
-def test_cuccaro_adder_quantum_modulus_dynamic():
-    """QuantumModulus registers as a and b.
-
-    The Cuccaro adder operates on the raw qubits, so the measurement outcome
-    corresponds to the raw modulo-2**size addition, which the QuantumModulus
-    decoder reports modulo the modulus (default Montgomery shift is 0).
+    - inputs: (a_kind, b_kind), with a_kind in {"quantum", "classical", "list"}
+      and b_kind in {"variable", "list"}.
+    - c_in_kind: None | "qbool" | "qubit" — optional carry-in.
+    - c_out: add a carry-out register.
+    - ctrl_kind: None | "kwarg" | "env" — optional control, via ``ctrl=`` or
+      ``with control()``.
+    - c_in_val: value (0/1) of the carry-in.
     """
+    a_kind, b_kind = inputs
+
+    def build_c_in():
+        if c_in_kind == "qubit":
+            c_in = QuantumVariable(1)[0]
+            if c_in_val:
+                x(c_in)
+        else:
+            c_in = QuantumBool()
+            if c_in_val:
+                c_in.flip()
+        return c_in
+
+    def apply(a_arg, b_arg, kwargs):
+        if ctrl_kind is None:
+            cuccaro_adder(a_arg, b_arg, **kwargs)
+        else:
+            qbl = QuantumBool()
+            qbl.flip()  # ctrl is always |1>
+            if ctrl_kind == "kwarg":
+                cuccaro_adder(a_arg, b_arg, ctrl=qbl, **kwargs)
+            else:
+                with control(qbl):
+                    cuccaro_adder(a_arg, b_arg, **kwargs)
 
     @boolean_simulation
-    def add_qq(N, j, k):
-        A = QuantumModulus(N)
-        B = QuantumModulus(N)
-        A[:] = j
+    def add(N, L, j, k):
+        B = QuantumFloat(L)
         B[:] = k
-        cuccaro_adder(A, B)
-        return measure(A), measure(B)
+        b_arg = B[:] if b_kind == "list" else B
+
+        if a_kind == "classical":
+            a_arg = j
+        else:
+            A = QuantumFloat(N)
+            A[:] = j
+            a_arg = A[:] if a_kind == "list" else A
+
+        kwargs = {}
+        if c_in_kind is not None:
+            kwargs["c_in"] = build_c_in()
+        if c_out:
+            c_out_qb = QuantumBool()
+            kwargs["c_out"] = c_out_qb
+
+        apply(a_arg, b_arg, kwargs)
+
+        res = []
+        if a_kind != "classical":
+            res.append(measure(A))
+        res.append(measure(B))
+        if c_out:
+            res.append(measure(c_out_qb))
+        return tuple(res)
+
+    return add
+
+
+def _sweep(add, sizes_a, sizes_b, check):
+    for N in sizes_a:
+        for L in sizes_b:
+            for j in range(1 << N):
+                for k in range(1 << L):
+                    check(add, N, L, j, k)
+
+
+def _sweep_equal(add, sizes, check):
+    for N in sizes:
+        for j in range(1 << N):
+            for k in range(1 << N):
+                check(add, N, N, j, k)
+
+
+def _check_qq(c_in_val=0):
+    """Check factory: quantum a, A unchanged, B += a + c_in (mod 2**L)."""
+
+    def check(add, N, L, j, k):
+        A, B = add(N, L, j, k)
+        assert A == j
+        assert B == (k + j + c_in_val) % (1 << L)
+
+    return check
+
+
+def _check_cout_qq(c_in_val=0):
+    """Check factory: quantum a with carry-out, overflow captured in c_out."""
+
+    def check(add, N, L, j, k):
+        A, B, cout = add(N, L, j, k)
+        total = k + j + c_in_val
+        assert A == j
+        assert B == total % (1 << L)
+        assert cout == (total >= (1 << L))
+
+    return check
+
+
+def _check_cq(c_in_val=0):
+    """Check factory: classical a, B += a + c_in (mod 2**L)."""
+
+    def check(add, N, L, j, k):
+        (B,) = add(N, L, j, k)
+        assert B == (k + j + c_in_val) % (1 << L)
+
+    return check
+
+
+def _check_cout_cq(c_in_val=0):
+    """Check factory: classical a with carry-out, overflow captured in c_out."""
+
+    def check(add, N, L, j, k):
+        B, cout = add(N, L, j, k)
+        total = k + j + c_in_val
+        assert B == total % (1 << L)
+        assert cout == (total >= (1 << L))
+
+    return check
+
+
+def test_cuccaro_adder_dynamic_basic():
+    """Exhaustive quantum-quantum addition over small register sizes."""
+    _sweep(_mk_add(("quantum", "variable")), range(2, 6), range(2, 6), _check_qq())
+
+
+def test_cuccaro_adder_dynamic_cin():
+    """Exhaustive addition with a QuantumBool carry-in."""
+    for c_in_val in (0, 1):
+        add = _mk_add(("quantum", "variable"), c_in_kind="qbool", c_in_val=c_in_val)
+        _sweep(add, range(2, 6), range(2, 6), _check_qq(c_in_val))
+
+
+def test_cuccaro_adder_dynamic_cin_qubit():
+    """Exhaustive addition with a bare Qubit carry-in."""
+    for c_in_val in (0, 1):
+        add = _mk_add(("quantum", "variable"), c_in_kind="qubit", c_in_val=c_in_val)
+        _sweep(add, range(2, 6), range(2, 6), _check_qq(c_in_val))
+
+
+def test_cuccaro_adder_dynamic_cout():
+    """Exhaustive classical-a addition capturing the carry-out overflow."""
+    for c_in_val in (0, 1):
+        add = _mk_add(("classical", "variable"), c_in_kind="qbool", c_out=True, c_in_val=c_in_val)
+        _sweep_equal(add, range(2, 6), _check_cout_cq(c_in_val))
+
+
+def test_cuccaro_adder_dynamic_cout_qubit():
+    """Exhaustive classical-a addition with a bare Qubit carry-in and carry-out."""
+    for c_in_val in (0, 1):
+        add = _mk_add(("classical", "variable"), c_in_kind="qubit", c_out=True, c_in_val=c_in_val)
+        _sweep_equal(add, range(2, 6), _check_cout_cq(c_in_val))
+
+
+def test_cuccaro_adder_dynamic_cout_equal_sizes():
+    """Exhaustive equal-size quantum addition with carry-out."""
+    for c_in_val in (0, 1):
+        add = _mk_add(("quantum", "variable"), c_in_kind="qbool", c_out=True, c_in_val=c_in_val)
+        _sweep_equal(add, range(2, 6), _check_cout_qq(c_in_val))
+
+
+def test_cuccaro_adder_dynamic_ctrl():
+    """Exhaustive controlled addition via ctrl kwarg and control environment."""
+    for c_in_val in (0, 1):
+        for ctrl_kind in ("kwarg", "env"):
+            add = _mk_add(("quantum", "variable"), c_in_kind="qbool", ctrl_kind=ctrl_kind, c_in_val=c_in_val)
+            _sweep(add, range(2, 5), range(2, 5), _check_qq(c_in_val))
+
+
+def test_cuccaro_adder_dynamic_ctrl_qubit():
+    """Exhaustive controlled addition with a bare Qubit carry-in."""
+    for c_in_val in (0, 1):
+        for ctrl_kind in ("kwarg", "env"):
+            add = _mk_add(("quantum", "variable"), c_in_kind="qubit", ctrl_kind=ctrl_kind, c_in_val=c_in_val)
+            _sweep(add, range(2, 5), range(2, 5), _check_qq(c_in_val))
+
+
+def test_cuccaro_adder_dynamic_cout_ctrl():
+    """Exhaustive addition with carry-out and control combined."""
+    for c_in_val in (0, 1):
+        add = _mk_add(("quantum", "variable"), c_in_kind="qbool", c_out=True, ctrl_kind="kwarg", c_in_val=c_in_val)
+        _sweep_equal(add, range(2, 5), _check_cout_qq(c_in_val))
+
+
+def test_cuccaro_adder_dynamic_list_target():
+    """Exhaustive classical-quantum and quantum-quantum addition on list[Qubit]."""
+    add_cq = _mk_add(("classical", "list"))
+    _sweep_equal(add_cq, range(2, 5), _check_cq())
+
+    add_qq = _mk_add(("list", "list"))
+    _sweep(add_qq, range(2, 5), range(2, 5), _check_qq())
+
+
+def test_cuccaro_adder_dynamic_classical_a_wider_than_b():
+    """Classical a wider than the target wraps modulo 2**len(b) in dynamic mode."""
+    add = _mk_add(("classical", "variable"))
+    check = _check_cq()
+    for N in range(2, 6):
+        for j in range(1 << (N + 3)):
+            for k in range(1 << N):
+                check(add, N, N, j, k)
+
+
+# -- other quantum types (dynamic) -------------------------------------------
+
+
+QTYPE_SPECS = {
+    "qvariable": {
+        "make": QuantumVariable,
+        "encode": int_encoder,
+        "sizes": [2, 3, 4],
+        "values": lambda n: range(1 << n),
+        "expected": lambda j, k, n: (k + j) % (1 << n),
+    },
+    "qbool": {
+        "make": lambda n: QuantumBool(),
+        "encode": int_encoder,
+        "sizes": [1],
+        "values": lambda n: range(2),
+        "expected": lambda j, k, n: (k + j) % 2,
+    },
+    "qmodulus": {
+        "make": QuantumModulus,
+        "encode": lambda qv, v: qv.__setitem__(slice(None), v),
+        "sizes": [13],
+        "values": range,
+        "expected": lambda j, k, n: ((k + j) % (1 << n.bit_length())) % n,
+    },
+}
+
+
+def _mk_type_add(make, encode, a_kind):
+    """Factory for a ``@boolean_simulation`` adder on non-QuantumFloat types."""
 
     @boolean_simulation
-    def add_cq(N, j, k):
-        B = QuantumModulus(N)
-        B[:] = k
-        cuccaro_adder(j, B)
+    def add(n_a, n_b, j, k):
+        if a_kind == "quantum":
+            A = make(n_a)
+            encode(A, j)
+            a_arg = A
+        else:
+            a_arg = j
+        B = make(n_b)
+        encode(B, k)
+        cuccaro_adder(a_arg, B)
+        if a_kind == "quantum":
+            return measure(A), measure(B)
         return measure(B)
 
-    for j in range(13):
-        for k in range(13):
-            A, B = add_qq(13, j, k)
-            assert A == j
-            # raw addition is modulo 2**4 = 16, decoded modulo 13
-            assert B == ((j + k) % 16) % 13
+    return add
 
-    for j in range(13):
-        for k in range(13):
-            assert add_cq(13, j, k) == ((j + k) % 16) % 13
+
+@pytest.mark.parametrize("qtype", ["qvariable", "qbool", "qmodulus"])
+def test_cuccaro_adder_dynamic_quantum_types(qtype):
+    """Exhaustive addition on QuantumVariable, QuantumBool and QuantumModulus."""
+    spec = QTYPE_SPECS[qtype]
+    add_qq = _mk_type_add(spec["make"], spec["encode"], "quantum")
+    add_cq = _mk_type_add(spec["make"], spec["encode"], "classical")
+
+    for n_a in spec["sizes"]:
+        for n_b in spec["sizes"]:
+            for j in spec["values"](n_a):
+                for k in spec["values"](n_b):
+                    A, B = add_qq(n_a, n_b, j, k)
+                    assert A == spec["expected"](j, 0, n_a)  # A is unchanged
+                    assert B == spec["expected"](j, k, n_b)
+
+    for n in spec["sizes"]:
+        for j in spec["values"](n):
+            for k in spec["values"](n):
+                assert add_cq(n, n, j, k) == spec["expected"](j, k, n)


### PR DESCRIPTION
## Description

<!-- What does this PR do? Keep it concise. -->

`cuccaro_adder` now works with `QuantumModulus` and other quantum types that pass plain qubit lists as targets, fixing #839 (`AttributeError: 'list' object has no attribute 'duplicate'`). It now accepts `QuantumVariable`, `list[Qubit]`, and `DynamicQubitArray` for both operands, and classical addends larger than the target register are truncated modulo `2**len(b)` so modulo addition behaves as documented. The adder body was refactored into small helper functions, tests were expanded to cover the new inputs and the issue regression, and a changelog entry was added. This branch also introduces a new `adder_utilities.py` module with a shared register check, which is intended as the starting point for a separate, future PR that consolidates utilities across all adder implementations.

## Related Issues

<!-- Link related issues. Use closing keywords to auto-close them on merge. -->
Closes #
Related to #

## Type of Change

<!-- Check all that apply -->
- [ ] Feature (new functionality)
- [ ] Change Request (modification of existing functionality)
- [ ] Bug Fix
- [ ] Refactoring (no behavior change)
- [ ] Performance improvement
- [ ] Documentation
- [ ] CI / Build

## Breaking Change?
- [ ] Yes
- [ ] No

If yes, describe the impact and migration path:


## What was changed?

<!-- Bullet list of concrete changes -->
-
-

## How was it tested?

<!-- Optional - Reference Test-IDs from the linked issue(s) and describe any additional testing. -->

| Test-ID | Status |
|---------|--------|
| T-001   | ✅ / ❌ |
| T-002   | ✅ / ❌ |
| T-003   | ✅ / ❌ |
| T-004   | ✅ / ❌ |

## Screenshots / Output (if applicable)

<!-- Add additional information if it helps -->

## Checklist
- [ ] My code follows the project's coding standards
- [ ] I have performed a self-review
- [ ] I have added/updated tests (referencing issue Test-IDs)
- [ ] All tests pass locally and in CI
- [ ] I have updated the documentation
- [ ] I have added a changelog entry to `changelog-dev.rst`
- [ ] Breaking changes are documented with migration path

## Reviewer Notes

<!-- Anything specific the reviewer should focus on? -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed the Cuccaro adder for qubit lists and dynamic qubit arrays.
  - Classical addends larger than the target register are reduced modulo the register size.
  - Improved carry-in, carry-out, controlled-operation, and quantum-modulus arithmetic behavior.
  - Added clearer validation for unsupported register and carry types.
  - Fixed controlled operations so carry-out remains unchanged when control is disabled.

- **Documentation**
  - Expanded adder documentation with usage examples, supported input types, size behavior, and error conditions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->