### PR TITLE
Fix/cold optimization routine precompute

### DIFF
--- a/documentation/source/general/changelog/changelog-dev.rst
+++ b/documentation/source/general/changelog/changelog-dev.rst
@@ -194,6 +194,12 @@ Bug Fixes
   wrong cost function, and the optimization-pulse ansatz divided by zero for
   scheduling functions with vanishing derivative at the domain endpoints.
 
+* :meth:`DCQOProblem.run <qrisp.cold.DCQOProblem.run>`'s COLD method now
+  raises a clear ``ValueError`` for ``N_opt < 1`` or the default ``N_opt=None``,
+  instead of failing deep inside ``range()`` or SciPy with confusing,
+  inconsistent error messages
+  (`#877 <https://github.com/eclipse-qrisp/Qrisp/issues/877>`_).
+
 Compatibility
 -------------
 

--- a/documentation/source/general/changelog/changelog-dev.rst
+++ b/documentation/source/general/changelog/changelog-dev.rst
@@ -187,6 +187,13 @@ Bug Fixes
   constants, by passing the constants to ``eval_jaxpr``
   (`PR #750 <https://github.com/eclipse-qrisp/Qrisp/pull/750>`_).
 
+* Fixed :meth:`DCQOProblem.run <qrisp.cold.DCQOProblem.run>`'s COLD method
+  with ``objective="exp_value"``, which could be dramatically slower and
+  converge to worse results than in qrisp 0.8: an unused exponential-size
+  cost table was built on every call, the fast statevector path used the
+  wrong cost function, and the optimization-pulse ansatz divided by zero for
+  scheduling functions with vanishing derivative at the domain endpoints.
+
 Compatibility
 -------------
 

--- a/src/qrisp/algorithms/cold/dcqo_problem.py
+++ b/src/qrisp/algorithms/cold/dcqo_problem.py
@@ -648,6 +648,9 @@ class DCQOProblem:
 
         # Run COLD routine
         if method == "COLD":
+            if N_opt is None or N_opt < 1:
+                raise ValueError(f"N_opt must be a positive integer for the COLD method (received {N_opt!r}).")
+
             qarg1, qarg2 = qarg.duplicate(), qarg.duplicate()
 
             # If we optimize the Hamiltonian expectation value,

--- a/src/qrisp/algorithms/cold/dcqo_problem.py
+++ b/src/qrisp/algorithms/cold/dcqo_problem.py
@@ -181,9 +181,15 @@ class DCQOProblem:
         """
         # Sympy symbols for t and T
         t_sym, T_sym = sp.symbols("t T", real=True)
-        # Array for t values
+        # Array for t values. Midpoint rule: each Trotter step represents the interval
+        # [(s)*dt, (s+1)*dt], so t_list never touches t=0 or t=T exactly. This matters
+        # for COLD, where g_deriv = 1/lamdot below is only finite where lamdot != 0;
+        # lam_func's like the smooth "soft start/stop" schedule have lamdot = 0 exactly
+        # at the domain endpoints, so sampling the endpoints (as a left/right Riemann
+        # rule would) hits that singularity. The midpoint rule is also second-order
+        # accurate for the Trotterization itself, vs. first-order for an endpoint rule.
         dt = T / N_steps
-        t_list = np.linspace(dt, T, N_steps)
+        t_list = (np.arange(N_steps) + 0.5) * dt
 
         # Sympy functions for lam and lamdot
         lam_func = sp.lambdify((t_sym, T_sym), self.lam_func(), "numpy")
@@ -328,9 +334,9 @@ class DCQOProblem:
         # Compute time-function lamda(t, T) and the derivative lamdot(t, T)
         self._precompute_timegrid(N_steps, T, "COLD")
 
-        # Precompute opt pulses
+        # Precompute opt pulses. Must match the midpoint grid used in _precompute_timegrid.
         dt = T / N_steps
-        t_list = np.linspace(dt, T, int(N_steps))
+        t_list = (np.arange(int(N_steps)) + 0.5) * dt
         sin_matrix, cos_matrix = self._precompute_opt_pulses(N_steps, T, t_list, N_opt=len(opt_params), CRAB=CRAB)
         beta = opt_params
 
@@ -456,13 +462,26 @@ class DCQOProblem:
         """
         # Different objective functions: exp_value, agp coeffs magnitude, agp coeffs amplitude
 
-        # Precompute costs for statevector method
-        n_qubits = len(qarg)
-        num_states = 1 << n_qubits
-        bit_indices = np.arange(n_qubits - 1, -1, -1, dtype=np.uint64)
-        state_indices = np.arange(num_states, dtype=np.uint64)
-        basis = ((state_indices[:, None] >> bit_indices) & 1).astype(np.int8)
-        costs = np.einsum("bi,ij,bj->b", basis, self.Q, basis)
+        # Precompute costs for the statevector fallback path of objective_exp. This is
+        # exponential in n_qubits, so only build it when it can actually be used.
+        # costs[b] must equal <x_b| H_prob |x_b> for computational basis state x_b, so
+        # it is derived from H_prob's own (diagonal, Z-only) terms rather than from Q:
+        # H_prob is caller-supplied and not guaranteed to relate to Q via any fixed
+        # h/J convention.
+        if objective == "exp_value" and exp_value_backend is None:
+            n_qubits = len(qarg)
+            num_states = 1 << n_qubits
+            bit_indices = np.arange(n_qubits - 1, -1, -1, dtype=np.uint64)
+            state_indices = np.arange(num_states, dtype=np.uint64)
+            basis = ((state_indices[:, None] >> bit_indices) & 1).astype(np.int8)
+            z = 1 - 2 * basis
+            costs = np.zeros(num_states)
+            for term, coeff in self.H_prob.terms_dict.items():
+                indices = list(term.factor_dict.keys())
+                if indices:
+                    costs += coeff * np.prod(z[:, indices], axis=1)
+                else:
+                    costs += coeff
 
         # Expectation value of the QUBO Hamiltonian
         def objective_exp(params, CRAB):
@@ -500,8 +519,9 @@ class DCQOProblem:
         # Magnitude of the AGP coefficients (coeffs are treated as uniform for simplification)
         # (sum of absolute values for each timestep)
         def objective_mag(params, CRAB):
-            # Precompute opt pulses to be multiplied with opt params
-            t_list = np.linspace(T / N_steps, T, int(N_steps))
+            # Precompute opt pulses to be multiplied with opt params.
+            # Must match the midpoint grid used in _precompute_timegrid.
+            t_list = (np.arange(int(N_steps)) + 0.5) * (T / N_steps)
             sin_matrix, cos_matrix = self._precompute_opt_pulses(N_steps, T, t_list, N_opt=len(params), CRAB=CRAB)
             magnitude = 0
 

--- a/tests/algorithms_tests/cd_tests/test_cold.py
+++ b/tests/algorithms_tests/cd_tests/test_cold.py
@@ -1,7 +1,11 @@
+import time
+
 import numpy as np
 import sympy as sp
 
 from qrisp import QuantumVariable
+from qrisp import h as had_gate
+from qrisp import z as z_gate
 from qrisp.algorithms.cold import DCQOProblem, solve_QUBO
 from qrisp.interface.provider_backends.qiskit_backend import QiskitBackend
 from qrisp.operators.qubit import X, Y, Z
@@ -162,3 +166,149 @@ def test_cold_full_example():
 
     assert isinstance(result, dict)
     assert len(result) > 0
+
+
+def test_cold_expvalue_fast_path_matches_hprob():
+    # optimization_routine's exp_value objective has a fast statevector path that
+    # estimates <H_prob> via a precomputed cost table. That table must be derived from
+    # H_prob's own diagonal terms; deriving it from Q via a hand-rolled formula instead
+    # (as in a past regression) computes a different function of the bitstring, since
+    # H_prob is caller-supplied and not guaranteed to relate to Q via any fixed
+    # convention. N_steps/maxiter are kept minimal since only the objective function's
+    # correctness at one point is under test, not the quality of the optimization.
+    Q = np.array([[-1.2, 0.40, 0.0, 0.0], [0.40, 0.30, 0.20, 0.0], [0.0, 0.20, -1.1, 0.30], [0.0, 0.0, 0.30, -0.80]])
+    N = Q.shape[0]
+    h = -0.5 * np.diag(Q) - 0.5 * np.sum(Q, axis=1)
+    J = 0.5 * Q
+
+    H_init = 1 * sum([X(i) for i in range(N)])
+    H_prob = sum([sum([J[i][j] * Z(i) * Z(j) for j in range(i)]) for i in range(N)]) + sum(
+        [h[i] * Z(i) for i in range(N)]
+    )
+    H_control = sum([Z(i) for i in range(N)])
+    A_lam = sum([Y(i) for i in range(N)])
+
+    def alpha(lam, f, f_deriv):
+        A = lam * h + f
+        B = 1 - lam
+        C = h + f_deriv
+        nom = np.sum(A + 4 * B * C)
+        denom = 2 * (np.sum(A**2) + N * (B**2)) + 4 * (lam**2) * np.sum(np.tril(J, -1).sum(axis=1))
+        return [nom / denom] * N
+
+    def lam():
+        t, T = sp.symbols("t T", real=True)
+        return t / T
+
+    def qarg_prep(q):
+        had_gate(q)
+        z_gate(q)
+        return q
+
+    problem = DCQOProblem(Q, H_init, H_prob, A_lam, alpha, lam, H_control=H_control, qarg_prep=qarg_prep)
+
+    qarg1 = QuantumVariable(N)
+    qc = problem.compile_U_cold(qarg1, N_opt=1, N_steps=2, T=4, CRAB=False)
+
+    qarg2 = QuantumVariable(N)
+    opt_params, cost = problem.optimization_routine(
+        qarg2,
+        N_opt=1,
+        N_steps=2,
+        T=4,
+        qc=qc,
+        CRAB=False,
+        optimizer="Nelder-Mead",
+        options={"maxiter": 1, "maxfev": 1},
+        objective="exp_value",
+        bounds=(-2, 2),
+    )
+
+    subs_dic = {sp.Symbol("par_0"): float(opt_params[0])}
+    qarg3 = QuantumVariable(N)
+    ground_truth = H_prob.expectation_value(
+        qarg3, compile=False, subs_dic=subs_dic, precompiled_qc=qc, precision=0.01
+    )()
+
+    assert abs(cost - ground_truth) < 0.1
+
+
+def test_cold_no_exponential_precompute_for_non_expvalue_objective():
+    # optimization_routine's exp_value fast path needs a 2**n_qubits cost table, but a
+    # past regression built it unconditionally regardless of which objective was
+    # selected. This must stay gated: at n_qubits=24, an accidental 2**24-entry table
+    # would take orders of magnitude longer than the classical-only work
+    # "agp_coeff_magnitude" actually needs, so a generous wall-clock ceiling here
+    # directly catches a regression of that gate without ever materializing such a
+    # table itself (which would also cost real time/memory in a CI run).
+    N = 24
+    Q = np.eye(N)
+    h = -0.5 * np.diag(Q) - 0.5 * np.sum(Q, axis=1)
+
+    H_init = 1 * sum([X(i) for i in range(N)])
+    H_prob = sum([h[i] * Z(i) for i in range(N)])
+    H_control = sum([Z(i) for i in range(N)])
+    A_lam = sum([Y(i) for i in range(N)])
+
+    def alpha(lam, f, f_deriv):
+        return [0.0] * N
+
+    def lam():
+        t, T = sp.symbols("t T", real=True)
+        return t / T
+
+    problem = DCQOProblem(Q, H_init, H_prob, A_lam, alpha, lam, H_control=H_control)
+    problem._precompute_timegrid(N_steps=5, T=8, method="COLD")
+
+    qarg = QuantumVariable(N)
+
+    t0 = time.perf_counter()
+    problem.optimization_routine(
+        qarg,
+        N_opt=1,
+        N_steps=5,
+        T=8,
+        qc=None,
+        CRAB=False,
+        optimizer="Nelder-Mead",
+        options={"maxiter": 3},
+        objective="agp_coeff_magnitude",
+        bounds=(-2, 2),
+    )
+    elapsed = time.perf_counter() - t0
+
+    assert elapsed < 5.0
+
+
+def test_cold_g_deriv_stays_finite_for_smooth_schedule():
+    # create_COLD_instance's smooth scheduling function has zero derivative at the
+    # domain endpoints. g_deriv = 1/lamdot must not be evaluated exactly at those
+    # endpoints (a past regression's right-endpoint time grid did, producing a
+    # ~1e32 value that made the COLD optimization landscape chaotic). Sampling closer
+    # to a genuine zero-derivative point inevitably makes g_deriv larger -- with the
+    # midpoint rule it grows as N_steps**3 (~1.3e9 at N_steps=1000), which is still
+    # six orders of magnitude below where float64 angle precision actually breaks
+    # down (~1e15); 1e10 comfortably separates that expected, benign growth from the
+    # ~1e32 signature of hitting the singularity exactly. This is a pure classical
+    # check on _precompute_timegrid's output, independent of n_qubits and of any
+    # quantum simulation, so it stays fast regardless of scale.
+    def lam():
+        t, T = sp.symbols("t T", real=True)
+        return sp.sin(sp.pi / 2 * sp.sin(sp.pi * t / (2 * T)) ** 2) ** 2
+
+    N = 2
+    Q = np.eye(N)
+    h = -0.5 * np.diag(Q) - 0.5 * np.sum(Q, axis=1)
+    H_init = sum([X(i) for i in range(N)])
+    H_prob = sum([h[i] * Z(i) for i in range(N)])
+    A_lam = sum([Y(i) for i in range(N)])
+    H_control = sum([Z(i) for i in range(N)])
+
+    def alpha(lam, f, f_deriv):
+        return [0.0] * N
+
+    problem = DCQOProblem(Q, H_init, H_prob, A_lam, alpha, lam, H_control=H_control)
+    problem._precompute_timegrid(N_steps=50, T=10, method="COLD")
+
+    assert np.all(np.isfinite(problem.g_deriv))
+    assert np.max(np.abs(problem.g_deriv)) < 1e10

--- a/tests/algorithms_tests/cd_tests/test_cold.py
+++ b/tests/algorithms_tests/cd_tests/test_cold.py
@@ -1,6 +1,7 @@
 import time
 
 import numpy as np
+import pytest
 import sympy as sp
 
 from qrisp import QuantumVariable
@@ -312,3 +313,16 @@ def test_cold_g_deriv_stays_finite_for_smooth_schedule():
 
     assert np.all(np.isfinite(problem.g_deriv))
     assert np.max(np.abs(problem.g_deriv)) < 1e10
+
+
+@pytest.mark.parametrize("n_opt", [None, 0, -1])
+def test_cold_rejects_invalid_n_opt(n_opt):
+    # method="COLD" needs at least one control-pulse parameter; N_opt's default (None)
+    # and 0 used to fail deep inside range()/scipy with confusing, inconsistent errors
+    # instead of explaining the actual constraint (issue #877).
+    Q = np.array([[-1.2, 0.40, 0.0, 0.0], [0.40, 0.30, 0.20, 0.0], [0.0, 0.20, -1.1, 0.30], [0.0, 0.0, 0.30, -0.80]])
+    problem_args = {"method": "COLD", "uniform": True}
+    run_args = {"N_steps": 10, "T": 5, "CRAB": False, "objective": "exp_value", "bounds": (-2, 2), "N_opt": n_opt}
+
+    with pytest.raises(ValueError, match="N_opt must be a positive integer"):
+        solve_QUBO(Q, problem_args, run_args)


### PR DESCRIPTION
## Description

Fixes three compounding bugs in DCQOProblem.run's COLD method with
objective="exp_value" that made runs through solve_QUBO dramatically
slower and land on much worse, inconsistent results compared to
qrisp 0.8. Also makes N_opt validation explicit for COLD. Adds
regression tests for all four.

## Related Issues

<!-- Link related issues. Use closing keywords to auto-close them on merge. -->
Closes #877 

## Type of Change

<!-- Check all that apply -->
- [ ] Feature (new functionality)
- [ ] Change Request (modification of existing functionality)
- [x] Bug Fix
- [ ] Refactoring (no behavior change)
- [ ] Performance improvement
- [ ] Documentation
- [ ] CI / Build

## Breaking Change?
- [ ] Yes
- [x] No

## What was changed?

- `optimization_routine` built an exponential-size (2**n_qubits) cost
  table unconditionally, even when the objective didn't need it. Now
  gated behind `objective == "exp_value" and exp_value_backend is None`.
- The fast statevector path computed cost as raw QUBO cost `x^T Q x`
  instead of `H_prob`'s actual expectation value. Now derived from
  `H_prob`'s own diagonal terms.
- The Trotterization time grid always sampled `t=T` exactly, dividing
  by zero in COLD's `g_deriv = 1/lamdot` for schedules with vanishing
  derivative at the endpoints (e.g. `create_COLD_instance`'s default).
  Switched to the midpoint rule, which avoids the exact endpoints and
  is incidentally more accurate.
- `run()`'s COLD method now raises a clear `ValueError` for
  `N_opt < 1` or the default `N_opt=None`, instead of failing deep
  inside `range()` or SciPy with confusing, inconsistent errors (#877).
- Added one regression test per bug to `test_cold.py`.

## How was it tested?
- `tests/algorithms_tests/cd_tests/`: 18/18 pass.
- Each new test confirmed to fail pre-fix and pass post-fix, and runs
  fast (all well under 1s).
- Reproduced the original report (10-qubit QUBO, exp_value): landscape
  went from 21 spurious extrema (up to a 2.7e32 blow-up) to 3, matching
  qrisp 0.8's shape; runtime stabilized from a chaotic 8-19s to a
  steady 7.5-7.9s across 5 runs.
- Confirmed the existing suite doesn't catch the three performance/
  quality bugs: all 12 pre-existing tests pass even with those fixes
  reverted.
- `ruff format --check` and `ruff check src/` (pinned CI version)
  clean on all added lines.

All tests pass locally

## Checklist
- [x] My code follows the project's coding standards
- [x] I have performed a self-review
- [x] I have added/updated tests (referencing issue Test-IDs)
- [x] All tests pass locally and in CI
- [ ] I have updated the documentation
- [x] I have added a changelog entry to `changelog-dev.rst`
- [x] Breaking changes are documented with migration path (N/A)

## Reviewer Notes
- The grid change affects LCD too (shared `t_list`). Checked directly:
  same top-5 outcomes/ranking, ~1% probability shift — expected from a
  more accurate discretization, not a regression.
- `g_deriv` is now finite everywhere but still grows as `N_steps**3`
  (unavoidable, not a bug) - stays well below float64's precision
  floor for realistic `N_steps`.
- A smaller residual runtime gap vs qrisp 0.8 remains on the original
  case (~7.7s here vs ~3s there) that I haven't root-caused - flagging
  rather than hiding it.
- N_opt is kept required (no default value) rather than defaulting to
  1 - deliberate: it's a modeling choice, and
  silently defaulting risks masking an under-tuned COLD run rather
  than erroring loudly.