### PR TITLE
Aligned Python Version compatibility in the docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ You can install Qrisp using pip:
 pip install qrisp
 ```
 
-Qrisp has been confirmed to work with Python version 3.11 & 3.12.
+Qrisp requires Python 3.11 or later, up to and including Python 3.13 (`>=3.11, <3.14`).
 
 Qrisp is compatible with any QASM-capable quantum backend! In particular, it offers convenient interfaces for using IBM, IQM and AQT quantum computers, and any quantum backend provider is invited to reach out for a tight integration! 
 

--- a/documentation/source/general/setup.rst
+++ b/documentation/source/general/setup.rst
@@ -3,7 +3,7 @@
 Setup
 =====
 
-Qrisp is written in pure Python implying it can be installed conveniently with `PyPi <https://pypi.org/>`_. Currently Python version 3.11 - 3.12 have been confirmed to work with Qrisp.
+Qrisp is written in pure Python implying it can be installed conveniently with `PyPi <https://pypi.org/>`_. Qrisp requires Python 3.11 or later, up to and including Python 3.13 (``>=3.11, <3.14``).
 
 Simply execute:
 

--- a/documentation/source/reference/Development Guide/getting_started.rst
+++ b/documentation/source/reference/Development Guide/getting_started.rst
@@ -11,7 +11,8 @@ verifying that everything works before you make any changes.
 Environment setup
 -----------------
 
-Qrisp currently requires **Python 3.11 or later**. We recommend working inside a virtual
+Qrisp currently requires **Python 3.11 or later, up to and including Python 3.13**
+(``>=3.11, <3.14``). We recommend working inside a virtual
 environment (e.g. ``venv``, ``conda``, or any other tool you prefer).
 
 We recommend installing Qrisp in *editable* mode so that every change you make to the source is


### PR DESCRIPTION
## Description

Aligns the documented Python version support with what the package actually declares.
The docs contradicted each other — the Setup page claimed only 3.11–3.12 were supported,
while the Development Guide said "3.11 or later" with no upper bound. Both now state the
real constraint, `>=3.11, <3.14`, matching `requires-python` in `pyproject.toml` and
`python_requires` in `setup.py`.

## Related Issues

Closes #<ISSUE>

## Type of Change

<!-- Check all that apply -->
- [ ] Feature (new functionality)
- [ ] Change Request (modification of existing functionality)
- [ ] Bug Fix
- [ ] Refactoring (no behavior change)
- [ ] Performance improvement
- [x] Documentation
- [ ] CI / Build

## Breaking Change?
- [ ] Yes
- [x] No

If yes, describe the impact and migration path:


## What was changed?

- `documentation/source/general/setup.rst`: replaced "Currently Python version 3.11 - 3.12
  have been confirmed to work with Qrisp" with the actual supported range (3.11 through
  3.13, i.e. `>=3.11, <3.14`).
- `documentation/source/reference/Development Guide/getting_started.rst`: the open-ended
  "Python 3.11 or later" now carries the upper bound as well.
- `README.md`: the same stale "confirmed to work with Python version 3.11 & 3.12" claim
  was present here too and has been updated for consistency (not mentioned in the issue,
  but it is the third copy of the same statement).

No packaging metadata was touched — `pyproject.toml` and `setup.py` already specified
`>=3.11, <3.14` correctly, and the 3.11/3.12/3.13 trove classifiers were already in place.
This PR only makes the prose agree with them.

## How was it tested?

Documentation-only change; the linked issue defines no Test-IDs. Verified by reviewing the
rendered diff and confirming all three statements now match the packaging constraint.
The edits are prose plus inline literals, with no new directives,
roles, or cross-references.

## Screenshots / Output (if applicable)

Grep across the repo after the change — every prose statement and the packaging metadata
now agree:

```
README.md:40:            Qrisp requires Python 3.11 or later, up to and including Python 3.13 (`>=3.11, <3.14`).
setup.rst:6:            ... Qrisp requires Python 3.11 or later, up to and including Python 3.13 (``>=3.11, <3.14``).
getting_started.rst:14: Qrisp currently requires **Python 3.11 or later, up to and including Python 3.13**
                        (``>=3.11, <3.14``).
pyproject.toml:16:      requires-python = ">=3.11, <3.14"
setup.py:37:            python_requires=">=3.11, <3.14",
```

## Checklist
- [x] My code follows the project's coding standards
- [x] I have performed a self-review
- [x] I have added/updated tests (referencing issue Test-IDs) — n/a, prose-only change
- [x] All tests pass locally and in CI
- [x] I have updated the documentation
- [ ] I have added a changelog entry 
- [x] Breaking changes are documented with migration path — n/a, no breaking changes